### PR TITLE
fix(tokens): green the token test gate (9 pre-existing failures + on-import build)

### DIFF
--- a/packages/tokens/scripts/__tests__/figma-sync.test.js
+++ b/packages/tokens/scripts/__tests__/figma-sync.test.js
@@ -386,7 +386,7 @@ describe('transformVariables', () => {
     const collections = [
       {
         id: 'coll1',
-        name: 'Colors',
+        name: 'S2A / Semantic / Color',
         modes: [
           { modeId: 'mode1', name: 'Light' },
         ],
@@ -447,7 +447,7 @@ describe('transformVariables', () => {
     const collections = [
       {
         id: 'coll1',
-        name: 'Colors',
+        name: 'S2A / Semantic / Color',
         modes: [
           { modeId: 'mode1', name: 'Light' },
           { modeId: 'mode2', name: 'Dark' },
@@ -488,7 +488,7 @@ describe('transformVariables', () => {
     const collections = [
       {
         id: 'coll1',
-        name: 'Colors',
+        name: 'S2A / Semantic / Color',
         modes: [
           { modeId: 'mode1', name: 'Light' },
         ],
@@ -518,7 +518,7 @@ describe('transformVariables', () => {
     const collections = [
       {
         id: 'coll1',
-        name: 'Colors',
+        name: 'S2A / Semantic / Color',
         modes: [
           { modeId: 'mode1', name: 'Light' },
         ],
@@ -550,7 +550,7 @@ describe('transformVariables', () => {
     const collections = [
       {
         id: 'coll1',
-        name: 'Colors',
+        name: 'S2A / Semantic / Color',
         modes: [
           { modeId: 'mode1', name: 'Light' },
         ],
@@ -579,7 +579,7 @@ describe('transformVariables', () => {
     const collections = [
       {
         id: 'coll1',
-        name: 'Colors',
+        name: 'S2A / Semantic / Color',
         modes: [
           { modeId: 'mode1', name: 'Light' },
         ],
@@ -589,8 +589,8 @@ describe('transformVariables', () => {
     const result = transformVariables({ variables, collections });
 
     const file = result.files[0];
-    expect(file.fileName).toContain('colors');
-    expect(file.collection.name).toBe('Colors');
+    expect(file.fileName).toContain('color');
+    expect(file.collection.name).toBe('S2A / Semantic / Color');
     expect(file.mode.name).toBe('Light');
   });
 

--- a/packages/tokens/scripts/__tests__/typography-conversion.test.js
+++ b/packages/tokens/scripts/__tests__/typography-conversion.test.js
@@ -568,7 +568,7 @@ describe("convertNumberTokens", () => {
     expect(tokens.typography["line-height"]["20"].$value).toBe("20px");
   });
 
-  it("converts opacity values from 0-100 to 0-1", () => {
+  it("converts opacity values from 0-100 to a CSS percentage string", () => {
     const maps = {
       fontSize: { valueByKey: new Map(), keyByValue: new Map() },
       lineHeight: { valueByKey: new Map(), keyByValue: new Map() },
@@ -586,12 +586,13 @@ describe("convertNumberTokens", () => {
 
     convertNumberTokens(tokens, [], maps);
 
-    expect(tokens.opacity.disabled.$value).toBe(0.48);
-    expect(tokens.opacity.hidden.$value).toBe(0);
-    expect(tokens.opacity.full.$value).toBe(1);
+    // Opacity is emitted as a CSS percentage string (Figma stores 0–100).
+    expect(tokens.opacity.disabled.$value).toBe("48%");
+    expect(tokens.opacity.hidden.$value).toBe("0%");
+    expect(tokens.opacity.full.$value).toBe("100%");
   });
 
-  it("clamps opacity values to 0-1 range", () => {
+  it("clamps opacity values to 0-100% range", () => {
     const maps = {
       fontSize: { valueByKey: new Map(), keyByValue: new Map() },
       lineHeight: { valueByKey: new Map(), keyByValue: new Map() },
@@ -608,8 +609,8 @@ describe("convertNumberTokens", () => {
 
     convertNumberTokens(tokens, [], maps);
 
-    expect(tokens.opacity.negative.$value).toBe(0);
-    expect(tokens.opacity.over.$value).toBe(1);
+    expect(tokens.opacity.negative.$value).toBe("0%");
+    expect(tokens.opacity.over.$value).toBe("100%");
   });
 
   it("converts other numeric values to px", () => {

--- a/packages/tokens/scripts/build-tokens.js
+++ b/packages/tokens/scripts/build-tokens.js
@@ -106,6 +106,10 @@ const PACKAGE_DIR = path.join(__dirname, "..");
 const FIGMA_TOKENS_DIR = path.join(PACKAGE_DIR, "json");
 const FIGMA_METADATA_PATH = path.join(FIGMA_TOKENS_DIR, "metadata.json");
 
+// Only run the build when this script is executed directly (node build-tokens.js).
+// Importing it for its utilities (e.g. in tests) must not kick off a build +
+// process.exit(1).
+if (require.main === module)
 (async () => {
   try {
     if (!(await hasFigmaTokens())) {

--- a/packages/tokens/scripts/sync-figma-variables.js
+++ b/packages/tokens/scripts/sync-figma-variables.js
@@ -319,7 +319,9 @@ function transformVariables({ variables, collections }) {
   }
 
   for (const variable of variables) {
-    if (!variable || variable.deletedButReferenced) {
+    // Skip remote (library-imported) and deleted variables — only local
+    // variables belong in the generated token files.
+    if (!variable || variable.deletedButReferenced || variable.remote) {
       continue;
     }
 
@@ -539,10 +541,9 @@ function toSlug(value) {
   const normalized = String(value || "")
     .trim()
     .toLowerCase()
-    .replace(/[^a-z0-9_]+/g, "-")
+    .replace(/[^a-z0-9]+/g, "-")
     .replace(/-+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .replace(/_+/g, "_");
+    .replace(/^-+|-+$/g, "");
   return normalized || "token";
 }
 
@@ -555,8 +556,14 @@ async function safeParseJson(response) {
   }
 }
 
-// Export functions for testing
+if (require.main === module) {
+  main();
+}
+
+// Single export block — a prior duplicate module.exports overwrote this one at
+// runtime, dropping splitVariablePath/parseEnv/stripQuotes/hydrateEnv.
 module.exports = {
+  main,
   normalizeVariables,
   normalizeCollections,
   parseEnv,
@@ -564,15 +571,4 @@ module.exports = {
   splitVariablePath,
   transformVariables,
   hydrateEnv,
-};
-
-if (require.main === module) {
-  main();
-}
-
-module.exports = {
-  main,
-  normalizeVariables,
-  normalizeCollections,
-  transformVariables,
 };


### PR DESCRIPTION
## Summary

Greens the long-red **`nx test tokens`** gate — it had **9 failing tests + 1 unhandled error** (`process.exit(1)`), all pre-existing on `main` (unrelated to any token release). Result: **211 passed, 0 errors**, and **no token CSS/dist output changes**.

The failures split cleanly into genuine implementation bugs and stale tests.

## Implementation fixes (real bugs)

**`sync-figma-variables.js`**
- **`toSlug` now maps `_` → `-`.** It previously *preserved* underscores (`Primary_Value` → `primary_value`), violating the kebab-case convention the rest of S2A uses. This test had been red since the first commit — the impl never matched it.
- **Skip `remote` variables in `transformVariables`.** Library-imported (remote) variables were being written into local token files; only local variables belong there.
- **Merge the duplicate `module.exports`.** A second `module.exports` block silently overwrote the first at runtime, dropping `splitVariablePath` / `parseEnv` / `stripQuotes` / `hydrateEnv` from the module's runtime exports.

**`build-tokens.js`**
- **Guard the top-level build IIFE behind `require.main === module`.** The module ran a full `buildFromFigma()` on *every import* — so importing it for a utility (`pruneCssDuplicates`) in the css-processing tests kicked off a build that threw and called `process.exit(1)`. (The underlying throw was a `rewriteSemanticRefsToS2a` ReferenceError that only surfaces under vitest's stricter evaluation; not running the build on import resolves it. The direct `node build-tokens.js` build path is unaffected — verified green.)

## Stale-test fixes (behavior was already correct)

**`typography-conversion.test.js`** — opacity is emitted as a **CSS percentage string** (`"48%"`), matching the shipped CSS (`--s2a-opacity-48: 48%`), not the old `0–1` decimal the tests still expected. Updated expectations + titles.

**`figma-sync.test.js`** — the `transformVariables` fixtures used the toy collection name `'Colors'`, which the (intended) production collection filter rejects, so they produced empty output. Renamed to a valid target collection (`'S2A / Semantic / Color'`) and updated the dependent file-structure assertions. The production filter is unchanged.

## Why this matters

This gate currently blocks the tokens **0.0.19** release PR (#100) and any future tokens PR. With it green, those can actually merge on a passing check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
