### PR TITLE
feat(consonant-specs-plugin): critic-vs-defender skill + post-#45 fixes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd /Users/mhuntsberry/Desktop/consonant-2 && git fetch origin --quiet 2>/dev/null; BEHIND=$(git rev-list HEAD..origin/main --count 2>/dev/null || echo 0); if [ \"$BEHIND\" -gt \"0\" ] 2>/dev/null; then echo \"Your branch is $BEHIND commit(s) behind main — type /sync to get latest before you start.\"; fi"
+            "command": "git fetch origin --quiet 2>/dev/null; BEHIND=$(git rev-list HEAD..origin/main --count 2>/dev/null || echo 0); if [ \"$BEHIND\" -gt \"0\" ] 2>/dev/null; then echo \"Your branch is $BEHIND commit(s) behind main — type /sync to get latest before you start.\"; fi"
           }
         ]
       }

--- a/.mcp.json
+++ b/.mcp.json
@@ -18,10 +18,6 @@
     "design-systems": {
       "type": "http",
       "url": "https://design-systems-mcp.southleft.com/mcp"
-    },
-    "corp-jira": {
-      "command": "node",
-      "args": ["/Users/mhuntsberry/adobe-mcp-servers/src/corp-jira/dist/index.js"]
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,9 @@ That creates a branch, opens a draft PR, and gives you a live Storybook preview 
 - Your PR preview: `https://adobecom.github.io/consonant/pr-preview/pr-<number>/` (posted automatically as a PR comment once CI runs)
 
 **MCP servers available (configured by setup script):**
-- `figma-dev-mode-mcp-server` — reads your open Figma file directly
-- `figma-console` — executes code in Figma, takes screenshots, reads variables
+- `consonant-specs` — **primary Figma bridge** for this repo, served by the `consonant-specs-plugin` running inside Figma. Use `mcp__consonant-specs__figma_*` tools by default for any Figma operation (status, navigate, selection, execute, screenshots, get_file_info, etc.). WebSocket bridge listens on `127.0.0.1:9220`.
+- `figma-console` — **secondary Figma bridge**, served by a separate "Figma Desktop Bridge" plugin (port `9223`). Usually not running. Only use `mcp__figma-console__*` tools if you've explicitly verified its plugin is up — don't default to it.
+- `figma-dev-mode-mcp-server` — reads your open Figma file directly (Figma's built-in MCP)
 - `s2a-ds` — looks up design tokens, component specs, and validates CSS
 
 ---

--- a/apps/consonant-specs-plugin/skills/critic-vs-defender/SKILL.md
+++ b/apps/consonant-specs-plugin/skills/critic-vs-defender/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: critic-vs-defender
+description: Use when you have a written plan, spec, or design proposal that needs adversarial pressure-testing to surface flaws, ambiguities, hidden assumptions, and missing details before implementation.
+---
+
+# Critic vs. Defender
+
+## Overview
+
+Adversarial debate strengthens plans. A **critic** subagent hunts for flaws, ambiguities, and gaps. A **defender** subagent responds to each one — addressing it, arguing it's unnecessary, removing it from scope, or escalating a premise problem to the human. They iterate until they reach consensus or escalate. The output is a sharper plan with weaknesses surfaced and resolved.
+
+## When to Use
+
+- A written plan, spec, or design proposal is ready for pressure-testing
+- You want to find blind spots, hidden assumptions, or unclear details before coding
+- The plan is large enough that single-pass review would miss things
+
+**Not for:**
+- Quick questions or trivial tasks
+- Code review — use `superpowers:requesting-code-review`
+- Open-ended exploration — use `superpowers:brainstorming`
+- Plans too small to debate
+
+## Before You Start
+
+Ask the user:
+1. **Which plan?** (file path, prior message, or pasted content)
+2. **Which model for the subagents?** Default `sonnet` unless told otherwise
+3. **Max rounds before tiebreaker?** Default 3
+
+State to the user: "Pressure-testing this plan with critic vs. defender. I'll report when they converge or when they need a tiebreaker."
+
+## Workflow
+
+```
+Round 1: Critic finds issues → Defender responds (ADDRESS / ARGUE-UNNECESSARY / REMOVE-FROM-SCOPE / ESCALATE-PREMISE)
+  └─ If critic returns PLAN-TOO-THIN → stop; ask the user to flesh out the plan before continuing
+Round N: Critic marks RESOLVED / ACCEPTED / DISPUTED / HUMAN-DECIDES → Defender responds to DISPUTED only
+Stop when no DISPUTED items remain OR max rounds reached
+If DISPUTED or HUMAN-DECIDES items remain → ask the user as tiebreaker
+Output the strengthened plan
+```
+
+The critic and defender run **sequentially** within each round (defender needs critic's output). Do not dispatch them in parallel.
+
+## Round 1 Prompts
+
+**Critic** (general-purpose agent, chosen model):
+
+> You are the CRITIC in a critic vs. defender debate. Find every flaw, ambiguity, or missing detail in this plan. Be specific — quote the part of the plan and explain the problem.
+>
+> Plan:
+> [PASTE FULL PLAN]
+>
+> Calibration — read before responding:
+> - **If the plan is too vague or too short to engage with substantively, stop and return only: "PLAN-TOO-THIN: [one-line reason]."** Do not fabricate issues to fill a list. A plan with no concrete claims has nothing to grip.
+> - **Quality over quantity.** If you have 3 substantive concerns, return 3. If you have 12, return 12. Never pad. Never invent issues to satisfy the categories below.
+> - **If the plan's premise itself is wrong** (wrong question being answered, fundamentally infeasible approach, etc.), lead with a single PREMISE finding before per-line findings — labeled `PREMISE` instead of a number.
+>
+> Return a numbered list. For each issue:
+> - **Quote:** exact wording from the plan
+> - **Concern:** what's wrong, unclear, or missing
+> - **Severity:** see anchors below
+>
+> Severity anchors (use literally — don't inflate):
+> - **blocker** — won't ship right without resolving
+> - **major** — significant rework or harm risk if shipped as-is
+> - **minor** — polish or low-impact ambiguity
+>
+> Do NOT propose solutions. Cover **as applicable** (only when the plan gives you something to grip — do not invent gaps to hit every category): hidden assumptions, missing edge cases, unspecified behavior, contradictions, ambiguous wording, scope risks, missing dependencies, missing acceptance criteria.
+
+**Defender** (general-purpose agent, same model):
+
+> You are the DEFENDER in a critic vs. defender debate. The CRITIC raised these issues. For each one, choose ONE of four response types:
+> - **ADDRESS** — propose a concrete edit to the plan that resolves the concern
+> - **ARGUE-UNNECESSARY** — explain why the issue doesn't need to be fixed (out of scope, false premise, already covered, low impact, etc.)
+> - **REMOVE-FROM-SCOPE** — the right answer is to cut that feature or element from the plan entirely
+> - **ESCALATE-PREMISE** — the issue points at a fundamental problem with the plan's premise that no per-line edit can fix; flag for the human to decide
+>
+> Calibration — read before responding:
+> - **"Don't concede reflexively" means don't fold under pressure — it does NOT mean manufacture pushback against valid concerns.** If the critic is right, say so via ADDRESS or REMOVE-FROM-SCOPE. Honest agreement beats fake disagreement.
+> - **ARGUE-UNNECESSARY exists for cases where the critic is actually wrong**, not as a balance requirement. It's fine if you don't use it at all in a given round.
+> - **If a majority of issues are ESCALATE-PREMISE**, the plan is unsalvageable by line-edits. Surface that as a single top-line conclusion instead of going line-by-line.
+>
+> Plan:
+> [PASTE FULL PLAN]
+>
+> Critic's findings:
+> [PASTE CRITIC OUTPUT]
+>
+> For each numbered issue return: response type + detail.
+
+## Round N Prompts (Subsequent Rounds)
+
+**Critic — judge defender's responses:**
+
+> You previously raised issues against this plan. The DEFENDER responded with one of four types: ADDRESS, ARGUE-UNNECESSARY, REMOVE-FROM-SCOPE, or ESCALATE-PREMISE. For each issue, mark exactly one status:
+> - **RESOLVED** — defender's ADDRESS or REMOVE-FROM-SCOPE fixes the concern
+> - **ACCEPTED** — defender's ARGUE-UNNECESSARY convinced you the issue is not necessary to fix
+> - **DISPUTED** — defender's response does not satisfy you; explain specifically why
+> - **HUMAN-DECIDES** — defender marked ESCALATE-PREMISE; pass this item to the human, don't argue further
+>
+> Calibration — read before responding:
+> - **ACCEPTED requires an actual reason** ("on reflection, the impact is low enough" or "the defender's framing of the constraint was correct"). Don't ACCEPT just to converge or feel cooperative.
+> - **If you're yielding under pressure but still skeptical, mark DISPUTED** with the residual concern. An honest dispute beats a fake consensus.
+> - **Multiple rounds is not a signal to converge.** If real concerns remain, that's what escalation to the human is for. The point of this debate is honest disagreement, not agreement-at-all-costs.
+>
+> Plan:
+> [PLAN]
+>
+> Your previous findings:
+> [PREVIOUS CRITIC OUTPUT]
+>
+> Defender's responses:
+> [PREVIOUS DEFENDER OUTPUT]
+>
+> Return a numbered list with status. For DISPUTED items, include a follow-up explanation.
+
+If no DISPUTED items remain → no more debate rounds. Go to the Tiebreaker step if any HUMAN-DECIDES items exist; otherwise straight to the Final Step.
+
+**Defender — respond to DISPUTED items only:**
+
+> The critic still disputes these issues. For each, choose one of the same four response types as Round 1:
+> - **ADDRESS** with a stronger edit
+> - **ARGUE-UNNECESSARY** with stronger reasoning
+> - **REMOVE-FROM-SCOPE** if cutting is the right move
+> - **ESCALATE-PREMISE** if you've hit a genuine impasse — pass it to the human, don't fake agreement
+>
+> Disputed issues with critic's follow-up:
+> [PASTE DISPUTED ITEMS]
+
+## Tiebreaker
+
+If max rounds is reached with DISPUTED items still remaining — or if any issues were marked HUMAN-DECIDES (defender's ESCALATE-PREMISE) — do **not** decide on your own. Present each one to the user with:
+- Critic's latest concern
+- Defender's latest argument (or "defender flagged this as a premise problem the plan can't resolve by edits" for HUMAN-DECIDES)
+- Ask: keep critic's position, keep defender's position, propose a different resolution, or — for premise escalations — rework the plan's foundation before continuing?
+
+## Final Step — Produce the Strengthened Plan
+
+Apply every RESOLVED change (edits and removals) and every user-decided tiebreaker to the plan. Output the revised plan (or a diff against the original if it's a file).
+
+If the original plan is a file, ask the user before overwriting it.
+
+## Quick Reference
+
+| Phase | Agent | Job |
+|---|---|---|
+| Round 1 | Critic | Find issues (or PLAN-TOO-THIN if too vague to engage); no solutions |
+| Round 1 | Defender | ADDRESS / ARGUE-UNNECESSARY / REMOVE-FROM-SCOPE / ESCALATE-PREMISE per issue |
+| Round N | Critic | RESOLVED / ACCEPTED / DISPUTED / HUMAN-DECIDES per issue |
+| Round N | Defender | Respond to DISPUTED only |
+| Final | Orchestrator | Apply fixes; ask user about disputes + premise escalations |
+
+## Common Mistakes
+
+- **Defender collapses to ADDRESS-everything (or fakes pushback).** Both ends are failure modes. Use ARGUE-UNNECESSARY only when the critic is wrong, REMOVE-FROM-SCOPE when cutting is right, ESCALATE-PREMISE when the plan itself is broken. "Don't concede reflexively" is not a quota — honest ADDRESS beats fake disagreement.
+- **Padding the critic's list.** If the plan is thin, return PLAN-TOO-THIN. Five real findings beats twenty padded ones. Don't invent issues to satisfy every category in the prompt.
+- **Severity inflation.** Not everything is a blocker. Use the anchors literally: blocker = won't ship right; major = costly if shipped as-is; minor = polish.
+- **Drifting toward consensus across rounds.** Repeated rounds aren't a hint to converge. If the critic still has real concerns, mark DISPUTED and escalate. Fake consensus is worse than honest disagreement.
+- **Critic proposes solutions in Round 1.** Round 1 is for finding problems only. Solutions belong to the defender.
+- **Orchestrator decides the tie.** If max rounds hit with disputes, ask the user — don't pick a side yourself.
+- **Re-litigating resolved issues.** Drop RESOLVED and ACCEPTED items from the next defender prompt. Only DISPUTED carries forward.
+- **Burying the final plan in a transcript.** Output is the strengthened plan, not the debate log. Summarize the debate briefly, but lead with the revised plan.
+- **Running critic and defender in parallel.** Defender needs critic's findings to respond. Always sequential.

--- a/apps/consonant-specs-plugin/src/code.ts
+++ b/apps/consonant-specs-plugin/src/code.ts
@@ -1618,6 +1618,7 @@ async function drawA11yAnnotations(
 figma.showUI(__html__, { width: 300, height: 500, themeColors: true });
 
 figma.ui.onmessage = async (msg: { type: string; [key: string]: unknown }) => {
+  try {
   switch (msg.type) {
     case 'ui-ready':
       notifySelection();
@@ -2144,6 +2145,9 @@ case 'localize': {
       }
       break;
     }
+  }
+  } catch (e) {
+    console.error('[plugin/code] message handler threw for', msg?.type, e);
   }
 };
 

--- a/apps/consonant-specs-plugin/src/spec-card-gaps.ts
+++ b/apps/consonant-specs-plugin/src/spec-card-gaps.ts
@@ -22,27 +22,31 @@ interface CardBox {
 export async function generateCardGaps(node: SceneNode): Promise<void> {
   await figma.loadFontAsync({ family: 'Inter', style: 'Bold' });
 
-  // Remove any existing overlays first
+  // Remove any existing overlays — both legacy children of the node and
+  // page-level overlays from prior runs (matched by name).
   if ('children' in node) {
-    const old = (node as FrameNode).children.filter(c => c.name === 'spacing-in-between-overlay');
-    for (const o of old) o.remove();
+    const oldChildren = (node as FrameNode).children.filter(c => c.name === 'spacing-in-between-overlay');
+    for (const o of oldChildren) o.remove();
   }
+  const oldPageOverlays = figma.currentPage.children.filter(c => c.name === 'spacing-in-between-overlay');
+  for (const o of oldPageOverlays) o.remove();
 
-  // Overlay directly on the original node
+  // Overlay floats above the node — parented to the page so it works on
+  // instances (which reject appendChild). Coordinates are absolute.
   const overlay = figma.createFrame();
   overlay.name = 'spacing-in-between-overlay';
   overlay.resize(node.width, node.height);
   overlay.fills = [];
   overlay.clipsContent = false;
-  const savedClipsContent = 'clipsContent' in node ? (node as FrameNode).clipsContent : undefined;
-  if ('clipsContent' in node) (node as FrameNode).clipsContent = false;
-  (node as FrameNode).appendChild(overlay);
-  if ('layoutMode' in node && (node as FrameNode).layoutMode !== 'NONE') {
-    overlay.layoutPositioning = 'ABSOLUTE';
+  figma.currentPage.appendChild(overlay);
+  const abb = 'absoluteBoundingBox' in node ? (node as { absoluteBoundingBox: { x: number; y: number } | null }).absoluteBoundingBox : null;
+  if (abb) {
+    overlay.x = abb.x;
+    overlay.y = abb.y;
+  } else {
+    overlay.x = node.absoluteTransform[0][2];
+    overlay.y = node.absoluteTransform[1][2];
   }
-  overlay.resize(node.width, node.height);
-  overlay.x = 0;
-  overlay.y = 0;
 
   // Collect all card-like leaf containers: find groups of same-sized siblings
   const cards: CardBox[] = [];
@@ -51,7 +55,6 @@ export async function generateCardGaps(node: SceneNode): Promise<void> {
   if (cards.length < 2) {
     figma.ui.postMessage({ type: 'spec-it-status', message: 'No card gaps found.' });
     overlay.remove();
-    if (savedClipsContent !== undefined) (node as FrameNode).clipsContent = savedClipsContent;
     return;
   }
 
@@ -96,8 +99,8 @@ export async function generateCardGaps(node: SceneNode): Promise<void> {
 
   figma.ui.postMessage({ type: 'spec-it-status', message: `Found ${cards.length} cards, ${rows.length} rows` });
 
-  // Restore original clipsContent — don't permanently mutate the user's design
-  if (savedClipsContent !== undefined) (node as FrameNode).clipsContent = savedClipsContent;
+  // Select the overlay so the user can see where it landed in the layer panel.
+  figma.currentPage.selection = [overlay];
 }
 
 /**

--- a/apps/consonant-specs-plugin/src/spec-colors.ts
+++ b/apps/consonant-specs-plugin/src/spec-colors.ts
@@ -120,13 +120,6 @@ export async function generateColorAnnotations(node: SceneNode, yOffset = 0): Pr
         }
       }
 
-      // Text nodes: use textStyleId if a style is bound, otherwise use fontFamily
-      if (n.type === 'TEXT') {
-        const textNode = n as TextNode;
-        const hasStyle = textNode.textStyleId && textNode.textStyleId !== '' && textNode.textStyleId !== figma.mixed;
-        properties.push({ type: hasStyle ? 'textStyleId' : 'fontFamily' });
-      }
-
       // Frames with effects get effects property
       if ('effects' in n) {
         const effects = (n as any).effects;

--- a/apps/consonant-specs-plugin/src/spec-layout.ts
+++ b/apps/consonant-specs-plugin/src/spec-layout.ts
@@ -5,16 +5,21 @@ import { matchSpacing, matchColor, detectNodeColorRole } from './tokens';
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function removeOverlays(node: SceneNode, overlayName: string): void {
-  if (!('children' in node)) return;
-  const toRemove = (node as FrameNode).children.filter(c => c.name === overlayName);
-  for (const child of toRemove) child.remove();
-  // Also check one level of children for stale overlays
-  for (const child of (node as FrameNode).children) {
-    if ('children' in child) {
-      const nested = (child as FrameNode).children.filter(c => c.name === overlayName);
-      for (const n of nested) n.remove();
+  // Legacy: overlays used to be parented inside the node.
+  if ('children' in node) {
+    const toRemove = (node as FrameNode).children.filter(c => c.name === overlayName);
+    for (const child of toRemove) child.remove();
+    // Also check one level of children for stale overlays
+    for (const child of (node as FrameNode).children) {
+      if ('children' in child) {
+        const nested = (child as FrameNode).children.filter(c => c.name === overlayName);
+        for (const n of nested) n.remove();
+      }
     }
   }
+  // New: overlays are now parented to the page so they work on instances.
+  const pageOverlays = figma.currentPage.children.filter(c => c.name === overlayName);
+  for (const o of pageOverlays) o.remove();
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -784,21 +789,22 @@ export async function generateSpacingSection(sourceNode: SceneNode): Promise<voi
   // Remove any existing overlays first
   removeOverlays(sourceNode, 'spacing-detailed-overlay');
 
-  // Overlay directly on the original node
+  // Overlay floats above the node — parented to the page so it works on
+  // instances (which reject appendChild). Coordinates are absolute.
   const overlay = figma.createFrame();
   overlay.name = 'spacing-detailed-overlay';
   overlay.resize(sourceNode.width, sourceNode.height);
   overlay.fills = [];
   overlay.clipsContent = false;
-  const savedClipsContent = 'clipsContent' in sourceNode ? (sourceNode as FrameNode).clipsContent : undefined;
-  if ('clipsContent' in sourceNode) (sourceNode as FrameNode).clipsContent = false;
-  (sourceNode as FrameNode).appendChild(overlay);
-  if ('layoutMode' in sourceNode && (sourceNode as FrameNode).layoutMode !== 'NONE') {
-    overlay.layoutPositioning = 'ABSOLUTE';
+  figma.currentPage.appendChild(overlay);
+  const abb = 'absoluteBoundingBox' in sourceNode ? (sourceNode as { absoluteBoundingBox: { x: number; y: number } | null }).absoluteBoundingBox : null;
+  if (abb) {
+    overlay.x = abb.x;
+    overlay.y = abb.y;
+  } else {
+    overlay.x = sourceNode.absoluteTransform[0][2];
+    overlay.y = sourceNode.absoluteTransform[1][2];
   }
-  overlay.resize(sourceNode.width, sourceNode.height);
-  overlay.x = 0;
-  overlay.y = 0;
 
   const scale = 1;
   const margin = 0;
@@ -825,8 +831,8 @@ export async function generateSpacingSection(sourceNode: SceneNode): Promise<voi
   }
   drawChildSpacing(sourceNode);
 
-  // Restore original clipsContent — don't permanently mutate the user's design
-  if (savedClipsContent !== undefined) (sourceNode as FrameNode).clipsContent = savedClipsContent;
+  // Select the overlay so the user can see where it landed in the layer panel.
+  figma.currentPage.selection = [overlay];
 }
 
 export async function generateLayoutSection(sourceNode: SceneNode): Promise<FrameNode | null> {

--- a/apps/consonant-specs-plugin/src/spec-spacing-general.ts
+++ b/apps/consonant-specs-plugin/src/spec-spacing-general.ts
@@ -25,7 +25,14 @@ export async function generateSpacingGeneral(node: SceneNode, yOffset = 0): Prom
 
   await figma.loadFontAsync({ family: 'Inter', style: 'Bold' });
 
-  const clone = node.clone();
+  // Clone the source. If it's an instance, detach the clone so we can
+  // appendChild the overlay into it. This only detaches the spec copy —
+  // the user's original instance is untouched.
+  const rawClone = node.clone();
+  const clone: FrameNode = rawClone.type === 'INSTANCE'
+    ? (rawClone as InstanceNode).detachInstance()
+    : (rawClone as FrameNode);
+
   const sourceX = node.absoluteTransform[0][2];
   const sourceY = node.absoluteTransform[1][2];
   figma.currentPage.appendChild(clone);
@@ -40,7 +47,7 @@ export async function generateSpacingGeneral(node: SceneNode, yOffset = 0): Prom
   overlay.y = 0;
   overlay.fills = [];
   overlay.clipsContent = false;
-  (clone as FrameNode).clipsContent = false;
+  clone.clipsContent = false;
   clone.appendChild(overlay);
   overlay.layoutPositioning = 'ABSOLUTE';
   overlay.resize(node.width, node.height);
@@ -85,6 +92,10 @@ export async function generateSpacingGeneral(node: SceneNode, yOffset = 0): Prom
 
 
   figma.ui.postMessage({ type: 'spec-it-status', message: 'Spacing general complete!' });
+
+  // Select the spec clone so the user can see where it landed in the layer panel.
+  figma.currentPage.selection = [clone];
+
   return clone.height + 40;
 }
 

--- a/apps/consonant-specs-plugin/src/ui.ts
+++ b/apps/consonant-specs-plugin/src/ui.ts
@@ -153,8 +153,9 @@ document.getElementById('s2aBannerDismiss')?.addEventListener('click', () => {
 let currentSelection: { count: number; hasAutoLayout: boolean } = { count: 0, hasAutoLayout: false };
 
 function updateTabControls(prefix: string) {
-  const placeholder = document.getElementById(`${prefix}Placeholder`) as HTMLElement;
-  const controls = document.getElementById(`${prefix}Controls`) as HTMLElement;
+  const placeholder = document.getElementById(`${prefix}Placeholder`);
+  const controls = document.getElementById(`${prefix}Controls`);
+  if (!placeholder || !controls) return;
   const empty = currentSelection.count === 0;
   placeholder.style.display = empty ? 'block' : 'none';
   controls.style.display = empty ? 'none' : 'block';
@@ -201,6 +202,7 @@ window.addEventListener('message', (event) => {
   const msg = event.data.pluginMessage;
   if (!msg) return;
 
+  try {
   switch (msg.type) {
     case 'selection-changed':
       updateSelectionInfo(msg.selection);
@@ -305,6 +307,9 @@ window.addEventListener('message', (event) => {
       }
       break;
     }
+  }
+  } catch (e) {
+    console.error('[plugin/ui] message handler threw for', msg.type, e);
   }
 });
 
@@ -600,8 +605,9 @@ function updateApiKeyUi(hasKey: boolean, masked?: string) {
 
 // A11y tab — controls visibility
 function updateA11yControls() {
-  const placeholder = document.getElementById('a11yPlaceholder') as HTMLElement;
-  const controls = document.getElementById('a11yControls') as HTMLElement;
+  const placeholder = document.getElementById('a11yPlaceholder');
+  const controls = document.getElementById('a11yControls');
+  if (!placeholder || !controls) return;
   if (currentSelection.count === 0) {
     placeholder.style.display = 'block';
     controls.style.display = 'none';
@@ -1311,8 +1317,8 @@ function attachBridgeWsHandlers(ws: WebSocket, port: number) {
             appendBridgeLog('\u2192 ' + message.method + ' ERR: ' + err.message);
           }
         });
-    } catch {
-      // ignore malformed messages
+    } catch (e) {
+      console.error('[plugin/ui] ws.onmessage threw:', e);
     }
   };
 

--- a/apps/s2a-toolkit/server/figma-story-server.js
+++ b/apps/s2a-toolkit/server/figma-story-server.js
@@ -23,7 +23,7 @@ import { spawn, spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { tmpdir, homedir } from 'os';
 import { WebSocket } from 'ws';
-import { globSync } from '/Users/mhuntsberry/Desktop/consonant-2/node_modules/glob/dist/esm/index.js';
+import { globSync } from 'glob';
 
 const __dirname   = dirname(fileURLToPath(import.meta.url));
 const ROOT        = resolve(__dirname, '..', '..', '..');
@@ -525,7 +525,7 @@ ${tokenTable(grouped.borderRadius)}
 
 const CLAUDE_BIN = (() => {
   for (const p of [
-    '/Users/mhuntsberry/.local/bin/claude',
+    `${process.env.HOME}/.local/bin/claude`,
     '/usr/local/bin/claude',
     process.env.CLAUDE_BIN,
   ]) { if (p && existsSync(p)) return p; }
@@ -542,7 +542,7 @@ function claudeEnv() {
     HOME:   process.env.HOME,
     USER:   process.env.USER,
     TMPDIR: process.env.TMPDIR || '/tmp',
-    PATH:   `${process.env.PATH}:/Users/mhuntsberry/.local/bin`,
+    PATH:   `${process.env.PATH}:${process.env.HOME}/.local/bin`,
   };
 }
 


### PR DESCRIPTION
## Summary

Five commits accumulated on `taeho-branch` after PR #45 (A11y) was squash-merged. This PR ships them as a clean diff against current `main`:

- **feat:** Add `critic-vs-defender` skill — adversarial debate workflow for pressure-testing plans (critic + defender subagents iterate until consensus or human tiebreaker). Empirically tested with Opus subagents; defender uses four response types to avoid collapsing to ADDRESS-everything. See [`SKILL.md`](apps/consonant-specs-plugin/skills/critic-vs-defender/SKILL.md).
- **fix:** Specs tab now works on component instances (not just main components) and auto-selects overlay
- **fix:** Null-guard tab controls + surface message-handler errors that were previously silent
- **fix:** Colors spec no longer annotates text style
- **chore:** Remove hardcoded user paths from `.mcp.json` / scripts; clarify MCP server roles in `CLAUDE.md`

## Test plan

- [ ] Open a component instance in Figma → Specs tab loads (regression check vs. main-components-only behavior)
- [ ] Generate a Colors spec → verify text style is no longer annotated
- [ ] Open the plugin with no selection / missing nodes → tab controls don't throw
- [ ] On a fresh user setup, `.mcp.json` paths resolve (no leftover `mhuntsberry` references)
- [ ] `critic-vs-defender/SKILL.md` is discoverable from the plugin's skills folder — static file, no runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)