### PR TITLE
feat: test 3 prototype

### DIFF
--- a/apps/storybook/stories/prototyping/matthewhuntsberry/test-3.stories.js
+++ b/apps/storybook/stories/prototyping/matthewhuntsberry/test-3.stories.js
@@ -1,0 +1,15 @@
+import { html } from "lit";
+import { Test3 } from "../../../../../packages/components/src/prototyping/matthewhuntsberry/test-3/test-3.js";
+
+export default {
+  title: "Prototyping/matthewhuntsberry/Test3",
+  tags: ["autodocs"],
+  argTypes: {
+    label: { control: "text" },
+  },
+};
+
+export const Default = {
+  args: { label: "Test3" },
+  render: (args) => Test3(args),
+};

--- a/packages/components/src/prototyping/matthewhuntsberry/test-3/test-3.css
+++ b/packages/components/src/prototyping/matthewhuntsberry/test-3/test-3.css
@@ -1,0 +1,16 @@
+/* Test3 — Prototype
+   Designer: matthewhuntsberry
+   Use semantic tokens only — never hardcode values.
+   Token reference: packages/tokens/css/ */
+
+.test-3 {
+  display: flex;
+  align-items: center;
+  padding: var(--s2a-spacing-md);
+  background: var(--s2a-color-background-default);
+  color: var(--s2a-color-content-default);
+}
+
+.test-3__label {
+  font: var(--s2a-typography-body-lg);
+}

--- a/packages/components/src/prototyping/matthewhuntsberry/test-3/test-3.js
+++ b/packages/components/src/prototyping/matthewhuntsberry/test-3/test-3.js
@@ -1,0 +1,16 @@
+import { html } from "lit";
+import "./test-3.css";
+
+/**
+ * Test3 — Prototype
+ * Designer: matthewhuntsberry
+ * Branch: feat/test-3
+ */
+export const Test3 = (args = {}) => {
+  const { label = "Test3" } = args;
+  return html`
+    <div class="test-3">
+      <span class="test-3__label">${label}</span>
+    </div>
+  `;
+};


### PR DESCRIPTION
## Prototype: test 3

Scaffold created via `/start-feature`.

**Story:** `Prototyping/matthewhuntsberry/Test3`
**Preview:** Will be posted automatically once CI runs at `https://adobecom.github.io/consonant/pr-preview/pr-<number>/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)