### PR TITLE
feat: elastic-card prototype

### DIFF
--- a/apps/storybook/stories/prototyping/matthewhuntsberry/elastic-card.stories.js
+++ b/apps/storybook/stories/prototyping/matthewhuntsberry/elastic-card.stories.js
@@ -1,0 +1,15 @@
+import { html } from "lit";
+import { ElasticCard } from "../../../../../packages/components/src/prototyping/matthewhuntsberry/elastic-card/elastic-card.js";
+
+export default {
+  title: "Prototyping/matthewhuntsberry/ElasticCard",
+  tags: ["autodocs"],
+  argTypes: {
+    label: { control: "text" },
+  },
+};
+
+export const Default = {
+  args: { label: "ElasticCard" },
+  render: (args) => ElasticCard(args),
+};

--- a/packages/components/src/prototyping/matthewhuntsberry/elastic-card/elastic-card.css
+++ b/packages/components/src/prototyping/matthewhuntsberry/elastic-card/elastic-card.css
@@ -1,0 +1,16 @@
+/* ElasticCard — Prototype
+   Designer: matthewhuntsberry
+   Use semantic tokens only — never hardcode values.
+   Token reference: packages/tokens/css/ */
+
+.elastic-card {
+  display: flex;
+  align-items: center;
+  padding: var(--s2a-spacing-md);
+  background: var(--s2a-color-background-default);
+  color: var(--s2a-color-content-default);
+}
+
+.elastic-card__label {
+  font: var(--s2a-typography-body-lg);
+}

--- a/packages/components/src/prototyping/matthewhuntsberry/elastic-card/elastic-card.js
+++ b/packages/components/src/prototyping/matthewhuntsberry/elastic-card/elastic-card.js
@@ -1,0 +1,16 @@
+import { html } from "lit";
+import "./elastic-card.css";
+
+/**
+ * ElasticCard — Prototype
+ * Designer: matthewhuntsberry
+ * Branch: feat/elastic-card
+ */
+export const ElasticCard = (args = {}) => {
+  const { label = "ElasticCard" } = args;
+  return html`
+    <div class="elastic-card">
+      <span class="elastic-card__label">${label}</span>
+    </div>
+  `;
+};


### PR DESCRIPTION
## Prototype: elastic-card

Scaffold created via `/start-feature`.

**Story:** `Prototyping/matthewhuntsberry/ElasticCard`
**Preview:** Will be posted automatically once CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)