### PR TITLE
feat: nav-card prototype

### DIFF
--- a/apps/storybook/stories/prototyping/matthewhuntsberry/nav-card.stories.js
+++ b/apps/storybook/stories/prototyping/matthewhuntsberry/nav-card.stories.js
@@ -1,0 +1,15 @@
+import { html } from "lit";
+import { NavCard } from "../../../../../packages/components/src/prototyping/matthewhuntsberry/nav-card/nav-card.js";
+
+export default {
+  title: "Prototyping/matthewhuntsberry/NavCard",
+  tags: ["autodocs"],
+  argTypes: {
+    label: { control: "text" },
+  },
+};
+
+export const Default = {
+  args: { label: "NavCard" },
+  render: (args) => NavCard(args),
+};

--- a/packages/components/src/prototyping/matthewhuntsberry/nav-card/nav-card.css
+++ b/packages/components/src/prototyping/matthewhuntsberry/nav-card/nav-card.css
@@ -1,0 +1,16 @@
+/* NavCard — Prototype
+   Designer: matthewhuntsberry
+   Use semantic tokens only — never hardcode values.
+   Token reference: packages/tokens/css/ */
+
+.nav-card {
+  display: flex;
+  align-items: center;
+  padding: var(--s2a-spacing-md);
+  background: var(--s2a-color-background-default);
+  color: var(--s2a-color-content-default);
+}
+
+.nav-card__label {
+  font: var(--s2a-typography-body-lg);
+}

--- a/packages/components/src/prototyping/matthewhuntsberry/nav-card/nav-card.js
+++ b/packages/components/src/prototyping/matthewhuntsberry/nav-card/nav-card.js
@@ -1,0 +1,16 @@
+import { html } from "lit";
+import "./nav-card.css";
+
+/**
+ * NavCard — Prototype
+ * Designer: matthewhuntsberry
+ * Branch: feat/nav-card
+ */
+export const NavCard = (args = {}) => {
+  const { label = "NavCard" } = args;
+  return html`
+    <div class="nav-card">
+      <span class="nav-card__label">${label}</span>
+    </div>
+  `;
+};


### PR DESCRIPTION
## Prototype: NavCard

Scaffold created via `/start-feature`.

**Story:** `Prototyping/matthewhuntsberry/NavCard`
**Preview:** Will be posted automatically once CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)