### PR TITLE
feat: button-component prototype

### DIFF
--- a/apps/storybook/stories/prototyping/matthewhuntsberry/button-component.stories.js
+++ b/apps/storybook/stories/prototyping/matthewhuntsberry/button-component.stories.js
@@ -1,0 +1,15 @@
+import { html } from "lit";
+import { ButtonComponent } from "../../../../../packages/components/src/prototyping/matthewhuntsberry/button-component/button-component.js";
+
+export default {
+  title: "Prototyping/matthewhuntsberry/ButtonComponent",
+  tags: ["autodocs"],
+  argTypes: {
+    label: { control: "text" },
+  },
+};
+
+export const Default = {
+  args: { label: "ButtonComponent" },
+  render: (args) => ButtonComponent(args),
+};

--- a/packages/components/src/prototyping/matthewhuntsberry/button-component/button-component.css
+++ b/packages/components/src/prototyping/matthewhuntsberry/button-component/button-component.css
@@ -1,0 +1,16 @@
+/* ButtonComponent — Prototype
+   Designer: matthewhuntsberry
+   Use semantic tokens only — never hardcode values.
+   Token reference: packages/tokens/css/ */
+
+.button-component {
+  display: flex;
+  align-items: center;
+  padding: var(--s2a-spacing-md);
+  background: var(--s2a-color-background-default);
+  color: var(--s2a-color-content-default);
+}
+
+.button-component__label {
+  font: var(--s2a-typography-body-lg);
+}

--- a/packages/components/src/prototyping/matthewhuntsberry/button-component/button-component.js
+++ b/packages/components/src/prototyping/matthewhuntsberry/button-component/button-component.js
@@ -1,0 +1,16 @@
+import { html } from "lit";
+import "./button-component.css";
+
+/**
+ * ButtonComponent — Prototype
+ * Designer: matthewhuntsberry
+ * Branch: feat/button-component
+ */
+export const ButtonComponent = (args = {}) => {
+  const { label = "ButtonComponent" } = args;
+  return html`
+    <div class="button-component">
+      <span class="button-component__label">${label}</span>
+    </div>
+  `;
+};


### PR DESCRIPTION
## Prototype: button component

Scaffold created via `/start-feature`.

**Story:** `Prototyping/matthewhuntsberry/ButtonComponent`
**Preview:** Will be posted automatically once CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)