### PR TITLE
Consonant Tools plugin: spec-annotation fixes from July

### DIFF
--- a/apps/consonant-specs-plugin/CLAUDE.md
+++ b/apps/consonant-specs-plugin/CLAUDE.md
@@ -32,6 +32,10 @@
 19. **Never rationalize skipping a rule** — If you catch yourself thinking "this case is simple enough to skip," that's exactly when the rule matters most.
 20. **When rules conflict, prefer honesty over helpfulness** — If two rules pull opposite directions (e.g., rule 11 stay-in-scope vs. rule 14 surface failures), pick the path that keeps you better informed. Surface the conflict and what you chose. Helpfulness without honesty isn't help.
 
+## Plan validation
+
+21. **Suggest critic-vs-defender after non-trivial planning** — When a multi-step plan, spec, or design proposal is finalized but not yet being implemented, prompt: "Want me to pressure-test this with critic-vs-defender before we start?" Skip trivial fixes, one-line edits, or quick back-and-forth that doesn't produce an explicit plan. Suggest only — don't auto-run (would dispatch subagents without permission, conflicting with rule 10).
+
 ---
 
 # Development workflow — IMPORTANT

--- a/apps/consonant-specs-plugin/src/spec-anatomy.ts
+++ b/apps/consonant-specs-plugin/src/spec-anatomy.ts
@@ -718,7 +718,10 @@ export async function generateAnatomySection(sourceNode: SceneNode): Promise<Fra
     if (!tp) return null;
     const fills = getNodeFills(label);
     const colorHex = fills[0]?.hex ?? '';
-    return `${tp.fontFamily}|${tp.fontWeight}|${tp.fontSize}|${label.textDecoration}|${colorHex}`;
+    // textDecoration can be figma.mixed (a symbol) on mixed-decoration text;
+    // interpolating a symbol into a template literal throws at runtime.
+    const deco = label.textDecoration === figma.mixed ? 'mixed' : label.textDecoration;
+    return `${tp.fontFamily}|${tp.fontWeight}|${tp.fontSize}|${deco}|${colorHex}`;
   };
   const ctaEntries = rawEntries
     .filter(e => ctaFlags.get(e.node))

--- a/apps/consonant-specs-plugin/src/spec-card-gaps.ts
+++ b/apps/consonant-specs-plugin/src/spec-card-gaps.ts
@@ -28,13 +28,18 @@ export async function generateCardGaps(node: SceneNode): Promise<void> {
     const oldChildren = (node as FrameNode).children.filter(c => c.name === 'spacing-in-between-overlay');
     for (const o of oldChildren) o.remove();
   }
-  const oldPageOverlays = figma.currentPage.children.filter(c => c.name === 'spacing-in-between-overlay');
+  // Scope removal to the overlay belonging to this specific node (tagged via
+  // pluginData) so regenerating one node's gaps doesn't wipe another's.
+  const oldPageOverlays = figma.currentPage.children.filter(c =>
+    c.name === 'spacing-in-between-overlay' && c.getPluginData('specTarget') === node.id
+  );
   for (const o of oldPageOverlays) o.remove();
 
   // Overlay floats above the node — parented to the page so it works on
   // instances (which reject appendChild). Coordinates are absolute.
   const overlay = figma.createFrame();
   overlay.name = 'spacing-in-between-overlay';
+  overlay.setPluginData('specTarget', node.id);
   overlay.resize(node.width, node.height);
   overlay.fills = [];
   overlay.clipsContent = false;

--- a/apps/consonant-specs-plugin/src/spec-layout.ts
+++ b/apps/consonant-specs-plugin/src/spec-layout.ts
@@ -4,7 +4,7 @@ import { matchSpacing, matchColor, detectNodeColorRole } from './tokens';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-function removeOverlays(node: SceneNode, overlayName: string): void {
+function removeOverlays(node: SceneNode, overlayName: string, targetId?: string): void {
   // Legacy: overlays used to be parented inside the node.
   if ('children' in node) {
     const toRemove = (node as FrameNode).children.filter(c => c.name === overlayName);
@@ -18,7 +18,12 @@ function removeOverlays(node: SceneNode, overlayName: string): void {
     }
   }
   // New: overlays are now parented to the page so they work on instances.
-  const pageOverlays = figma.currentPage.children.filter(c => c.name === overlayName);
+  // Scope removal to the overlay belonging to this specific node (tagged via
+  // pluginData) so regenerating one node's overlay doesn't wipe another's.
+  const pageOverlays = figma.currentPage.children.filter(c =>
+    c.name === overlayName &&
+    (targetId === undefined || c.getPluginData('specTarget') === targetId)
+  );
   for (const o of pageOverlays) o.remove();
 }
 
@@ -787,12 +792,13 @@ export async function generateSpacingSection(sourceNode: SceneNode): Promise<voi
   if (!('children' in sourceNode) || sourceNode.children.length === 0) return;
 
   // Remove any existing overlays first
-  removeOverlays(sourceNode, 'spacing-detailed-overlay');
+  removeOverlays(sourceNode, 'spacing-detailed-overlay', sourceNode.id);
 
   // Overlay floats above the node — parented to the page so it works on
   // instances (which reject appendChild). Coordinates are absolute.
   const overlay = figma.createFrame();
   overlay.name = 'spacing-detailed-overlay';
+  overlay.setPluginData('specTarget', sourceNode.id);
   overlay.resize(sourceNode.width, sourceNode.height);
   overlay.fills = [];
   overlay.clipsContent = false;


### PR DESCRIPTION
Rescues four commits from the retired long-lived `taeho-branch` onto a clean branch off main (a fifth, a localize chore, is superseded by #104):

- guard `figma.mixed` textDecoration in the anatomy spec (crash fix)
- scope card-gap overlay removal to its own node (was removing sibling overlays)
- scope spacing overlay removal to its own node (same class of bug)
- docs: add plugin rule 21 (suggest critic-vs-defender after planning)

All cherry-picked conflict-free; plugin esbuild passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)