### PR TITLE
Localize v2 — rewritten localization tab (translate-first, 10 languages, keyless providers)

### DIFF
--- a/apps/consonant-specs-plugin/manifest.json
+++ b/apps/consonant-specs-plugin/manifest.json
@@ -12,11 +12,7 @@
     "allowedDomains": [
       "https://api.anthropic.com",
       "https://api.mymemory.translated.net",
-      "https://lingva.ml",
-      "https://lingva.thedaviddelta.com",
-      "https://api-free.deepl.com",
-      "https://translation.googleapis.com",
-      "https://api.cognitive.microsofttranslator.com",
+      "https://translate.googleapis.com",
       "http://localhost:9300",
       "ws://localhost:9220",
       "ws://localhost:9221",
@@ -32,6 +28,6 @@
       "ws://localhost:9231",
       "ws://localhost:9232"
     ],
-    "reasoning": "Localize tab calls translation APIs. Bridge tab connects to consonant-mcp HTTP on port 9300. WebSocket ports 9220-9222 connect to consonant-mcp, 9223-9232 to figma-console MCP (fallback)."
+    "reasoning": "Localize tab calls translation APIs (Google gtx endpoint, MyMemory). Bridge tab connects to consonant-mcp HTTP on port 9300. WebSocket ports 9220-9222 connect to consonant-mcp, 9223-9232 to figma-console MCP (fallback)."
   }
 }

--- a/apps/consonant-specs-plugin/src/code.ts
+++ b/apps/consonant-specs-plugin/src/code.ts
@@ -2,7 +2,8 @@ import { getTokenVersion, getTokenCount, hasS2AVariables, loadLibraryTokens, rel
 import { getNodeProperties } from './annotations';
 import { specIt } from './spec-it';
 import { runS2AAudit, runFullAlign, runTextColorsAlign } from './s2a-audit';
-import { localize, collectSourceText, TranslationProvider } from './localize';
+import { localizeViaApi, collectSourceText, applyTranslationsToClones } from './localize';
+import type { ApiProvider } from './localize-languages';
 import { generateBlueline, generateBluelinePanels, placeCategoryBadge } from './a11y-blueline';
 import { runStructuralScan } from './a11y-structural-scan';
 import { generateFocusIndicators, collectFocusableElements } from './spec-focus-indicators';
@@ -1297,24 +1298,6 @@ async function handleBridgeMethod(method: string, params: Record<string, any>): 
   }
 }
 
-function apiKeyStorageKey(provider: string): string {
-  return `api-key-${provider}`;
-}
-
-function maskKey(key: string): string {
-  if (key.length <= 8) return '••••';
-  return `${key.slice(0, 6)}…${key.slice(-4)}`;
-}
-
-async function postApiKeyState(provider: string): Promise<void> {
-  const key = await figma.clientStorage.getAsync(apiKeyStorageKey(provider));
-  figma.ui.postMessage({
-    type: 'api-key-state',
-    hasKey: typeof key === 'string' && key.length > 0,
-    masked: typeof key === 'string' && key.length > 0 ? maskKey(key) : undefined,
-  });
-}
-
 // ── A11y annotation mode drawing ─────────────────────────────────────────────
 
 let annotateRunning = false;
@@ -2061,25 +2044,13 @@ figma.ui.onmessage = async (msg: { type: string; [key: string]: unknown }) => {
       }
       break;
     }
-    case 'get-api-key': {
-      const provider = typeof msg.provider === 'string' ? msg.provider : 'mymemory';
-      await postApiKeyState(provider);
+    case 'get-email': {
+      const email = (await figma.clientStorage.getAsync('mymemory-email')) || '';
+      figma.ui.postMessage({ type: 'email-state', email });
       break;
     }
-    case 'save-api-key': {
-      const key = typeof msg.key === 'string' ? msg.key.trim() : '';
-      const provider = typeof msg.provider === 'string' ? msg.provider : 'mymemory';
-      if (!key) { figma.notify('Empty API key', { error: true }); break; }
-      await figma.clientStorage.setAsync(apiKeyStorageKey(provider), key);
-      await postApiKeyState(provider);
-      figma.notify('API key saved');
-      break;
-    }
-    case 'clear-api-key': {
-      const provider = typeof msg.provider === 'string' ? msg.provider : 'mymemory';
-      await figma.clientStorage.deleteAsync(apiKeyStorageKey(provider));
-      await postApiKeyState(provider);
-      figma.notify('API key cleared');
+    case 'save-email': {
+      await figma.clientStorage.setAsync('mymemory-email', String(msg.email ?? ''));
       break;
     }
     // ── Bridge unified command handler (figma-console MCP protocol) ──────
@@ -2097,51 +2068,71 @@ figma.ui.onmessage = async (msg: { type: string; [key: string]: unknown }) => {
     }
 case 'localize': {
       const sel = figma.currentPage.selection;
-      if (sel.length === 0) { figma.notify('Select a frame first'); break; }
-      const provider = (typeof msg.provider === 'string' ? msg.provider : 'mymemory') as TranslationProvider;
+      if (sel.length !== 1) { figma.notify('Select exactly one frame'); break; }
+      const provider = msg.provider as ApiProvider;
       const languages = Array.isArray(msg.languages) ? (msg.languages as string[]) : [];
-      const applyRtl = Boolean(msg.applyRtl);
       if (languages.length === 0) {
         figma.ui.postMessage({ type: 'localize-status', message: 'Select at least one language.' });
         break;
       }
-
-      // Bridge provider — collect text and send to UI for prompt generation
-      if (provider === 'bridge') {
-        const sourceTexts = collectSourceText(sel[0]);
-        if (sourceTexts.length === 0) {
-          figma.ui.postMessage({ type: 'localize-status', message: 'No text found in selection.' });
-          break;
-        }
-        figma.ui.postMessage({
-          type: 'localize-bridge-prompt',
-          frameName: sel[0].name,
-          frameId: sel[0].id,
-          languages,
-          applyRtl,
-          sourceTexts,
-        });
-        break;
-      }
-
-      const needsKey = ['deepl', 'google', 'azure'].includes(provider);
-      let apiKey = '';
-      if (needsKey) {
-        apiKey = await figma.clientStorage.getAsync(apiKeyStorageKey(provider)) || '';
-        if (!apiKey) {
-          figma.ui.postMessage({ type: 'localize-status', message: `Add your ${provider} API key first.` });
-          break;
-        }
-      }
+      const email = (await figma.clientStorage.getAsync('mymemory-email')) || '';
       try {
-        const result = await localize(sel[0], languages, applyRtl, provider, apiKey);
-        const errTail = result.errors.length > 0 ? ` (errors: ${result.errors.join('; ')})` : '';
-        figma.ui.postMessage({ type: 'localize-status', message: `Created ${result.created} localized frame(s).${errTail}` });
-        figma.notify(`Localized ${result.created} frame(s)`);
+        const result = await localizeViaApi(
+          sel[0],
+          languages,
+          Boolean(msg.applyRtl),
+          provider,
+          email,
+          (message) => figma.ui.postMessage({ type: 'localize-status', message }),
+        );
+        figma.ui.postMessage({ type: 'localize-done', created: result.created, errors: result.errors });
+        if (result.created === 0 && result.errors.length > 0) {
+          figma.notify('Localize failed — see plugin window for details', { error: true });
+        } else if (result.created > 0 && result.errors.length > 0) {
+          figma.notify(`Localized ${result.created} frame(s), ${result.errors.length} language(s) failed`);
+        } else {
+          figma.notify(`Localized ${result.created} frame(s)`);
+        }
       } catch (e: any) {
         const errorMsg = e instanceof Error ? e.message : 'Unknown error';
         figma.ui.postMessage({ type: 'localize-status', message: `Error: ${errorMsg}` });
         figma.notify(`Localize failed: ${errorMsg}`, { error: true });
+      }
+      break;
+    }
+    case 'paste-collect': {
+      const sel = figma.currentPage.selection;
+      if (sel.length !== 1) { figma.notify('Select exactly one frame'); break; }
+      const strings = collectSourceText(sel[0]);
+      if (strings.length === 0) {
+        figma.ui.postMessage({ type: 'localize-status', message: 'No text found in selection.' });
+        break;
+      }
+      figma.ui.postMessage({ type: 'paste-source', frameName: sel[0].name, strings });
+      break;
+    }
+    case 'paste-apply': {
+      const sel = figma.currentPage.selection;
+      if (sel.length !== 1) { figma.notify('Select exactly one frame'); break; }
+      const translations = msg.translations as Record<string, string[]>;
+      try {
+        const result = await applyTranslationsToClones(
+          sel[0],
+          translations,
+          Boolean(msg.applyRtl),
+          (message) => figma.ui.postMessage({ type: 'localize-status', message }),
+        );
+        figma.ui.postMessage({ type: 'localize-done', created: result.created, errors: result.errors });
+        if (result.created === 0 && result.errors.length > 0) {
+          figma.notify('Localize failed — see plugin window for details', { error: true });
+        } else if (result.created > 0 && result.errors.length > 0) {
+          figma.notify(`Localized ${result.created} frame(s), ${result.errors.length} language(s) failed`);
+        } else {
+          figma.notify(`Localized ${result.created} frame(s)`);
+        }
+      } catch (e: any) {
+        const errorMsg = e instanceof Error ? e.message : 'Unknown error';
+        figma.ui.postMessage({ type: 'localize-status', message: `Error: ${errorMsg}` });
       }
       break;
     }

--- a/apps/consonant-specs-plugin/src/code.ts
+++ b/apps/consonant-specs-plugin/src/code.ts
@@ -1598,7 +1598,7 @@ async function drawA11yAnnotations(
   container.locked = true;
 }
 
-figma.showUI(__html__, { width: 300, height: 500, themeColors: true });
+figma.showUI(__html__, { width: 360, height: 500, themeColors: true });
 
 figma.ui.onmessage = async (msg: { type: string; [key: string]: unknown }) => {
   try {
@@ -1750,7 +1750,7 @@ figma.ui.onmessage = async (msg: { type: string; [key: string]: unknown }) => {
       if (wide) {
         figma.ui.resize(450, 600);
       } else {
-        figma.ui.resize(300, 500);  // restores the default set in showUI at code.ts:1606
+        figma.ui.resize(360, 500);  // restores the default set in showUI at code.ts:1601
       }
       return;
     }

--- a/apps/consonant-specs-plugin/src/localize-languages.ts
+++ b/apps/consonant-specs-plugin/src/localize-languages.ts
@@ -1,0 +1,25 @@
+export type ApiProvider = 'google' | 'mymemory';
+export type Provider = ApiProvider | 'paste';
+
+export interface LangMeta {
+  name: string;
+  fallbackFont: string | null;
+  group: 'latin' | 'cjk' | 'other';
+  note: string;
+  codes: Record<ApiProvider, string>;
+}
+
+export const LANG_META: Record<string, LangMeta> = {
+  de: { name: 'German',     fallbackFont: null, group: 'latin', note: 'long-word wrapping, ~1.5× text', codes: { google: 'de',    mymemory: 'de' } },
+  fr: { name: 'French',     fallbackFont: null, group: 'latin', note: '~1.2× text expansion',           codes: { google: 'fr',    mymemory: 'fr' } },
+  es: { name: 'Spanish',    fallbackFont: null, group: 'latin', note: '~1.25× text expansion',          codes: { google: 'es',    mymemory: 'es' } },
+  it: { name: 'Italian',    fallbackFont: null, group: 'latin', note: 'text expansion',                 codes: { google: 'it',    mymemory: 'it' } },
+  pt: { name: 'Portuguese', fallbackFont: null, group: 'latin', note: 'text expansion',                 codes: { google: 'pt',    mymemory: 'pt' } },
+  zh: { name: 'Chinese',    fallbackFont: 'Noto Sans SC',     group: 'cjk',   note: 'short sentences',                 codes: { google: 'zh-CN', mymemory: 'zh-CN' } },
+  ja: { name: 'Japanese',   fallbackFont: 'Noto Sans JP',     group: 'cjk',   note: 'no word breaks',                  codes: { google: 'ja',    mymemory: 'ja' } },
+  ko: { name: 'Korean',     fallbackFont: 'Noto Sans KR',     group: 'cjk',   note: 'tall glyphs',                     codes: { google: 'ko',    mymemory: 'ko' } },
+  th: { name: 'Thai',       fallbackFont: 'Noto Sans Thai',   group: 'other', note: 'extra line-height for ligatures', codes: { google: 'th',    mymemory: 'th' } },
+  ar: { name: 'Arabic',     fallbackFont: 'Noto Sans Arabic', group: 'other', note: 'RTL',                             codes: { google: 'ar',    mymemory: 'ar' } },
+};
+
+export const LANG_ORDER = Object.keys(LANG_META);

--- a/apps/consonant-specs-plugin/src/localize-paste.ts
+++ b/apps/consonant-specs-plugin/src/localize-paste.ts
@@ -1,0 +1,53 @@
+import { LANG_META } from './localize-languages';
+
+export function buildPastePrompt(frameName: string, strings: string[], langs: string[]): string {
+  const langNames = langs.map((l) => `${l} (${LANG_META[l]?.name ?? l})`).join(', ');
+  const numbered = strings.map((s, i) => `${i + 1}. ${JSON.stringify(s)}`).join('\n');
+  const placeholders = Array(strings.length).fill('"..."').join(', ');
+  const shape = `{"translations": {${langs.map((l) => `"${l}": [${placeholders}]`).join(', ')}}}`;
+  return [
+    `Translate the following ${strings.length} UI strings from the design frame "${frameName}" from English into: ${langNames}.`,
+    '',
+    numbered,
+    '',
+    `Respond with ONLY the JSON below — no commentary, no markdown. Each language's array must contain exactly ${strings.length} translations in the same order as the numbered list:`,
+    shape,
+  ].join('\n');
+}
+
+export function parsePasteResponse(
+  raw: string,
+  langs: string[],
+  expectedCount: number,
+): { ok: true; translations: Record<string, string[]> } | { ok: false; error: string } {
+  const cleaned = raw.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '');
+  let data: unknown;
+  try {
+    data = JSON.parse(cleaned);
+  } catch {
+    const start = cleaned.indexOf('{');
+    const end = cleaned.lastIndexOf('}');
+    if (start === -1 || end === -1 || end <= start) {
+      return { ok: false, error: 'That doesn’t look like valid JSON. Paste the model’s JSON response only.' };
+    }
+    try {
+      data = JSON.parse(cleaned.slice(start, end + 1));
+    } catch {
+      return { ok: false, error: 'That doesn’t look like valid JSON. Paste the model’s JSON response only.' };
+    }
+  }
+  const translations = (data as { translations?: unknown } | null)?.translations;
+  if (typeof translations !== 'object' || translations === null) {
+    return { ok: false, error: 'JSON is missing the "translations" object.' };
+  }
+  const out: Record<string, string[]> = {};
+  for (const lang of langs) {
+    const arr = (translations as Record<string, unknown>)[lang];
+    if (!Array.isArray(arr)) return { ok: false, error: `Missing translations for ${LANG_META[lang]?.name ?? lang}.` };
+    if (arr.length !== expectedCount) {
+      return { ok: false, error: `${LANG_META[lang]?.name ?? lang}: expected ${expectedCount} strings, got ${arr.length}.` };
+    }
+    out[lang] = arr.map(String);
+  }
+  return { ok: true, translations: out };
+}

--- a/apps/consonant-specs-plugin/src/localize-providers.ts
+++ b/apps/consonant-specs-plugin/src/localize-providers.ts
@@ -1,0 +1,64 @@
+import type { ApiProvider } from './localize-languages';
+
+export function parseGtxResponse(data: unknown): string {
+  const segments = Array.isArray(data) ? (data as unknown[])[0] : null;
+  if (!Array.isArray(segments)) throw new Error('Unexpected response from Google translate endpoint');
+  return (segments as unknown[][]).map((s) => String(s[0] ?? '')).join('');
+}
+
+export function parseMyMemoryResponse(data: unknown, fallback: string): string {
+  const text = (data as { responseData?: { translatedText?: unknown } } | null)?.responseData?.translatedText;
+  return typeof text === 'string' && text.length > 0 ? text : fallback;
+}
+
+// MyMemory returns responseStatus as either a number (200) or a STRING ("403") depending
+// on the error path — live-captured 2026-08-05 via
+// curl "https://api.mymemory.translated.net/get?q=&langpair=en|de":
+// {"responseDetails":"NO QUERY SPECIFIED...","responseStatus":"403",...}
+// A `typeof status === 'number'` guard never fires for the string form, so the error
+// text (also duplicated into responseData.translatedText) falls through and gets
+// treated as a real translation. Coerce to a number before comparing.
+export function assertMyMemoryOk(data: unknown): void {
+  const status = (data as { responseStatus?: unknown } | null)?.responseStatus;
+  if (status == null) return;
+  const n = Number(status);
+  if (!Number.isFinite(n) || n === 200) return;
+  const details = (data as { responseDetails?: unknown }).responseDetails;
+  throw new Error(`MyMemory: ${typeof details === 'string' && details ? details : `error ${status}`}`);
+}
+
+async function fetchJson(url: string, providerLabel: string): Promise<unknown> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`${providerLabel} error ${res.status}`);
+  return res.json();
+}
+
+async function translateGoogleGtx(strings: string[], langCode: string): Promise<string[]> {
+  return Promise.all(strings.map(async (s) => {
+    const url = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=en&tl=${langCode}&dt=t&q=${encodeURIComponent(s)}`;
+    return parseGtxResponse(await fetchJson(url, 'Google'));
+  }));
+}
+
+async function translateMyMemory(strings: string[], langCode: string, email: string): Promise<string[]> {
+  return Promise.all(strings.map(async (s) => {
+    let url = `https://api.mymemory.translated.net/get?q=${encodeURIComponent(s)}&langpair=en|${langCode}`;
+    if (email) url += `&de=${encodeURIComponent(email)}`;
+    const data = await fetchJson(url, 'MyMemory');
+    assertMyMemoryOk(data);
+    return parseMyMemoryResponse(data, s);
+  }));
+}
+
+export async function translateStrings(
+  provider: ApiProvider,
+  strings: string[],
+  langCode: string,
+  email: string,
+): Promise<string[]> {
+  switch (provider) {
+    case 'google': return translateGoogleGtx(strings, langCode);
+    case 'mymemory': return translateMyMemory(strings, langCode, email);
+    default: throw new Error(`Unknown translation provider: ${provider satisfies never}`);
+  }
+}

--- a/apps/consonant-specs-plugin/src/localize.ts
+++ b/apps/consonant-specs-plugin/src/localize.ts
@@ -1,174 +1,36 @@
-// ── Localize: translate text in cloned frames via multiple translation backends ──
-
-export type TranslationProvider = 'mymemory' | 'lingva' | 'deepl' | 'google' | 'azure' | 'bridge';
-
-const LANG_META: Record<string, { name: string; fallbackFont: string | null; codes: Record<TranslationProvider, string> }> = {
-  de: {
-    name: 'German', fallbackFont: null, // Latin — original font works fine
-    codes: { mymemory: 'de', lingva: 'de', deepl: 'DE', google: 'de', azure: 'de', bridge: 'German' },
-  },
-  zh: {
-    name: 'Chinese', fallbackFont: 'Noto Sans SC',
-    codes: { mymemory: 'zh-CN', lingva: 'zh', deepl: 'ZH', google: 'zh-CN', azure: 'zh-Hans', bridge: 'Simplified Chinese' },
-  },
-  th: {
-    name: 'Thai', fallbackFont: 'Noto Sans Thai',
-    codes: { mymemory: 'th', lingva: 'th', deepl: 'TH', google: 'th', azure: 'th', bridge: 'Thai' },
-  },
-  ar: {
-    name: 'Arabic', fallbackFont: 'Noto Sans Arabic',
-    codes: { mymemory: 'ar', lingva: 'ar', deepl: 'AR', google: 'ar', azure: 'ar', bridge: 'Arabic' },
-  },
-};
-
-export const PROVIDERS: { id: TranslationProvider; label: string; needsKey: boolean }[] = [
-  { id: 'mymemory', label: 'MyMemory (free, no key)', needsKey: false },
-  { id: 'lingva', label: 'Lingva (free, no key)', needsKey: false },
-  { id: 'deepl', label: 'DeepL Free (key required)', needsKey: true },
-  { id: 'google', label: 'Google Cloud (key required)', needsKey: true },
-  { id: 'azure', label: 'Microsoft Azure (key required)', needsKey: true },
-  { id: 'bridge', label: 'Claude via Bridge (no key)', needsKey: false },
-];
-
-// ── Helpers ──
+import { LANG_META, type ApiProvider } from './localize-languages';
+import { translateStrings } from './localize-providers';
 
 function norm(s: string): string {
   return s
     .replace(/[\u2028\u2029\n\r]+/g, ' ')
-    .replace(/[\u2018\u2019]/g, "'")
-    .replace(/[\u201C\u201D]/g, '"');
+    .replace(/[‘’]/g, "'")
+    .replace(/[“”]/g, '"');
 }
 
 function collectTextNodes(node: SceneNode, acc: TextNode[]): void {
   if (node.type === 'TEXT' && node.characters.length > 0) acc.push(node);
   if ('children' in node) {
-    for (const child of (node as any).children as SceneNode[]) collectTextNodes(child, acc);
+    for (const child of (node as ChildrenMixin & SceneNode).children) collectTextNodes(child, acc);
   }
 }
 
-function collectFonts(nodes: TextNode[]): FontName[] {
-  const seen = new Set<string>();
-  const fonts: FontName[] = [];
-  for (const n of nodes) {
-    try {
-      const fn = n.getRangeFontName(0, 1);
-      if (fn === figma.mixed) continue;
-      const key = JSON.stringify(fn);
-      if (!seen.has(key)) { seen.add(key); fonts.push(fn as FontName); }
-    } catch (_) {}
-  }
-  return fonts;
+export function collectSourceText(node: SceneNode): string[] {
+  const acc: TextNode[] = [];
+  collectTextNodes(node, acc);
+  return acc.map((n) => norm(n.characters));
 }
-
-async function loadFonts(fonts: FontName[]): Promise<void> {
-  await Promise.all(fonts.map((f) => figma.loadFontAsync(f).catch(() => {})));
-}
-
-// ── Translation backends ──
-
-async function translateMyMemory(strings: string[], langCode: string): Promise<string[]> {
-  return Promise.all(strings.map(async (s) => {
-    const url = `https://api.mymemory.translated.net/get?q=${encodeURIComponent(s)}&langpair=en|${langCode}`;
-    const res = await fetch(url);
-    if (!res.ok) throw new Error(`MyMemory error ${res.status}`);
-    const data = await res.json();
-    return data?.responseData?.translatedText || s;
-  }));
-}
-
-async function translateLingva(strings: string[], langCode: string): Promise<string[]> {
-  const instances = ['lingva.ml', 'lingva.thedaviddelta.com'];
-  return Promise.all(strings.map(async (s) => {
-    for (const host of instances) {
-      try {
-        const url = `https://${host}/api/v1/en/${langCode}/${encodeURIComponent(s)}`;
-        const res = await fetch(url);
-        if (!res.ok) continue;
-        const data = await res.json();
-        if (data?.translation) return data.translation;
-      } catch (_) {}
-    }
-    return s;
-  }));
-}
-
-async function translateDeepL(strings: string[], langCode: string, apiKey: string): Promise<string[]> {
-  const res = await fetch('https://api-free.deepl.com/v2/translate', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Authorization': `DeepL-Auth-Key ${apiKey}` },
-    body: JSON.stringify({ text: strings, source_lang: 'EN', target_lang: langCode }),
-  });
-  if (!res.ok) {
-    let msg = `DeepL error ${res.status}`;
-    try { const b = await res.json(); if (b?.message) msg = b.message; } catch (_) {}
-    throw new Error(msg);
-  }
-  const data = await res.json();
-  return (data.translations as Array<{ text: string }>).map((t) => t.text);
-}
-
-async function translateGoogle(strings: string[], langCode: string, apiKey: string): Promise<string[]> {
-  const res = await fetch(`https://translation.googleapis.com/language/translate/v2?key=${apiKey}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ q: strings, source: 'en', target: langCode, format: 'text' }),
-  });
-  if (!res.ok) {
-    let msg = `Google error ${res.status}`;
-    try { const b = await res.json(); if (b?.error?.message) msg = b.error.message; } catch (_) {}
-    throw new Error(msg);
-  }
-  const data = await res.json();
-  return (data.data.translations as Array<{ translatedText: string }>).map((t) => t.translatedText);
-}
-
-async function translateAzure(strings: string[], langCode: string, apiKey: string): Promise<string[]> {
-  const res = await fetch(`https://api.cognitive.microsofttranslator.com/translate?api-version=3.0&from=en&to=${langCode}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Ocp-Apim-Subscription-Key': apiKey,
-    },
-    body: JSON.stringify(strings.map((s) => ({ Text: s }))),
-  });
-  if (!res.ok) {
-    let msg = `Azure error ${res.status}`;
-    try { const b = await res.json(); if (b?.error?.message) msg = b.error.message; } catch (_) {}
-    throw new Error(msg);
-  }
-  const data = await res.json();
-  return (data as Array<{ translations: Array<{ text: string }> }>).map((t) => t.translations[0].text);
-}
-
-// ── Dispatcher ──
-
-async function translateStrings(
-  provider: TranslationProvider,
-  strings: string[],
-  langCode: string,
-  apiKey: string,
-): Promise<string[]> {
-  switch (provider) {
-    case 'mymemory': return translateMyMemory(strings, langCode);
-    case 'lingva': return translateLingva(strings, langCode);
-    case 'deepl': return translateDeepL(strings, langCode, apiKey);
-    case 'google': return translateGoogle(strings, langCode, apiKey);
-    case 'azure': return translateAzure(strings, langCode, apiKey);
-  }
-}
-
-// ── RTL transform ──
 
 function applyRTL(node: SceneNode): void {
   if (node.type === 'TEXT') {
-    try { (node as TextNode).textAlignHorizontal = 'RIGHT'; } catch (_) {}
+    try { node.textAlignHorizontal = 'RIGHT'; } catch (_) {}
   }
   if ((node.type === 'FRAME' || node.type === 'INSTANCE' || node.type === 'COMPONENT') && 'layoutMode' in node) {
     const frame = node as FrameNode;
     if (frame.layoutMode === 'HORIZONTAL') {
       const children = [...frame.children];
       for (let i = children.length - 1; i >= 0; i--) {
-        try { frame.appendChild(children[i] as any); } catch (_) {}
+        try { frame.appendChild(children[i]); } catch (_) {}
       }
     }
     if (frame.layoutMode === 'VERTICAL') {
@@ -176,147 +38,114 @@ function applyRTL(node: SceneNode): void {
     }
   }
   if ('children' in node) {
-    for (const child of (node as any).children as SceneNode[]) applyRTL(child);
+    for (const child of (node as ChildrenMixin & SceneNode).children) applyRTL(child);
   }
 }
 
-// ── Rewrite text nodes ──
-
-async function rewriteTextNodes(
-  nodes: TextNode[],
-  translations: string[],
-  fallbackFontFamily: string | null,
-): Promise<void> {
+async function rewriteTextNodes(nodes: TextNode[], translations: string[], fallbackFontFamily: string | null): Promise<void> {
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
     const translated = translations[i];
     if (typeof translated !== 'string') continue;
     try {
-      // Get the node's current font so we can preserve its style
       const existing = node.getRangeFontName(0, Math.max(1, node.characters.length));
-      if (existing === figma.mixed) continue; // skip mixed-font nodes
+      if (existing === figma.mixed) continue; // mixed-font nodes skipped (spec: acceptable)
       const currentFont = existing as FontName;
       await figma.loadFontAsync(currentFont);
-
       if (fallbackFontFamily) {
-        // Non-Latin language — swap family but try to keep the style (Bold, Medium, etc.)
         const targetFont: FontName = { family: fallbackFontFamily, style: currentFont.style };
         try {
           await figma.loadFontAsync(targetFont);
           node.fontName = targetFont;
         } catch (_) {
-          // Style not available in fallback font — fall back to Regular
           const regularFont: FontName = { family: fallbackFontFamily, style: 'Regular' };
           await figma.loadFontAsync(regularFont);
           node.fontName = regularFont;
         }
       }
-      // For Latin languages (fallbackFontFamily === null), keep original font entirely
-
       node.characters = translated;
     } catch (_) {}
   }
 }
 
-// ── Bridge: collect text for external translation ──
-
-export function collectSourceText(node: SceneNode): { nodeId: string; text: string }[] {
-  const textNodes: TextNode[] = [];
-  collectTextNodes(node, textNodes);
-  return textNodes.map(n => ({ nodeId: n.id, text: norm(n.characters) }));
-}
-
-// ── Main entry point ──
-
-export async function localize(
+// Shared apply path: used by both the API flow and paste mode.
+// Creates a clone per language ONLY for languages that already have translations —
+// a failed language never produces a frame (fixes the monorepo orphan-clone bug).
+export async function applyTranslationsToClones(
   node: SceneNode,
-  languages: string[],
+  translationsByLang: Record<string, string[]>,
   applyRtl: boolean,
-  provider: TranslationProvider,
-  apiKey: string,
+  onStatus: (msg: string) => void,
 ): Promise<{ created: number; errors: string[] }> {
   const errors: string[] = [];
   let created = 0;
-
   if (!('clone' in node)) throw new Error('Selected node cannot be cloned.');
-
-  const GAP = 40;
-  const baseX = (node as any).x + node.width + GAP;
-  const baseY = (node as any).y;
   const parent = node.parent;
   if (!parent || !('appendChild' in parent)) throw new Error('Selected node has no parent container.');
 
-  // Collect source text once (shared across all languages)
-  const sourceTextNodes: TextNode[] = [];
-  collectTextNodes(node, sourceTextNodes);
-  const originals = sourceTextNodes.map((n) => norm(n.characters));
+  const GAP = 40;
+  const baseX = (node as FrameNode).x + node.width + GAP;
+  const baseY = (node as FrameNode).y;
 
-  // Pre-validate languages and compute positions
-  const validLangs = languages
-    .map((code, i) => {
-      const meta = LANG_META[code];
-      if (!meta) { errors.push(`Unknown language: ${code}`); return null; }
-      if (provider === 'deepl' && code === 'th') { errors.push('Thai: DeepL does not support Thai — skipping'); return null; }
-      return { code, meta, x: baseX + i * (node.width + GAP) };
-    })
-    .filter(Boolean) as Array<{ code: string; meta: typeof LANG_META[string]; x: number }>;
-
-  // Clone all frames first (Figma API must be sequential for DOM mutations)
-  const clones: Array<{ code: string; meta: typeof LANG_META[string]; clone: SceneNode; textNodes: TextNode[] }> = [];
-  for (const lang of validLangs) {
-    const clone = (node as any).clone() as SceneNode;
-    clone.name = `[${lang.code}] ${node.name}`;
-    (parent as any).appendChild(clone);
-    (clone as any).x = lang.x;
-    (clone as any).y = baseY;
-
-    const textNodes: TextNode[] = [];
-    collectTextNodes(clone, textNodes);
-    clones.push({ code: lang.code, meta: lang.meta, clone, textNodes });
-  }
-
-  // Translate all languages in parallel (API calls are independent)
-  figma.ui.postMessage({ type: 'localize-status', message: `Translating ${originals.length} strings to ${validLangs.length} languages in parallel...` });
-
-  const translationResults = await Promise.allSettled(
-    clones.map(async ({ code, meta, textNodes: cloneTextNodes }) => {
-      if (cloneTextNodes.length === 0) return { code, translations: [] as string[] };
-      const langCode = meta.codes[provider];
-      const translations = await translateStrings(provider, originals, langCode, apiKey);
-      return { code, translations };
-    })
-  );
-
-  // Apply translations and font swaps (must be sequential — Figma font loading)
-  for (let i = 0; i < clones.length; i++) {
-    const { code, meta, clone, textNodes: cloneTextNodes } = clones[i];
-    const result2 = translationResults[i];
-
-    if (result2.status === 'rejected') {
-      const errMsg = result2.reason?.message || String(result2.reason);
-      errors.push(`${meta.name}: ${errMsg}`);
-      if (errMsg.includes('credit') || errMsg.includes('API error') || errMsg.includes('authentication') ||
-          errMsg.includes('invalid') || errMsg.includes('rate') || errMsg.includes('quota') || errMsg.includes('key')) {
-        try { clone.remove(); } catch (_) {}
-        break;
-      }
-      continue;
-    }
-
-    const { translations } = result2.value;
-    if (cloneTextNodes.length === 0 || translations.length === 0) { created++; continue; }
-
+  const langs = Object.keys(translationsByLang);
+  for (let i = 0; i < langs.length; i++) {
+    const code = langs[i];
+    const meta = LANG_META[code];
+    if (!meta) { errors.push(`Unknown language: ${code}`); continue; }
+    onStatus(`Applying ${meta.name} (${i + 1}/${langs.length})...`);
+    let clone: SceneNode | null = null;
     try {
-      const sourceFonts = collectFonts(cloneTextNodes);
-      await loadFonts(sourceFonts);
-      await rewriteTextNodes(cloneTextNodes, translations, meta.fallbackFont);
+      clone = (node as FrameNode).clone();
+      clone.name = `[${code}] ${node.name}`;
+      (parent as ChildrenMixin).appendChild(clone);
+      clone.x = baseX + created * (node.width + GAP);
+      clone.y = baseY;
+      const cloneTextNodes: TextNode[] = [];
+      collectTextNodes(clone, cloneTextNodes);
+      if (cloneTextNodes.length !== translationsByLang[code].length) {
+        try { clone.remove(); } catch (_) {}
+        errors.push(`${meta.name}: frame changed during translation (${cloneTextNodes.length} text nodes now vs ${translationsByLang[code].length} translated) — try again`);
+        continue;
+      }
+      await rewriteTextNodes(cloneTextNodes, translationsByLang[code], meta.fallbackFont);
       if (code === 'ar' && applyRtl) applyRTL(clone);
       created++;
-    } catch (e: any) {
-      errors.push(`${meta.name}: ${e.message || String(e)}`);
+    } catch (e) {
+      if (clone) { try { clone.remove(); } catch (_) {} }
+      errors.push(`${meta.name}: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
-
   try { figma.viewport.scrollAndZoomIntoView([node]); } catch (_) {}
   return { created, errors };
+}
+
+export async function localizeViaApi(
+  node: SceneNode,
+  languages: string[],
+  applyRtl: boolean,
+  provider: ApiProvider,
+  email: string,
+  onStatus: (msg: string) => void,
+): Promise<{ created: number; errors: string[] }> {
+  const originals = collectSourceText(node);
+  if (originals.length === 0) throw new Error('No text found in selection.');
+
+  const valid = languages.filter((code) => Boolean(LANG_META[code]));
+  onStatus(`Translating ${originals.length} strings into ${valid.length} languages...`);
+
+  // Translate FIRST — no clones exist yet, so a failed language cannot orphan a frame.
+  const settled = await Promise.allSettled(
+    valid.map((code) => translateStrings(provider, originals, LANG_META[code].codes[provider], email)),
+  );
+
+  const errors: string[] = [];
+  const translationsByLang: Record<string, string[]> = {};
+  settled.forEach((r, i) => {
+    const code = valid[i];
+    if (r.status === 'fulfilled') translationsByLang[code] = r.value;
+    else errors.push(`${LANG_META[code].name}: ${r.reason instanceof Error ? r.reason.message : String(r.reason)}`);
+  });
+
+  const applied = await applyTranslationsToClones(node, translationsByLang, applyRtl, onStatus);
+  return { created: applied.created, errors: [...errors, ...applied.errors] };
 }

--- a/apps/consonant-specs-plugin/src/ui.css
+++ b/apps/consonant-specs-plugin/src/ui.css
@@ -289,6 +289,18 @@ body {
   margin-bottom: 8px;
 }
 
+/* Localize tab — provider/language checklist + paste-mode markup */
+.lang-header { display: flex; justify-content: space-between; align-items: center; }
+.link-btn { background: none; border: none; color: var(--text-tertiary, #999); font-size: 11px; cursor: pointer; padding: 2px 0; }
+.lang-group { font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-tertiary, #999); margin: 8px 0 2px; }
+.lang-note { color: var(--text-tertiary, #999); font-size: 11px; }
+.rtl-row { margin-top: 8px; }
+#localizeContent textarea {
+  width: 100%; box-sizing: border-box; padding: 6px 8px; margin-top: 8px; margin-bottom: 8px;
+  border: 1px solid var(--border, #e5e5e5); border-radius: 4px;
+  font-family: var(--font-mono, monospace); font-size: 11px; resize: vertical;
+}
+
 .property-row {
   display: flex;
   justify-content: space-between;

--- a/apps/consonant-specs-plugin/src/ui.html
+++ b/apps/consonant-specs-plugin/src/ui.html
@@ -218,35 +218,27 @@
             <div id="localizeMain">
               <div class="section-title">Translation Provider</div>
               <select id="providerSelect" style="width:100%;box-sizing:border-box;padding:6px 8px;border:1px solid var(--border,#e5e5e5);border-radius:4px;font-size:12px;margin-bottom:12px;">
-                <option value="bridge">Claude via Bridge (no key)</option>
+                <option value="google">Google (free, no key)</option>
                 <option value="mymemory">MyMemory (free, no key)</option>
-                <option value="lingva">Lingva (free, no key)</option>
-                <option value="deepl">DeepL Free (key required)</option>
-                <option value="google">Google Cloud (key required)</option>
-                <option value="azure">Microsoft Azure (key required)</option>
+                <option value="paste">AI paste mode (any LLM)</option>
               </select>
-              <div id="apiKeySection" style="display:none;margin-bottom:12px;">
-                <input type="password" id="apiKeyInput" placeholder="API key..." style="width:100%;box-sizing:border-box;padding:6px 8px;border:1px solid var(--border,#e5e5e5);border-radius:4px;font-family:monospace;font-size:11px;" />
-                <div id="apiKeyStatus" style="color:var(--text-secondary);font-size:11px;margin-top:4px;"></div>
-                <div style="display:flex;gap:8px;margin-top:6px;">
-                  <button class="btn btn-secondary" id="saveKeyBtn" style="flex:1;">Save Key</button>
-                  <button class="btn btn-secondary" id="clearKeyBtn" style="flex:1;">Clear</button>
-                </div>
+              <div id="emailSection" style="display:none;margin-bottom:12px;">
+                <input type="email" id="emailInput" placeholder="Optional email — raises free quota 5k → 50k chars/day" style="width:100%;box-sizing:border-box;padding:6px 8px;border:1px solid var(--border,#e5e5e5);border-radius:4px;font-size:12px;" />
               </div>
-              <div style="display:flex;justify-content:space-between;align-items:center;">
+              <div class="lang-header">
                 <div class="section-title">Languages</div>
-                <button id="locCheckAll" style="background:none;border:none;color:var(--text-tertiary,#999);font-size:11px;cursor:pointer;padding:2px 0;">Check All</button>
+                <button id="locCheckAll" class="link-btn">Check All</button>
               </div>
-              <div class="match-checklist">
-                <label class="match-option"><input type="checkbox" id="locDe"> German <span style="color:var(--text-tertiary,#999);font-size:11px;">— long-word wrapping, 1.5× text</span></label>
-                <label class="match-option"><input type="checkbox" id="locZh"> Chinese <span style="color:var(--text-tertiary,#999);font-size:11px;">— short sentences</span></label>
-                <label class="match-option"><input type="checkbox" id="locTh"> Thai <span style="color:var(--text-tertiary,#999);font-size:11px;">— extra line-height for ligatures</span></label>
-                <label class="match-option"><input type="checkbox" id="locAr"> Arabic <span style="color:var(--text-tertiary,#999);font-size:11px;">— RTL</span></label>
-              </div>
-              <div class="match-checklist" style="margin-top:8px;">
+              <div class="match-checklist" id="langList"></div>
+              <div class="match-checklist rtl-row">
                 <label class="match-option"><input type="checkbox" id="locRtl"> Apply RTL layout</label>
               </div>
               <button class="btn" id="localizeBtn" style="margin-top:12px;">Localize Selection</button>
+              <div id="pasteSection" style="display:none;">
+                <button class="btn" id="copyPromptBtn">Copy prompt for AI chat</button>
+                <textarea id="pasteInput" rows="6" placeholder="Paste the JSON response here..."></textarea>
+                <button class="btn" id="applyPasteBtn">Apply translations</button>
+              </div>
               <div id="localizeStatus" style="margin-top:12px;"></div>
             </div>
           </div>

--- a/apps/consonant-specs-plugin/src/ui.ts
+++ b/apps/consonant-specs-plugin/src/ui.ts
@@ -1,4 +1,6 @@
 import { renderAlignV2ScanResult, renderAlignV2ApplyResult, setV2ActiveTab, collectV2ApplySelections } from './align-v2-ui';
+import { LANG_META, LANG_ORDER } from './localize-languages';
+import { buildPastePrompt, parsePasteResponse } from './localize-paste';
 
 function esc(s: unknown): string {
   return String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
@@ -211,17 +213,32 @@ window.addEventListener('message', (event) => {
       updateTabControls('match');
       updateTabControls('design');
       updateTabControls('specs');
-      updateTabControls('localize');
+      updateLocalizeControls();
       updateA11yControls();
-      break;
-    case 'api-key-state':
-      updateApiKeyUi(msg.hasKey as boolean, msg.masked as string | undefined);
       break;
     case 'localize-status':
       updateLocalizeStatus(msg.message as string);
+      // Terminal statuses from code.ts's catch blocks (both the 'localize' and
+      // 'paste-apply' handlers report failures the same way, so re-enable both —
+      // harmless if only one was actually in flight) and from 'paste-collect'
+      // finding no text (which otherwise never sends a further message, and
+      // copyPromptBtn would stay disabled forever).
+      if (typeof msg.message === 'string' && msg.message.startsWith('Error')) {
+        if (localizeBtn) localizeBtn.disabled = false;
+        if (applyPasteBtn) applyPasteBtn.disabled = false;
+      }
+      if (msg.message === 'No text found in selection.') {
+        if (copyPromptBtn) copyPromptBtn.disabled = false;
+      }
       break;
-    case 'localize-bridge-prompt':
-      showLocalizeBridgePrompt(msg as any);
+    case 'localize-done':
+      handleLocalizeDone(msg.created as number, msg.errors as string[]);
+      break;
+    case 'paste-source':
+      handlePasteSource(msg.frameName as string, msg.strings as string[]);
+      break;
+    case 'email-state':
+      handleEmailState(msg.email as string);
       break;
     case 'token-status': {
       updateTokenStatus(msg.count as number, msg.version as string);
@@ -510,64 +527,63 @@ function updateSpecStatus(message: string) {
 }
 
 // Localize tab
-const KEYED_PROVIDERS = new Set(['deepl', 'google', 'azure']);
-
-const providerSelect = document.getElementById('providerSelect') as HTMLSelectElement | null;
-const apiKeySection = document.getElementById('apiKeySection') as HTMLElement | null;
-
-function syncKeySection() {
-  const provider = providerSelect?.value || 'mymemory';
-  if (apiKeySection) apiKeySection.style.display = KEYED_PROVIDERS.has(provider) ? 'block' : 'none';
-  postToPlugin('get-api-key', { provider });
+const GROUP_LABELS: Record<string, string> = { latin: 'Latin', cjk: 'CJK', other: 'Other' };
+const langList = document.getElementById('langList') as HTMLDivElement | null;
+if (langList) {
+  let currentGroup = '';
+  for (const code of LANG_ORDER) {
+    const m = LANG_META[code];
+    if (m.group !== currentGroup) {
+      currentGroup = m.group;
+      const h = document.createElement('div');
+      h.className = 'lang-group';
+      h.textContent = GROUP_LABELS[m.group];
+      langList.appendChild(h);
+    }
+    const label = document.createElement('label');
+    label.className = 'match-option';
+    label.innerHTML = `<input type="checkbox" id="loc-${code}"> ${esc(m.name)} <span class="lang-note">— ${esc(m.note)}</span>`;
+    langList.appendChild(label);
+  }
 }
 
-providerSelect?.addEventListener('change', syncKeySection);
-syncKeySection();
+function selectedLangs(): string[] {
+  return LANG_ORDER.filter((c) => Boolean((document.getElementById(`loc-${c}`) as HTMLInputElement | null)?.checked));
+}
+
+// Arabic auto-checks RTL
+document.getElementById('loc-ar')?.addEventListener('change', () => {
+  const ar = document.getElementById('loc-ar') as HTMLInputElement;
+  const rtl = document.getElementById('locRtl') as HTMLInputElement | null;
+  if (ar.checked && rtl) rtl.checked = true;
+});
 
 document.getElementById('locCheckAll')?.addEventListener('click', () => {
-  const ids = ['locDe', 'locZh', 'locTh', 'locAr'];
-  const boxes = ids.map(id => document.getElementById(id) as HTMLInputElement).filter(Boolean);
-  const allChecked = boxes.every(b => b.checked);
-  boxes.forEach(b => { b.checked = !allChecked; });
-  // Auto-check RTL when Arabic is checked
-  const locRtlEl = document.getElementById('locRtl') as HTMLInputElement | null;
-  if (locRtlEl && !allChecked) locRtlEl.checked = true;
+  const boxes = LANG_ORDER.map((c) => document.getElementById(`loc-${c}`) as HTMLInputElement).filter(Boolean);
+  const allChecked = boxes.every((b) => b.checked);
+  boxes.forEach((b) => { b.checked = !allChecked; });
+  const rtl = document.getElementById('locRtl') as HTMLInputElement | null;
+  if (rtl && !allChecked) rtl.checked = true;
 });
 
-const locAr = document.getElementById('locAr') as HTMLInputElement | null;
-const locRtl = document.getElementById('locRtl') as HTMLInputElement | null;
-locAr?.addEventListener('change', () => {
-  if (locAr.checked && locRtl && !locRtl.checked) locRtl.checked = true;
-});
+// Provider switching
+const providerSelect = document.getElementById('providerSelect') as HTMLSelectElement | null;
+function syncProviderUi(): void {
+  const p = providerSelect?.value || 'google';
+  const emailSection = document.getElementById('emailSection') as HTMLElement | null;
+  const pasteSection = document.getElementById('pasteSection') as HTMLElement | null;
+  const localizeMainBtn = document.getElementById('localizeBtn') as HTMLButtonElement | null;
+  if (emailSection) emailSection.style.display = p === 'mymemory' ? 'block' : 'none';
+  if (pasteSection) pasteSection.style.display = p === 'paste' ? 'block' : 'none';
+  if (localizeMainBtn) localizeMainBtn.style.display = p === 'paste' ? 'none' : 'block';
+}
+providerSelect?.addEventListener('change', syncProviderUi);
+syncProviderUi();
+postToPlugin('get-email');
 
-document.getElementById('localizeBtn')?.addEventListener('click', () => {
-  const languages: string[] = [];
-  if ((document.getElementById('locDe') as HTMLInputElement).checked) languages.push('de');
-  if ((document.getElementById('locZh') as HTMLInputElement).checked) languages.push('zh');
-  if ((document.getElementById('locTh') as HTMLInputElement).checked) languages.push('th');
-  if ((document.getElementById('locAr') as HTMLInputElement).checked) languages.push('ar');
-  if (languages.length === 0) {
-    updateLocalizeStatus('Select at least one language.');
-    return;
-  }
-  const provider = providerSelect?.value || 'mymemory';
-  const applyRtl = (document.getElementById('locRtl') as HTMLInputElement).checked;
-  postToPlugin('localize', { languages, applyRtl, provider });
-  updateLocalizeStatus('Localizing — this may take a moment...');
-});
-
-document.getElementById('saveKeyBtn')?.addEventListener('click', () => {
-  const input = document.getElementById('apiKeyInput') as HTMLInputElement;
-  const key = input.value.trim();
-  if (!key) return;
-  const provider = providerSelect?.value || '';
-  postToPlugin('save-api-key', { key, provider });
-  input.value = '';
-});
-
-document.getElementById('clearKeyBtn')?.addEventListener('click', () => {
-  const provider = providerSelect?.value || '';
-  postToPlugin('clear-api-key', { provider });
+document.getElementById('emailInput')?.addEventListener('change', () => {
+  const input = document.getElementById('emailInput') as HTMLInputElement;
+  postToPlugin('save-email', { email: input.value.trim() });
 });
 
 function updateLocalizeStatus(message: string) {
@@ -575,32 +591,98 @@ function updateLocalizeStatus(message: string) {
   if (el) el.innerHTML = `<span style="color:var(--text-secondary)">${esc(message)}</span>`;
 }
 
-const LANG_NAMES: Record<string, string> = { de: 'German', zh: 'Chinese', th: 'Thai', ar: 'Arabic' };
+// Re-entrancy guard: each action button is disabled the instant its message is
+// posted, and only re-enabled once the matching terminal response arrives from
+// code.ts (see the 'localize-status'/'localize-done'/'paste-source' cases in the
+// message dispatch switch above). This prevents a double-click (or a slow network
+// round trip) from firing duplicate 'localize' / 'paste-collect' / 'paste-apply'
+// messages, which would otherwise produce duplicate clone sets. Buttons are only
+// ever disabled right before a post() that is guaranteed a response, so local
+// validation failures (which return before posting) never need a matching re-enable.
+const localizeBtn = document.getElementById('localizeBtn') as HTMLButtonElement | null;
+const copyPromptBtn = document.getElementById('copyPromptBtn') as HTMLButtonElement | null;
+const applyPasteBtn = document.getElementById('applyPasteBtn') as HTMLButtonElement | null;
 
-function showLocalizeBridgePrompt(data: { frameName: string; frameId: string; languages: string[]; applyRtl: boolean; sourceTexts: { nodeId: string; text: string }[] }) {
-  const langList = data.languages.map(l => LANG_NAMES[l] || l).join(', ');
-  const cmd = `Translate the frame "${data.frameName}" (${data.frameId}) into ${langList}. ${data.sourceTexts.length} text strings to translate.${data.applyRtl ? ' Apply RTL layout for Arabic.' : ''}\n\nUse figma_execute to: 1) get text nodes from the frame, 2) clone the frame with a [${data.languages.join('/')}] prefix, 3) load fonts, 4) apply translations to the cloned text nodes.`;
-  const el = document.getElementById('localizeStatus');
-  if (el) {
-    el.innerHTML = `
-      <div style="padding:10px;background:var(--bg-secondary,#f5f5f5);border-radius:6px;border-left:3px solid var(--accent,#1473E6);">
-        <div style="font-weight:600;font-size:11px;color:var(--accent,#1473E6);margin-bottom:4px;">Ready for translation &#x2714;</div>
-        <div style="font-size:11px;color:var(--text-secondary);margin-bottom:6px;">Paste this in Claude Code to translate via bridge:</div>
-        <code id="localizeCmdText" style="display:block;background:var(--bg,#fff);padding:6px 8px;border-radius:4px;font-size:10px;border:1px solid var(--border,#e5e5e5);line-height:1.4;">${esc(cmd)}</code>
-        <button class="btn btn-secondary" id="copyLocalizeCmd" style="margin-top:6px;padding:4px 8px;font-size:10px;width:100%;">Copy</button>
-        <div style="font-size:10px;color:var(--text-tertiary,#999);margin-top:6px;">Requires Bridge connected + Claude Code open in this project</div>
-      </div>`;
-    document.getElementById('copyLocalizeCmd')?.addEventListener('click', async () => {
-      await copyToClipboard(cmd);
-      const btn = document.getElementById('copyLocalizeCmd');
-      if (btn) { btn.textContent = 'Copied!'; setTimeout(() => { btn.textContent = 'Copy'; }, 1500); }
-    });
-  }
+// One-click localize (google / mymemory)
+localizeBtn?.addEventListener('click', () => {
+  const languages = selectedLangs();
+  if (languages.length === 0) { updateLocalizeStatus('Select at least one language.'); return; }
+  localizeBtn.disabled = true;
+  postToPlugin('localize', {
+    provider: providerSelect?.value || 'google',
+    languages,
+    applyRtl: (document.getElementById('locRtl') as HTMLInputElement | null)?.checked ?? false,
+  });
+  updateLocalizeStatus('Localizing — this may take a moment...');
+});
+
+// Paste mode
+let pasteLangs: string[] = [];
+let pasteCount = 0;
+
+copyPromptBtn?.addEventListener('click', () => {
+  pasteLangs = selectedLangs();
+  if (pasteLangs.length === 0) { updateLocalizeStatus('Select at least one language.'); return; }
+  copyPromptBtn.disabled = true;
+  postToPlugin('paste-collect');
+});
+
+applyPasteBtn?.addEventListener('click', () => {
+  const raw = (document.getElementById('pasteInput') as HTMLTextAreaElement | null)?.value ?? '';
+  const parsed = parsePasteResponse(raw, pasteLangs, pasteCount);
+  if (!parsed.ok) { updateLocalizeStatus(parsed.error); return; }
+  applyPasteBtn.disabled = true;
+  postToPlugin('paste-apply', {
+    translations: parsed.translations,
+    applyRtl: (document.getElementById('locRtl') as HTMLInputElement | null)?.checked ?? false,
+  });
+  updateLocalizeStatus('Applying translations...');
+});
+
+function handleLocalizeDone(created: number, errors: string[]): void {
+  const errTail = errors && errors.length > 0 ? ` Errors: ${errors.join('; ')}` : '';
+  updateLocalizeStatus(`Created ${created} localized frame(s).${errTail}`);
+  if (localizeBtn) localizeBtn.disabled = false;
+  if (applyPasteBtn) applyPasteBtn.disabled = false;
 }
 
-function updateApiKeyUi(hasKey: boolean, masked?: string) {
-  const status = document.getElementById('apiKeyStatus') as HTMLElement;
-  if (status) status.textContent = hasKey ? `Saved: ${masked || '••••'}` : 'No key saved.';
+function handleEmailState(email: string): void {
+  const input = document.getElementById('emailInput') as HTMLInputElement | null;
+  if (input) input.value = email;
+}
+
+function handlePasteSource(frameName: string, strings: string[]): void {
+  pasteCount = strings.length;
+  const prompt = buildPastePrompt(frameName, strings, pasteLangs);
+  void copyToClipboard(prompt).then(() => {
+    updateLocalizeStatus(`Prompt for ${pasteCount} strings copied — paste it into any AI chat, then paste the JSON response below.`);
+    if (copyPromptBtn) copyPromptBtn.disabled = false;
+  });
+}
+
+// Localize tab — selection gating. code.ts's 'localize' / 'paste-collect' /
+// 'paste-apply' handlers only accept exactly ONE selected node — they reject 0
+// or 2+ selections via a transient figma.notify toast that never reaches this
+// UI. Mirror that contract here (unlike the generic updateTabControls used by
+// the other tabs, which only distinguishes empty vs. non-empty) so the panel
+// never renders in an actionable state for a selection the main thread will
+// silently refuse.
+function updateLocalizeControls(): void {
+  const placeholder = document.getElementById('localizePlaceholder');
+  const controls = document.getElementById('localizeControls');
+  if (!placeholder || !controls) return;
+  if (currentSelection.count === 1) {
+    placeholder.style.display = 'none';
+    controls.style.display = 'block';
+  } else if (currentSelection.count > 1) {
+    placeholder.textContent = 'Select exactly one frame';
+    placeholder.style.display = 'block';
+    controls.style.display = 'none';
+  } else {
+    placeholder.textContent = 'Select a frame to localize';
+    placeholder.style.display = 'block';
+    controls.style.display = 'none';
+  }
 }
 
 // A11y tab — controls visibility


### PR DESCRIPTION
## What

Rewrites the Consonant Tools plugin's **Localize** tab, porting the proven architecture from the standalone [localization-plugin](https://github.com/spicyxshrimp/localization-plugin) built and reviewed this week.

- **Translate-first flow** — translations are fetched *before* any frame is cloned, so a failed language can never leave an orphaned untranslated frame on canvas (the old clone-first flow could). Plus a length guard against mid-run canvas edits and clone cleanup on any failure.
- **10 languages** (was 4): de, fr, es, it, pt, zh, ja, ko, th, ar — grouped Latin / CJK / Other, each with a design-QA note and correct Noto fallback fonts; Arabic auto-enables the RTL layout transform.
- **Keyless providers only**: Google (gtx endpoint, default) and MyMemory (optional email raises the free quota 5k → 50k chars/day), plus an **AI paste mode** fallback that works with any LLM chat and needs no network at all.
- **Removed**: Lingva (dead — all public instances verified down, project unmaintained since 2023; it was silently returning untranslated English), DeepL/Google Cloud/Azure keyed providers and the whole API-key UI/storage, and the bridge-prompt localize path.
- **Bug fix**: MyMemory returns `responseStatus` as a *string* (`"403"`) on errors with the error text in `translatedText` — the old code pasted quota-error messages into frames as "translations". Now guarded with numeric coercion.
- Manifest network allowlist trimmed accordingly (translation domains now just `translate.googleapis.com` + `api.mymemory.translated.net`); bridge/localhost entries untouched.
- Plugin window widened 300 → 360 so language notes fit on one line.

## Testing

- Core modules are byte-identical ports from the standalone repo, where they're covered by 15 unit tests (parsers, language table, paste prompt/validation) and passed a multi-round adversarial review.
- Live-verified all 10 language codes against both endpoints; burst-tested the gtx endpoint (100/100 requests, no throttling).
- Manual smoke test in Figma: 10-language localization on a real frame, fonts + RTL confirmed.
- `dist/` rebuild verified; no other tabs/tools reference removed code (grep-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)