### PR TITLE
fix: add missing test-proto-1 component file

### DIFF
--- a/packages/components/src/prototyping/matthewhuntsberry/test-proto-1/test-proto-1.js
+++ b/packages/components/src/prototyping/matthewhuntsberry/test-proto-1/test-proto-1.js
@@ -1,0 +1,5 @@
+import { html } from 'lit';
+
+export function TestProto1({ label = 'TestProto1' } = {}) {
+  return html`<div class="test-proto-1">${label}</div>`;
+}


### PR DESCRIPTION
## Summary

- Adds the missing `test-proto-1.js` component implementation
- The story file was committed in #11 but the component was never added to git, breaking the Storybook build on every branch

## Root cause

`apps/storybook/stories/prototyping/matthewhuntsberry/test-proto-1.stories.js` imports from `packages/components/src/prototyping/matthewhuntsberry/test-proto-1/test-proto-1.js` — that file existed locally but was never staged and committed.

## Test plan

- [ ] Storybook build passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)