### PR TITLE
feat(s2a-toolkit): component-doc generator; retire Tokens tab, Spec sheet, export settings

### DIFF
--- a/apps/s2a-toolkit/BENTO-GENERATOR-SPEC.md
+++ b/apps/s2a-toolkit/BENTO-GENERATOR-SPEC.md
@@ -1,0 +1,135 @@
+# In‑Plugin Bento Doc Generator — Build Spec
+
+**Goal:** anyone selects a component set, clicks one button, and gets a fully‑populated bento doc in the current house style — no Claude, no bridge. Turns "ask Matt to run the doc script" into "click Generate."
+
+Status: spec / not built. Supersedes the plugin's old **Spec sheet** (dark‑section) generator.
+
+---
+
+## 1. User flow
+
+1. Select a `COMPONENT_SET` on canvas.
+2. Tools → **Docs → Generate bento doc**.
+3. Panel shows what was detected (name, version/status from the meta fence, axes for the variant grid) with smart defaults; author can tweak or just hit **Generate**.
+4. A complete bento doc appears to the right of the set on the same page; canvas zooms to it.
+
+Re‑running on a set that already has a `… · Docs` frame → **Update in place** vs **New version**.
+
+---
+
+## 2. Inputs
+
+| Input | Source | Default |
+|---|---|---|
+| Component set | current selection | — (error if not a `COMPONENT_SET`) |
+| Doc title | — | `{SetName} · Docs` |
+| Version / status / changelog | the `— s2a:meta —` fence in `set.description` | parsed automatically; editable |
+| Variant grid axes | auto‑detected from variant x/y clustering | auto; override only if mis‑detected |
+| Sections to include | checkboxes | all applicable ones on |
+| Placement | — | right of the set, same page |
+
+---
+
+## 3. What it reads off the set — fully automatic
+
+- **Variants** — `set.children.filter(c => c.type==='COMPONENT')`, parse each `Prop=Value, …` name → axes + values.
+- **Property table** — `set.componentPropertyDefinitions` → rows (variant / boolean / instance‑swap / text) with their options.
+- **Anatomy** — walk the default variant's layer tree → dot‑named layers (`.root`, `.icon-start`, `.label`, …) → anatomy list.
+- **Tokens / text styles** — bound variables on fills/strokes/spacing/radius + `getTextStyleIdAsync` on text layers (reuse the plugin's existing annotate/token‑binding helpers).
+- **Meta fence** — parse `— s2a:meta —` from `set.description`: `version`, `status`, `updated`, `changelog`, plus the `## Good to know` / `## Accessibility` prose blocks.
+
+**The fence is the contract:** if the description's meta + prose are current, the generator produces a complete doc with zero manual editing. (Ties directly to the versioning model.)
+
+---
+
+## 4. Output — the bento layout
+
+The generator **clones a canonical Bento Template** (a real frame in the file) and only swaps *content*, never structure. Sections (rows), each shown/hidden based on what the set actually has:
+
+1. **Hero + Versioning** — default‑variant instance + name; version/status/updated/changelog from the fence.
+2. **All variants** — the variant grid **+ axis labels** (row = one axis, columns = another).
+3. **Anatomy + Properties** — dot‑named layer list + the property table.
+4. **Slots** — only if the set uses Figma slots.
+5. **Good to know + Accessibility** — prose from the fence (or placeholders).
+6. **Dark‑mode preview** — the grid/hero re‑rendered in the dark theme mode.
+7. **Built from real surfaces** *(optional)* — provenance card.
+
+> **Why a template, not build‑from‑scratch:** the template owns the *style* (tokens, spacing, corner radii, type). When the house style evolves, you update **one template**, not the generator. The generator owns *content* only.
+
+---
+
+## 5. Repopulate algorithm (deterministic)
+
+Mirrors the clone‑and‑repopulate recipe we already run via the bridge:
+
+1. **Validate** selection is a `COMPONENT_SET`; parse the meta fence.
+2. **Clone** the Bento Template; rename `{Set} · Docs`; place right of the set on its page.
+3. **Hero** — `createInstance()` on the default `COMPONENT` variant; set the name text (Adobe Clean Display Bold).
+4. **Versioning card** — fill version / status / updated / changelog from the fence.
+5. **All variants** — remove template placeholders; place one instance per variant; run the **axis‑labeler**:
+   - cluster variants by rounded `x` (columns) and `y` (rows);
+   - a property that's constant down a column → column header; constant across a row → row label; skip globally‑constant props;
+   - **misaligned grids** (variant widths/heights differ so cells don't line up): align column headers to the top row and row labels to the left column — the three patterns already handled (variable‑width like IconButton/PromoCTA, variable‑height like RouterNavItem).
+6. **Anatomy** — emit the dot‑named layer list from the default variant.
+7. **Properties** — build the table from `componentPropertyDefinitions`.
+8. **Good to know / Accessibility** — inject the fence's prose blocks; if absent, leave template placeholders + flag.
+9. **Dark preview** — clone the grid/hero row; `setExplicitVariableModeForCollection(themeCollection, darkModeId)` on it.
+10. **Reflow** — reassert auto‑layout sizing bottom‑up: inner VERTICAL frames `primaryAxisSizingMode='AUTO'`, HORIZONTAL frames `counterAxisSizingMode='AUTO'`, doc `primaryAxisSizingMode='AUTO'`.
+11. **Select + zoom** to the doc; toast.
+
+---
+
+## 6. Automatic vs. needs‑input
+
+| Fully automatic | Needs input (smart default) |
+|---|---|
+| Variant grid + axis labels | Doc title |
+| Property table | Section toggles |
+| Anatomy | Axis override (rare) |
+| Version / status / changelog (from fence) | Prose: Good to know / Accessibility — **auto if written in the fence**, else placeholder |
+| Dark preview, placement, reflow | |
+
+The only genuinely non‑automatable content is the *prose* — and even that is automatic if the author keeps it in the component description (which the versioning model already asks them to do).
+
+---
+
+## 7. Architecture
+
+- **`code.ts`** — `bento:generate` message handler containing the algorithm (pure Figma API). Reuses existing token‑binding / annotate helpers.
+- **`ui.ts`** — a **Docs** tool: "Generate bento doc" button + detected‑axes confirmation + optional config fields.
+- **Bento Template** — a clean, dedicated template frame on a `📐 Templates` page, referenced by a stable name. **Prerequisite:** build this as a *placeholder* template (no embedded real component set), unlike today's `Button — v2 · Docs` which embeds the real Button set and is fragile to clone.
+
+---
+
+## 8. Generalization strategy (the hard part)
+
+The variance between components is handled by **conditional sections + a robust grid labeler**, not per‑component code:
+
+- Anatomy, property table, versioning, dark preview → generic, work for any set.
+- Variant grid → the axis‑labeler already covers clean grids + the three misaligned patterns.
+- Section variance (a button hero ≠ a card hero; Slots only sometimes) → the template contains every section; the generator **shows/hides** rows based on what the set has.
+- **Coverage phasing:** v1 = atoms + simple molecules (buttons, icon buttons, lockups, cards, inputs). v2 = complex/nested (marquees, routers, multi‑part cards).
+
+---
+
+## 9. Guardrails / known gotchas (learned building these by hand)
+
+- Selection not a `COMPONENT_SET` → clear error.
+- Single‑variant set → skip grid labels.
+- **Missing meta fence** → generate with placeholders + warn ("add a meta fence for auto version/changelog").
+- **Unloaded fonts** → load all range fonts (`getRangeAllFontNames`) before any text write, or it throws / silently no‑ops.
+- **`resize()` resets `primaryAxisSizingMode` to FIXED** → always reassert `'AUTO'` after resizing an auto‑height frame (else it clips its children).
+- **Hidden layers** (e.g. an intentionally‑hidden body) → report, don't force visible.
+- `textAutoResize='FILL'` is invalid — it's `WIDTH_AND_HEIGHT`; and a `TRUNCATE` text node won't accept FILL until switched to `HEIGHT`.
+
+---
+
+## 10. MVP (Phase 1)
+
+Select set → clone template → **Hero + Versioning (from fence) + All‑variants grid with axis labels + Properties + Anatomy + Dark preview + reflow**. Prose pulled from fence or placeholder.
+
+**Defer:** provenance card, update‑in‑place/versioned regeneration, complex‑component coverage.
+
+## 11. Effort / risk
+
+Most of the logic already exists as bridge scripts — axis‑labeling, clone‑and‑repopulate, dark‑mirror, meta‑fence parsing. The work is **porting it into deterministic `code.ts` + building the clean template**. Biggest ongoing risk is keeping the template in sync and the prose‑automation boundary — mitigated by the rule: **template owns style, fence owns content.**

--- a/apps/s2a-toolkit/DOC-GENERATOR-SPEC.md
+++ b/apps/s2a-toolkit/DOC-GENERATOR-SPEC.md
@@ -1,6 +1,6 @@
-# In‑Plugin Bento Doc Generator — Build Spec
+# In‑Plugin Component Doc Generator — Build Spec
 
-**Goal:** anyone selects a component set, clicks one button, and gets a fully‑populated bento doc in the current house style — no Claude, no bridge. Turns "ask Matt to run the doc script" into "click Generate."
+**Goal:** anyone selects a component set, clicks one button, and gets a fully‑populated component doc in the current house style — no Claude, no bridge. Turns "ask Matt to run the doc script" into "click Generate."
 
 Status: spec / not built. Supersedes the plugin's old **Spec sheet** (dark‑section) generator.
 
@@ -9,9 +9,9 @@ Status: spec / not built. Supersedes the plugin's old **Spec sheet** (dark‑sec
 ## 1. User flow
 
 1. Select a `COMPONENT_SET` on canvas.
-2. Tools → **Docs → Generate bento doc**.
+2. Tools → **Docs → Generate component doc**.
 3. Panel shows what was detected (name, version/status from the meta fence, axes for the variant grid) with smart defaults; author can tweak or just hit **Generate**.
-4. A complete bento doc appears to the right of the set on the same page; canvas zooms to it.
+4. A complete component doc appears to the right of the set on the same page; canvas zooms to it.
 
 Re‑running on a set that already has a `… · Docs` frame → **Update in place** vs **New version**.
 
@@ -42,9 +42,9 @@ Re‑running on a set that already has a `… · Docs` frame → **Update in pla
 
 ---
 
-## 4. Output — the bento layout
+## 4. Output — the doc layout
 
-The generator **clones a canonical Bento Template** (a real frame in the file) and only swaps *content*, never structure. Sections (rows), each shown/hidden based on what the set actually has:
+The generator **clones a canonical Doc Template** (a real frame in the file) and only swaps *content*, never structure. Sections (rows), each shown/hidden based on what the set actually has:
 
 1. **Hero + Versioning** — default‑variant instance + name; version/status/updated/changelog from the fence.
 2. **All variants** — the variant grid **+ axis labels** (row = one axis, columns = another).
@@ -63,7 +63,7 @@ The generator **clones a canonical Bento Template** (a real frame in the file) a
 Mirrors the clone‑and‑repopulate recipe we already run via the bridge:
 
 1. **Validate** selection is a `COMPONENT_SET`; parse the meta fence.
-2. **Clone** the Bento Template; rename `{Set} · Docs`; place right of the set on its page.
+2. **Clone** the Doc Template; rename `{Set} · Docs`; place right of the set on its page.
 3. **Hero** — `createInstance()` on the default `COMPONENT` variant; set the name text (Adobe Clean Display Bold).
 4. **Versioning card** — fill version / status / updated / changelog from the fence.
 5. **All variants** — remove template placeholders; place one instance per variant; run the **axis‑labeler**:
@@ -95,9 +95,9 @@ The only genuinely non‑automatable content is the *prose* — and even that is
 
 ## 7. Architecture
 
-- **`code.ts`** — `bento:generate` message handler containing the algorithm (pure Figma API). Reuses existing token‑binding / annotate helpers.
-- **`ui.ts`** — a **Docs** tool: "Generate bento doc" button + detected‑axes confirmation + optional config fields.
-- **Bento Template** — a clean, dedicated template frame on a `📐 Templates` page, referenced by a stable name. **Prerequisite:** build this as a *placeholder* template (no embedded real component set), unlike today's `Button — v2 · Docs` which embeds the real Button set and is fragile to clone.
+- **`code.ts`** — `doc:generate` message handler containing the algorithm (pure Figma API). Reuses existing token‑binding / annotate helpers.
+- **`ui.ts`** — a **Docs** tool: "Generate component doc" button + detected‑axes confirmation + optional config fields.
+- **Doc Template** — a clean, dedicated template frame on a `📐 Templates` page, referenced by a stable name. **Prerequisite:** build this as a *placeholder* template (no embedded real component set), unlike today's `Button — v2 · Docs` which embeds the real Button set and is fragile to clone.
 
 ---
 

--- a/apps/s2a-toolkit/dist/code.js
+++ b/apps/s2a-toolkit/dist/code.js
@@ -44,28 +44,6 @@ function serializeCollection(c) {
     variableIds: c.variableIds
   };
 }
-function tokenGroup(name) {
-  var _a;
-  const parts = name.split("/").filter((p) => p !== "s2a");
-  if (parts.length >= 4 && parts[1] === "transparent") return parts[0] + " / " + parts[1] + " / " + parts[2];
-  if (parts.length >= 3) return parts[0] + " / " + parts[1];
-  return (_a = parts[0]) != null ? _a : name;
-}
-function fmtTokenValue(val) {
-  if (val === null || val === void 0) return "\u2014";
-  if (typeof val === "number") return String(val);
-  if (typeof val === "string") return val;
-  if (typeof val === "boolean") return String(val);
-  if (typeof val === "object" && "r" in val) {
-    const c = val;
-    const h = (n) => Math.round(n * 255).toString(16).padStart(2, "0");
-    if (c.a !== void 0 && Math.abs(c.a - 1) > 4e-3) {
-      return "rgba(" + Math.round(c.r * 255) + ", " + Math.round(c.g * 255) + ", " + Math.round(c.b * 255) + ", " + Math.round(c.a * 100) / 100 + ")";
-    }
-    return "#" + h(c.r) + h(c.g) + h(c.b);
-  }
-  return JSON.stringify(val);
-}
 var DARK_VAR = {
   bgKnockout: "VariableID:6:18",
   bgSubtle: "VariableID:6:47",
@@ -258,6 +236,143 @@ function serializeNodeForProto(node, depth = 0) {
   }
   return base;
 }
+function bytesToBase64(bytes) {
+  let bin = "";
+  const chunkSize = 8192;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, Math.min(i + chunkSize, bytes.length));
+    bin += String.fromCharCode.apply(null, Array.from(chunk));
+  }
+  return btoa(bin);
+}
+function parseVariantProps(name) {
+  const props = {};
+  for (const part of name.split(",")) {
+    const eq = part.indexOf("=");
+    if (eq !== -1) props[part.slice(0, eq).trim()] = part.slice(eq + 1).trim();
+  }
+  return props;
+}
+function parseMetaFence(desc) {
+  const out = {
+    version: "",
+    status: "",
+    updated: "",
+    changelog: "",
+    goodToKnow: "",
+    accessibility: "",
+    description: "",
+    hadFence: false
+  };
+  if (!desc) return out;
+  const lines = desc.split("\n");
+  let idx = 0;
+  if (/s2a:meta/i.test(lines[0] || "")) {
+    out.hadFence = true;
+    let end = 1;
+    while (end < lines.length && lines[end].trim() !== "") end++;
+    const changelog = [];
+    let inChangelog = false;
+    for (const line of lines.slice(1, end)) {
+      const kv = line.match(/^([A-Za-z][\w-]*)\s*:\s*(.*)$/);
+      if (kv && !/^\s/.test(line)) {
+        inChangelog = false;
+        const k = kv[1].toLowerCase();
+        const v = kv[2].trim();
+        if (k === "version") out.version = v;
+        else if (k === "status") out.status = v;
+        else if (k === "updated") out.updated = v;
+        else if (k === "changelog") {
+          inChangelog = true;
+          if (v) changelog.push(v);
+        }
+      } else if (inChangelog) {
+        changelog.push(line.trim());
+      }
+    }
+    if (changelog.length) out.changelog = "changelog\n  " + changelog.join("\n  ");
+    idx = end + 1;
+  }
+  const rest = lines.slice(idx).join("\n").trim();
+  const gtk = rest.match(/##\s*Good to know\s*\n([\s\S]*?)(?=\n##\s|$)/i);
+  const a11y = rest.match(/##\s*Accessibility\s*\n([\s\S]*?)(?=\n##\s|$)/i);
+  if (gtk) out.goodToKnow = gtk[1].trim();
+  if (a11y) out.accessibility = a11y[1].trim();
+  out.description = rest.split(/\n##\s/)[0].split(/\n\s*\n/)[0].trim();
+  return out;
+}
+function pageOfNode(node) {
+  let p = node;
+  while (p && p.type !== "PAGE") p = p.parent;
+  return p != null ? p : null;
+}
+function pickDefaultVariant(variants) {
+  if (!variants.length) return void 0;
+  const DEFAULTISH = /* @__PURE__ */ new Set([
+    "default",
+    "resting",
+    "standard",
+    "md",
+    "solid",
+    "hug",
+    "block",
+    "horizontal",
+    "on-light"
+  ]);
+  let best = variants[0];
+  let bestScore = -1;
+  for (const v of variants) {
+    const score = Object.values(parseVariantProps(v.name)).filter((x) => DEFAULTISH.has(x.toLowerCase())).length;
+    if (score > bestScore) {
+      best = v;
+      bestScore = score;
+    }
+  }
+  return best;
+}
+function clearBentoSlot(frame) {
+  for (const c of [...frame.children]) c.remove();
+}
+function anatomyList(comp) {
+  const lines = [];
+  function walk(node, depth) {
+    if (node !== comp && (node.name.startsWith(".") || node.name.startsWith("["))) {
+      lines.push("  ".repeat(Math.max(0, depth - 1)) + node.name);
+    }
+    if ("children" in node && depth < 4) {
+      for (const c of node.children) walk(c, depth + 1);
+    }
+  }
+  walk(comp, 0);
+  return lines.length ? lines.join("\n") : ".root";
+}
+function setUsesNativeSlots(set) {
+  const v = set.children[0];
+  if (v && "findOne" in v) {
+    try {
+      return !!v.findOne((n) => n.type === "SLOT");
+    } catch (e) {
+    }
+  }
+  return false;
+}
+function clusterPositions(vals, tol) {
+  const sorted = Array.from(new Set(vals)).sort((a, b) => a - b);
+  const reps = [];
+  for (const v of sorted) if (!reps.some((r) => Math.abs(r - v) <= tol)) reps.push(v);
+  return reps;
+}
+function mkAxisLabel(chars, style, size, colorVar) {
+  const t = figma.createText();
+  t.name = "axis-label";
+  t.fontName = { family: "Adobe Clean", style };
+  t.fontSize = size;
+  t.characters = chars;
+  t.textAutoResize = "WIDTH_AND_HEIGHT";
+  t.fills = [{ type: "SOLID", color: { r: 0, g: 0, b: 0 } }];
+  if (colorVar) bfv(t, colorVar);
+  return t;
+}
 figma.on("selectionchange", notifySelection);
 figma.on("currentpagechange", () => {
   figma.ui.postMessage({
@@ -267,7 +382,7 @@ figma.on("currentpagechange", () => {
 });
 figma.showUI(__html__, { width: 320, height: 480, themeColors: true });
 figma.ui.onmessage = async (msg) => {
-  var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _A, _B, _C, _D, _E, _F, _G, _H, _I, _J, _K, _L, _M, _N, _O, _P, _Q, _R;
+  var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t, _u, _v, _w;
   switch (msg.type) {
     case "ui-ready":
       notifySelection();
@@ -306,24 +421,6 @@ figma.ui.onmessage = async (msg) => {
       });
       break;
     }
-    case "get-settings": {
-      try {
-        const settings = await figma.clientStorage.getAsync("github-settings");
-        figma.ui.postMessage({ type: "settings-loaded", settings: settings != null ? settings : null });
-      } catch (e) {
-        figma.ui.postMessage({ type: "settings-loaded", settings: null });
-      }
-      break;
-    }
-    case "save-settings": {
-      try {
-        await figma.clientStorage.setAsync("github-settings", msg.settings);
-        figma.ui.postMessage({ type: "settings-saved", success: true });
-      } catch (e) {
-        figma.ui.postMessage({ type: "settings-saved", success: false, error: e.message || String(e) });
-      }
-      break;
-    }
     case "notify": {
       figma.notify(msg.message);
       break;
@@ -354,6 +451,42 @@ figma.ui.onmessage = async (msg) => {
       const w = msg.width || 320;
       const h = msg.height || 480;
       figma.ui.resize(w, h);
+      break;
+    }
+    case "llm-capture:selection": {
+      const node = figma.currentPage.selection[0];
+      if (!node) {
+        figma.ui.postMessage({ type: "llm-capture:result", error: "Select a frame, section, component, or instance first" });
+        break;
+      }
+      if (!("exportAsync" in node)) {
+        figma.ui.postMessage({ type: "llm-capture:result", error: `${node.type} cannot be exported as an image` });
+        break;
+      }
+      try {
+        const maxDimension = Math.max(256, Math.min(msg.maxDimension || 2048, 4096));
+        const width = "width" in node ? node.width : maxDimension;
+        const height = "height" in node ? node.height : maxDimension;
+        const scale = Math.min(1, maxDimension / Math.max(width, height));
+        const bytes = await node.exportAsync({
+          format: "JPG",
+          constraint: { type: "SCALE", value: scale }
+        });
+        const capture = {
+          imageBase64: bytesToBase64(bytes),
+          mediaType: "image/jpeg",
+          scale,
+          maxDimension,
+          byteLength: bytes.length,
+          node: serializeNodeForProto(node),
+          fileKey: figma.fileKey || null,
+          fileName: figma.root.name,
+          page: { id: figma.currentPage.id, name: figma.currentPage.name }
+        };
+        figma.ui.postMessage({ type: "llm-capture:result", capture });
+      } catch (e) {
+        figma.ui.postMessage({ type: "llm-capture:result", error: e.message || String(e) });
+      }
       break;
     }
     case "annotate:apply": {
@@ -505,1237 +638,6 @@ figma.ui.onmessage = async (msg) => {
       figma.ui.postMessage({ type: "annotate:cleared", cleared });
       break;
     }
-    case "token-docs:generate": {
-      const collectionId = msg.collectionId;
-      const group = msg.group;
-      try {
-        let hTxt2 = function(chars, family, style, size, v, fixedW) {
-          const n = figma.createText();
-          n.fontName = { family, style };
-          n.fontSize = size;
-          n.characters = chars;
-          n.fills = [{ type: "SOLID", color: { r: 1, g: 1, b: 1 } }];
-          if (fixedW) n.resize(fixedW, n.height);
-          n.textAutoResize = "HEIGHT";
-          frame.appendChild(n);
-          if (!fixedW) n.layoutSizingHorizontal = "FILL";
-          if (v) bfv(n, v);
-          return n;
-        }, hSpacer2 = function(h) {
-          const sp = figma.createFrame();
-          sp.fills = [];
-          sp.resize(W - M * 2, h);
-          sp.primaryAxisSizingMode = "FIXED";
-          frame.appendChild(sp);
-          sp.layoutSizingHorizontal = "FILL";
-        }, hDiv2 = function() {
-          const r = figma.createRectangle();
-          r.resize(W - M * 2, 1);
-          r.fills = [{ type: "SOLID", color: { r: 1, g: 1, b: 1 }, opacity: 0.12 }];
-          frame.appendChild(r);
-          r.layoutSizingHorizontal = "FILL";
-          if (vBorder2) bfv(r, vBorder2);
-        }, bindStroke2 = function(node, v) {
-          var _a2;
-          const ss = [...(_a2 = node.strokes) != null ? _a2 : []];
-          if (!ss.length) return;
-          ss[0] = figma.variables.setBoundVariableForPaint(ss[0], "color", v);
-          node.strokes = ss;
-        };
-        var hTxt = hTxt2, hSpacer = hSpacer2, hDiv = hDiv2, bindStroke = bindStroke2;
-        if (collectionId === "text-styles") {
-          const tsAllColls = await figma.variables.getLocalVariableCollectionsAsync();
-          const responsiveColl = tsAllColls.find((c) => /Responsive/.test(c.name));
-          if (!responsiveColl) throw new Error("Responsive variable collection not found");
-          const MODE_ORDER_TS = ["sm", "md", "lg", "xl"];
-          const tsSortedModes = [...responsiveColl.modes].sort(
-            (a, b) => MODE_ORDER_TS.indexOf(a.name.toLowerCase()) - MODE_ORDER_TS.indexOf(b.name.toLowerCase())
-          );
-          const tsAllVars = await figma.variables.getLocalVariablesAsync();
-          const allTypoVars = tsAllVars.filter(
-            (v) => v.variableCollectionId === responsiveColl.id && v.name.toLowerCase().includes("/typography/")
-          );
-          const resolveVarMode = async (v, modeId) => {
-            let cur = v.valuesByMode[modeId];
-            for (let depth = 0; depth < 3; depth++) {
-              if (typeof cur === "number") return cur;
-              if (cur && typeof cur === "object" && cur.type === "VARIABLE_ALIAS") {
-                try {
-                  const ref = await figma.variables.getVariableByIdAsync(cur.id);
-                  if (!ref) break;
-                  cur = ref.valuesByMode[Object.keys(ref.valuesByMode)[0]];
-                } catch (e) {
-                  break;
-                }
-              } else {
-                break;
-              }
-            }
-            return typeof cur === "number" ? cur : null;
-          };
-          const tsTextStyles = await figma.getLocalTextStylesAsync();
-          const TS_STYLE_ORDER = [
-            "super",
-            "heading-1",
-            "heading-2",
-            "heading-3",
-            "heading-4",
-            "heading-5",
-            "heading-6",
-            "body-lg",
-            "body-md",
-            "body-sm",
-            "body-xs",
-            "eyebrow",
-            "label",
-            "caption"
-          ];
-          const typoStyles = tsTextStyles.filter((s) => s.name.startsWith("s2a/typography/")).sort((a, b) => {
-            const an = a.name.replace("s2a/typography/", "");
-            const bn = b.name.replace("s2a/typography/", "");
-            const ai = TS_STYLE_ORDER.indexOf(an);
-            const bi = TS_STYLE_ORDER.indexOf(bn);
-            if (ai !== -1 && bi !== -1) return ai - bi;
-            if (ai !== -1) return -1;
-            if (bi !== -1) return 1;
-            return a.name.localeCompare(b.name);
-          });
-          if (typoStyles.length === 0) throw new Error("No s2a/typography/* text styles found in this file");
-          await Promise.all([
-            figma.loadFontAsync({ family: "Adobe Clean Display", style: "Bold" }),
-            figma.loadFontAsync({ family: "Adobe Clean Display", style: "Black" }).catch(() => {
-            }),
-            figma.loadFontAsync({ family: "Adobe Clean", style: "Bold" }),
-            figma.loadFontAsync({ family: "Adobe Clean", style: "Regular" }),
-            figma.loadFontAsync({ family: "Adobe Clean", style: "ExtraBold" }).catch(() => {
-            })
-          ]);
-          const themeColl2 = tsAllColls.find((c) => c.id === DARK_VAR.collectionId);
-          const tsDarkId = themeColl2.modes.find((m) => m.name === "Dark").modeId;
-          const [tsVBg, tsVBorder, tsVBody, tsVSub, tsVKo] = await Promise.all([
-            figma.variables.getVariableByIdAsync(DARK_VAR.bgKnockout),
-            figma.variables.getVariableByIdAsync(DARK_VAR.borderSubtle),
-            figma.variables.getVariableByIdAsync(DARK_VAR.cBodySubtle),
-            figma.variables.getVariableByIdAsync(DARK_VAR.cSubheading),
-            figma.variables.getVariableByIdAsync(DARK_VAR.cKnockout)
-          ]);
-          const tsPage = figma.currentPage;
-          const tsSections = tsPage.children.filter((n) => n.type === "SECTION");
-          const tsLastSec = tsSections.reduce(
-            (a, b) => !a || b.y + b.height > a.y + a.height ? b : a,
-            null
-          );
-          let tsPlaceY = tsLastSec ? tsLastSec.y + tsLastSec.height + 80 : 0;
-          const tsPlaceX = (_w = tsLastSec == null ? void 0 : tsLastSec.x) != null ? _w : 0;
-          const TS_W = 2400, TS_M = 120;
-          const createdSections = [];
-          for (const mode of tsSortedModes) {
-            const sec2 = figma.createSection();
-            sec2.name = `typography \u2014 ${mode.name}`;
-            sec2.x = tsPlaceX;
-            sec2.y = tsPlaceY;
-            sec2.resizeWithoutConstraints(TS_W, 800);
-            const bgRect2 = figma.createRectangle();
-            bgRect2.resize(TS_W, 800);
-            bgRect2.x = 0;
-            bgRect2.y = 0;
-            bgRect2.fills = [{ type: "SOLID", color: { r: 0.04, g: 0.04, b: 0.047 } }];
-            sec2.appendChild(bgRect2);
-            if (tsVBg) bfv(bgRect2, tsVBg);
-            const frame2 = figma.createFrame();
-            frame2.name = ".content";
-            frame2.fills = [];
-            frame2.clipsContent = false;
-            frame2.layoutMode = "VERTICAL";
-            frame2.resize(TS_W, 800);
-            frame2.primaryAxisSizingMode = "AUTO";
-            frame2.counterAxisSizingMode = "FIXED";
-            frame2.paddingTop = 160;
-            frame2.paddingBottom = 120;
-            frame2.paddingLeft = TS_M;
-            frame2.paddingRight = TS_M;
-            frame2.itemSpacing = 0;
-            frame2.counterAxisAlignItems = "MIN";
-            frame2.x = 0;
-            frame2.y = 0;
-            sec2.appendChild(frame2);
-            frame2.setExplicitVariableModeForCollection(themeColl2, tsDarkId);
-            try {
-              frame2.setExplicitVariableModeForCollection(responsiveColl, mode.modeId);
-            } catch (e) {
-            }
-            const hT = (chars, family, style, size, v) => {
-              const n = figma.createText();
-              n.fontName = { family, style };
-              n.fontSize = size;
-              n.characters = chars;
-              n.fills = [{ type: "SOLID", color: { r: 1, g: 1, b: 1 } }];
-              n.textAutoResize = "HEIGHT";
-              frame2.appendChild(n);
-              n.layoutSizingHorizontal = "FILL";
-              if (v) bfv(n, v);
-              return n;
-            };
-            const hSp = (h) => {
-              const sp = figma.createFrame();
-              sp.fills = [];
-              sp.resize(TS_W - TS_M * 2, h);
-              sp.primaryAxisSizingMode = "FIXED";
-              frame2.appendChild(sp);
-              sp.layoutSizingHorizontal = "FILL";
-            };
-            const hDv = () => {
-              const r = figma.createRectangle();
-              r.resize(TS_W - TS_M * 2, 1);
-              r.fills = [{ type: "SOLID", color: { r: 1, g: 1, b: 1 }, opacity: 0.12 }];
-              frame2.appendChild(r);
-              r.layoutSizingHorizontal = "FILL";
-              if (tsVBorder) bfv(r, tsVBorder);
-            };
-            hT(`typography \u2014 ${mode.name}`, "Adobe Clean Display", "Bold", 56, tsVKo);
-            hSp(24);
-            hT(`S2A Responsive \xB7 ${mode.name.toUpperCase()} breakpoint`, "Adobe Clean", "Regular", 20, tsVBody);
-            hSp(24);
-            hT("May 2026  \xB7  @matt", "Adobe Clean", "Regular", 14, tsVBody);
-            hSp(80);
-            hDv();
-            hSp(56);
-            for (const ts of typoStyles) {
-              const styleName = ts.name.replace("s2a/typography/", "");
-              const fsVar = (_x = allTypoVars.find((v) => v.name === `s2a/typography/font-size/${styleName}`)) != null ? _x : null;
-              const lhVar = (_y = allTypoVars.find((v) => v.name === `s2a/typography/line-height/${styleName}`)) != null ? _y : null;
-              const lsVar = (_z = allTypoVars.find((v) => v.name === `s2a/typography/letter-spacing/${styleName}`)) != null ? _z : null;
-              const isDisplayStyle = ["super", "heading-1", "heading-2"].includes(styleName);
-              const isSmallStyle = ["eyebrow", "label", "caption"].includes(styleName);
-              const sampleText = isDisplayStyle ? "Make anything." : isSmallStyle ? "Everything you need to make anything you want." : "Everything you need to make anything.";
-              hT(styleName, "Adobe Clean", "Bold", 11, tsVSub);
-              hSp(8);
-              const textNode = figma.createText();
-              textNode.fontName = { family: "Adobe Clean", style: "Regular" };
-              textNode.fontSize = 16;
-              textNode.characters = sampleText;
-              frame2.appendChild(textNode);
-              textNode.layoutSizingHorizontal = "FILL";
-              textNode.textAutoResize = "HEIGHT";
-              try {
-                await textNode.setTextStyleIdAsync(ts.id);
-              } catch (e) {
-              }
-              if (fsVar) try {
-                textNode.setBoundVariable("fontSize", fsVar);
-              } catch (e) {
-              }
-              if (lhVar) try {
-                textNode.setBoundVariable("lineHeight", lhVar);
-              } catch (e) {
-              }
-              if (lsVar) try {
-                textNode.setBoundVariable("letterSpacing", lsVar);
-              } catch (e) {
-              }
-              if (tsVKo) bfv(textNode, tsVKo);
-              const fs = fsVar ? await resolveVarMode(fsVar, mode.modeId) : null;
-              const lh = lhVar ? await resolveVarMode(lhVar, mode.modeId) : null;
-              const ls = lsVar ? await resolveVarMode(lsVar, mode.modeId) : null;
-              hSp(8);
-              const fmtPx = (n) => n !== null ? n + "px" : "\u2014";
-              const fmtLs = (n) => n === null ? "\u2014" : n === 0 ? "0" : n.toFixed(2) + "px";
-              const vNode = figma.createText();
-              vNode.fontName = { family: "Adobe Clean", style: "Regular" };
-              vNode.fontSize = 13;
-              vNode.characters = `font-size ${fmtPx(fs)}  \xB7  line-height ${fmtPx(lh)}  \xB7  letter-spacing ${fmtLs(ls)}`;
-              frame2.appendChild(vNode);
-              vNode.layoutSizingHorizontal = "FILL";
-              vNode.textAutoResize = "HEIGHT";
-              if (tsVBody) bfv(vNode, tsVBody);
-              hSp(32);
-              hDv();
-              hSp(32);
-            }
-            const finalH2 = frame2.height;
-            sec2.resizeWithoutConstraints(TS_W, finalH2);
-            bgRect2.resize(TS_W, finalH2);
-            tsPlaceY += finalH2 + 80;
-            createdSections.push(sec2);
-          }
-          if (createdSections.length > 0) figma.viewport.scrollAndZoomIntoView(createdSections);
-          figma.notify(`${createdSections.length} typography breakpoint sections generated`);
-          figma.ui.postMessage({ type: "token-docs:result", sectionId: (_B = (_A = createdSections[0]) == null ? void 0 : _A.id) != null ? _B : "", count: createdSections.length });
-          break;
-        }
-        if (group.toLowerCase().includes("section-padding")) {
-          const spAllColls = await figma.variables.getLocalVariableCollectionsAsync();
-          const spColl = spAllColls.find((c) => c.id === collectionId);
-          if (!spColl) throw new Error("Collection not found: " + collectionId);
-          const MODE_ORDER_SP = ["sm", "md", "lg", "xl"];
-          const spSortedModes = [...spColl.modes].sort(
-            (a, b) => MODE_ORDER_SP.indexOf(a.name.toLowerCase()) - MODE_ORDER_SP.indexOf(b.name.toLowerCase())
-          );
-          const spAllVars = await figma.variables.getLocalVariablesAsync();
-          const spVars = spAllVars.filter(
-            (v) => v.variableCollectionId === collectionId && v.name.toLowerCase().includes("section-padding")
-          );
-          if (spVars.length === 0) throw new Error("No section-padding variables found in collection");
-          const SP_SIZE_ORDER = ["none", "2xs", "xs", "sm", "md", "lg", "xl", "2xl"];
-          const sortedSpVars = [...spVars].sort((a, b) => {
-            var _a2, _b2;
-            const an = (_a2 = a.name.split("/").pop()) != null ? _a2 : "";
-            const bn = (_b2 = b.name.split("/").pop()) != null ? _b2 : "";
-            const ai = SP_SIZE_ORDER.indexOf(an);
-            const bi = SP_SIZE_ORDER.indexOf(bn);
-            if (ai !== -1 && bi !== -1) return ai - bi;
-            if (ai !== -1) return -1;
-            if (bi !== -1) return 1;
-            return a.name.localeCompare(b.name);
-          });
-          const resolveSpMode = async (v, modeId) => {
-            let cur = v.valuesByMode[modeId];
-            for (let depth = 0; depth < 3; depth++) {
-              if (typeof cur === "number") return cur;
-              if (cur && typeof cur === "object" && cur.type === "VARIABLE_ALIAS") {
-                try {
-                  const ref = await figma.variables.getVariableByIdAsync(cur.id);
-                  if (!ref) break;
-                  cur = ref.valuesByMode[Object.keys(ref.valuesByMode)[0]];
-                } catch (e) {
-                  break;
-                }
-              } else {
-                break;
-              }
-            }
-            return typeof cur === "number" ? cur : null;
-          };
-          await Promise.all([
-            figma.loadFontAsync({ family: "Adobe Clean Display", style: "Bold" }),
-            figma.loadFontAsync({ family: "Adobe Clean", style: "Bold" }),
-            figma.loadFontAsync({ family: "Adobe Clean", style: "Regular" })
-          ]);
-          const spThemeColl = spAllColls.find((c) => c.id === DARK_VAR.collectionId);
-          const spDarkId = spThemeColl.modes.find((m) => m.name === "Dark").modeId;
-          const [spVBg, spVBorder, spVBody, spVSub, spVKo, spVBgSub] = await Promise.all([
-            figma.variables.getVariableByIdAsync(DARK_VAR.bgKnockout),
-            figma.variables.getVariableByIdAsync(DARK_VAR.borderSubtle),
-            figma.variables.getVariableByIdAsync(DARK_VAR.cBodySubtle),
-            figma.variables.getVariableByIdAsync(DARK_VAR.cSubheading),
-            figma.variables.getVariableByIdAsync(DARK_VAR.cKnockout),
-            figma.variables.getVariableByIdAsync(DARK_VAR.bgSubtle)
-          ]);
-          const spPage = figma.currentPage;
-          const spSections = spPage.children.filter((n) => n.type === "SECTION");
-          const spLastSec = spSections.reduce(
-            (a, b) => !a || b.y + b.height > a.y + a.height ? b : a,
-            null
-          );
-          let spPlaceY = spLastSec ? spLastSec.y + spLastSec.height + 80 : 0;
-          const spPlaceX = (_C = spLastSec == null ? void 0 : spLastSec.x) != null ? _C : 0;
-          const SP_W = 2400, SP_M = 120;
-          const spCreated = [];
-          for (const mode of spSortedModes) {
-            const sec2 = figma.createSection();
-            sec2.name = `viewport / section-padding \u2014 ${mode.name}`;
-            sec2.x = spPlaceX;
-            sec2.y = spPlaceY;
-            sec2.resizeWithoutConstraints(SP_W, 800);
-            const bgRect2 = figma.createRectangle();
-            bgRect2.resize(SP_W, 800);
-            bgRect2.x = 0;
-            bgRect2.y = 0;
-            bgRect2.fills = [{ type: "SOLID", color: { r: 0.04, g: 0.04, b: 0.047 } }];
-            sec2.appendChild(bgRect2);
-            if (spVBg) bfv(bgRect2, spVBg);
-            const frame2 = figma.createFrame();
-            frame2.name = ".content";
-            frame2.fills = [];
-            frame2.clipsContent = false;
-            frame2.layoutMode = "VERTICAL";
-            frame2.resize(SP_W, 800);
-            frame2.primaryAxisSizingMode = "AUTO";
-            frame2.counterAxisSizingMode = "FIXED";
-            frame2.paddingTop = 160;
-            frame2.paddingBottom = 120;
-            frame2.paddingLeft = SP_M;
-            frame2.paddingRight = SP_M;
-            frame2.itemSpacing = 0;
-            frame2.counterAxisAlignItems = "MIN";
-            frame2.x = 0;
-            frame2.y = 0;
-            sec2.appendChild(frame2);
-            frame2.setExplicitVariableModeForCollection(spThemeColl, spDarkId);
-            try {
-              frame2.setExplicitVariableModeForCollection(spColl, mode.modeId);
-            } catch (e) {
-            }
-            const spHT = (chars, family, style, size, v) => {
-              const n = figma.createText();
-              n.fontName = { family, style };
-              n.fontSize = size;
-              n.characters = chars;
-              n.fills = [{ type: "SOLID", color: { r: 1, g: 1, b: 1 } }];
-              n.textAutoResize = "HEIGHT";
-              frame2.appendChild(n);
-              n.layoutSizingHorizontal = "FILL";
-              if (v) bfv(n, v);
-              return n;
-            };
-            const spHSp = (h) => {
-              const sp = figma.createFrame();
-              sp.fills = [];
-              sp.resize(SP_W - SP_M * 2, h);
-              sp.primaryAxisSizingMode = "FIXED";
-              frame2.appendChild(sp);
-              sp.layoutSizingHorizontal = "FILL";
-            };
-            const spHDv = () => {
-              const r = figma.createRectangle();
-              r.resize(SP_W - SP_M * 2, 1);
-              r.fills = [{ type: "SOLID", color: { r: 1, g: 1, b: 1 }, opacity: 0.12 }];
-              frame2.appendChild(r);
-              r.layoutSizingHorizontal = "FILL";
-              if (spVBorder) bfv(r, spVBorder);
-            };
-            spHT(`viewport / section-padding \u2014 ${mode.name}`, "Adobe Clean Display", "Bold", 56, spVKo);
-            spHSp(24);
-            spHT(`S2A Responsive \xB7 ${mode.name.toUpperCase()} breakpoint`, "Adobe Clean", "Regular", 20, spVBody);
-            spHSp(24);
-            spHT("May 2026  \xB7  @matt", "Adobe Clean", "Regular", 14, spVBody);
-            spHSp(80);
-            spHDv();
-            spHSp(56);
-            for (const sv of sortedSpVars) {
-              const sizeName = (_D = sv.name.split("/").pop()) != null ? _D : sv.name;
-              const cssVar = "--" + sv.name.replace(/^s2a\//, "s2a-").replace(/\//g, "-");
-              const resolvedPx = await resolveSpMode(sv, mode.modeId);
-              const fmtPx = (n) => n !== null ? n + "px" : "\u2014";
-              const rowFrame = figma.createFrame();
-              rowFrame.name = sizeName;
-              rowFrame.fills = [];
-              rowFrame.layoutMode = "HORIZONTAL";
-              rowFrame.primaryAxisSizingMode = "FIXED";
-              rowFrame.counterAxisSizingMode = "AUTO";
-              rowFrame.counterAxisAlignItems = "CENTER";
-              rowFrame.itemSpacing = 32;
-              rowFrame.resize(SP_W - SP_M * 2, 40);
-              frame2.appendChild(rowFrame);
-              rowFrame.layoutSizingHorizontal = "FILL";
-              const infoCol = figma.createFrame();
-              infoCol.name = "info";
-              infoCol.fills = [];
-              infoCol.layoutMode = "VERTICAL";
-              infoCol.primaryAxisSizingMode = "AUTO";
-              infoCol.counterAxisSizingMode = "AUTO";
-              infoCol.itemSpacing = 4;
-              rowFrame.appendChild(infoCol);
-              infoCol.layoutSizingHorizontal = "FILL";
-              const nameNode = figma.createText();
-              nameNode.fontName = { family: "Adobe Clean", style: "Bold" };
-              nameNode.fontSize = 14;
-              nameNode.characters = sizeName;
-              nameNode.fills = [{ type: "SOLID", color: { r: 1, g: 1, b: 1 } }];
-              nameNode.textAutoResize = "WIDTH_AND_HEIGHT";
-              infoCol.appendChild(nameNode);
-              if (spVKo) bfv(nameNode, spVKo);
-              const metaNode = figma.createText();
-              metaNode.fontName = { family: "Adobe Clean", style: "Regular" };
-              metaNode.fontSize = 12;
-              metaNode.characters = `${cssVar}  \xB7  ${fmtPx(resolvedPx)}`;
-              metaNode.fills = [{ type: "SOLID", color: { r: 1, g: 1, b: 1 } }];
-              metaNode.textAutoResize = "WIDTH_AND_HEIGHT";
-              infoCol.appendChild(metaNode);
-              if (spVBody) bfv(metaNode, spVBody);
-              const swatchCol = figma.createFrame();
-              swatchCol.name = "swatch";
-              swatchCol.fills = [];
-              swatchCol.layoutMode = "HORIZONTAL";
-              swatchCol.primaryAxisSizingMode = "AUTO";
-              swatchCol.counterAxisSizingMode = "AUTO";
-              swatchCol.counterAxisAlignItems = "CENTER";
-              rowFrame.appendChild(swatchCol);
-              const swSizePx = resolvedPx !== null && resolvedPx > 0 ? Math.min(resolvedPx, 120) : null;
-              const swDisplay = swSizePx != null ? swSizePx : 4;
-              const sw = figma.createRectangle();
-              sw.resize(swDisplay, swDisplay);
-              sw.cornerRadius = 4;
-              sw.fills = [{ type: "SOLID", color: { r: 0.3, g: 0.3, b: 0.35 } }];
-              swatchCol.appendChild(sw);
-              if (spVBgSub) bfv(sw, spVBgSub);
-              if (swSizePx !== null) {
-                try {
-                  sw.setBoundVariable("width", sv);
-                } catch (e) {
-                }
-                try {
-                  sw.setBoundVariable("height", sv);
-                } catch (e) {
-                }
-              }
-              sw.setPluginData("s2aTokenVar", sv.name);
-              sw.setPluginData("s2aTokenProp", "spacing");
-              spHSp(16);
-            }
-            spHDv();
-            spHSp(56);
-            const finalH2 = frame2.height;
-            sec2.resizeWithoutConstraints(SP_W, finalH2);
-            bgRect2.resize(SP_W, finalH2);
-            spPlaceY += finalH2 + 80;
-            spCreated.push(sec2);
-          }
-          if (spCreated.length > 0) figma.viewport.scrollAndZoomIntoView(spCreated);
-          figma.notify(`${spCreated.length} section-padding breakpoint sections generated`);
-          figma.ui.postMessage({ type: "token-docs:result", sectionId: (_F = (_E = spCreated[0]) == null ? void 0 : _E.id) != null ? _F : "", count: spCreated.length });
-          break;
-        }
-        const allVars = await figma.variables.getLocalVariablesAsync();
-        const groupVars = allVars.filter(
-          (v) => v.variableCollectionId === collectionId && tokenGroup(v.name) === group
-        );
-        if (groupVars.length === 0) throw new Error("No variables found for group: " + group);
-        const allColls = await figma.variables.getLocalVariableCollectionsAsync();
-        const coll = allColls.find((c) => c.id === collectionId);
-        if (!coll) throw new Error("Collection not found: " + collectionId);
-        const defaultModeId = coll.defaultModeId;
-        const rows = [];
-        for (const v of groupVars) {
-          const rawVal = v.valuesByMode[defaultModeId];
-          let value = "", alias = "";
-          let rawNum;
-          if (rawVal && typeof rawVal === "object" && "type" in rawVal && rawVal.type === "VARIABLE_ALIAS") {
-            try {
-              const refVar = await figma.variables.getVariableByIdAsync(rawVal.id);
-              if (refVar) {
-                alias = refVar.name;
-                const refModeId = Object.keys(refVar.valuesByMode)[0];
-                const refVal = refVar.valuesByMode[refModeId];
-                value = fmtTokenValue(refVal);
-                if (typeof refVal === "number") rawNum = refVal;
-              }
-            } catch (e) {
-            }
-          } else {
-            value = fmtTokenValue(rawVal);
-            if (typeof rawVal === "number") rawNum = rawVal;
-          }
-          rows.push({
-            path: v.name,
-            cssVar: "--" + v.name.replace(/\//g, "-"),
-            value,
-            alias,
-            variable: v,
-            resolvedType: v.resolvedType,
-            rawNum
-          });
-        }
-        const TSHIRT = {
-          "none": 0,
-          "base": 1,
-          "5xs": 2,
-          "4xs": 3,
-          "3xs": 4,
-          "2xs": 5,
-          "xs": 6,
-          "sm": 7,
-          "md": 8,
-          "lg": 9,
-          "xl": 10,
-          "2xl": 11,
-          "3xl": 12,
-          "4xl": 13,
-          "5xl": 14,
-          "round": 98,
-          "pill": 98,
-          "full": 98,
-          "circle": 99
-        };
-        rows.sort((a, b) => {
-          var _a2, _b2;
-          const ak = ((_a2 = a.path.split("/").pop()) != null ? _a2 : "").toLowerCase();
-          const bk = ((_b2 = b.path.split("/").pop()) != null ? _b2 : "").toLowerCase();
-          const ao = ak in TSHIRT ? TSHIRT[ak] : -1;
-          const bo = bk in TSHIRT ? TSHIRT[bk] : -1;
-          if (ao !== -1 && bo !== -1) return ao - bo;
-          if (ao !== -1) return -1;
-          if (bo !== -1) return 1;
-          if (a.rawNum !== void 0 && b.rawNum !== void 0) return a.rawNum - b.rawNum;
-          return a.path.localeCompare(b.path);
-        });
-        await Promise.all([
-          figma.loadFontAsync({ family: "Adobe Clean Display", style: "Bold" }),
-          figma.loadFontAsync({ family: "Adobe Clean Display", style: "Black" }).catch(() => {
-          }),
-          figma.loadFontAsync({ family: "Adobe Clean", style: "Bold" }),
-          figma.loadFontAsync({ family: "Adobe Clean", style: "Regular" }),
-          figma.loadFontAsync({ family: "Adobe Clean", style: "ExtraBold" }).catch(() => {
-          })
-        ]);
-        const [vBg2, vBorder2, vBody2, vSub2, vKo2, vBgSub2] = await Promise.all([
-          figma.variables.getVariableByIdAsync(DARK_VAR.bgKnockout),
-          figma.variables.getVariableByIdAsync(DARK_VAR.borderSubtle),
-          figma.variables.getVariableByIdAsync(DARK_VAR.cBodySubtle),
-          figma.variables.getVariableByIdAsync(DARK_VAR.cSubheading),
-          figma.variables.getVariableByIdAsync(DARK_VAR.cKnockout),
-          figma.variables.getVariableByIdAsync(DARK_VAR.bgSubtle)
-        ]);
-        const themeColl = allColls.find((c) => c.id === DARK_VAR.collectionId);
-        const darkId = themeColl.modes.find((m) => m.name === "Dark").modeId;
-        const page = figma.currentPage;
-        const pageSections = page.children.filter((n) => n.type === "SECTION");
-        const lastSec = pageSections.reduce(
-          (a, b) => !a || b.y + b.height > a.y + a.height ? b : a,
-          null
-        );
-        const placeX = (_G = lastSec == null ? void 0 : lastSec.x) != null ? _G : 0;
-        const placeY = lastSec ? lastSec.y + lastSec.height + 80 : 0;
-        const W = 2400, M = 120;
-        const sec = figma.createSection();
-        sec.name = group;
-        sec.x = placeX;
-        sec.y = placeY;
-        sec.resizeWithoutConstraints(W, 800);
-        const bgRect = figma.createRectangle();
-        bgRect.resize(W, 800);
-        bgRect.x = 0;
-        bgRect.y = 0;
-        bgRect.fills = [{ type: "SOLID", color: { r: 0.04, g: 0.04, b: 0.047 } }];
-        sec.appendChild(bgRect);
-        if (vBg2) bfv(bgRect, vBg2);
-        const frame = figma.createFrame();
-        frame.name = ".content";
-        frame.fills = [];
-        frame.clipsContent = false;
-        frame.layoutMode = "VERTICAL";
-        frame.resize(W, 800);
-        frame.primaryAxisSizingMode = "AUTO";
-        frame.counterAxisSizingMode = "FIXED";
-        frame.paddingTop = 160;
-        frame.paddingBottom = 120;
-        frame.paddingLeft = M;
-        frame.paddingRight = M;
-        frame.itemSpacing = 0;
-        frame.counterAxisAlignItems = "MIN";
-        frame.x = 0;
-        frame.y = 0;
-        sec.appendChild(frame);
-        frame.setExplicitVariableModeForCollection(themeColl, darkId);
-        hTxt2(group, "Adobe Clean Display", "Bold", 56, vKo2);
-        hSpacer2(24);
-        hTxt2(coll.name, "Adobe Clean", "Regular", 20, vBody2, 1600);
-        hSpacer2(24);
-        hTxt2("May 2026  \xB7  @matt", "Adobe Clean", "Regular", 14, vBody2, 600);
-        hSpacer2(80);
-        hDiv2();
-        hSpacer2(56);
-        const gl = group.toLowerCase();
-        const isTypography = gl.includes("typography");
-        if (isTypography) {
-          const MODE_ORDER = ["sm", "md", "lg", "xl"];
-          const sortedModes = [...coll.modes].sort(
-            (a, b) => MODE_ORDER.indexOf(a.name.toLowerCase()) - MODE_ORDER.indexOf(b.name.toLowerCase())
-          );
-          const allTypoVars = allVars.filter(
-            (v) => v.variableCollectionId === collectionId && v.name.toLowerCase().includes("/typography/")
-          );
-          const textStyles = await figma.getLocalTextStylesAsync();
-          const STYLE_ORDER = [
-            "super",
-            "heading-1",
-            "heading-2",
-            "heading-3",
-            "heading-4",
-            "heading-5",
-            "heading-6",
-            "body-lg",
-            "body-md",
-            "body-sm",
-            "body-xs",
-            "eyebrow",
-            "label",
-            "caption"
-          ];
-          const availableStyles = STYLE_ORDER.filter(
-            (s) => allTypoVars.some((v) => v.name.endsWith(`/${s}`))
-          );
-          for (const styleName of availableStyles) {
-            const fsVar = (_H = allTypoVars.find((v) => v.name === `s2a/typography/font-size/${styleName}`)) != null ? _H : null;
-            const lhVar = (_I = allTypoVars.find((v) => v.name === `s2a/typography/line-height/${styleName}`)) != null ? _I : null;
-            const lsVar = (_J = allTypoVars.find((v) => v.name === `s2a/typography/letter-spacing/${styleName}`)) != null ? _J : null;
-            const textStyle = (_K = textStyles.find((s) => s.name === `s2a/typography/${styleName}`)) != null ? _K : null;
-            hTxt2(styleName, "Adobe Clean", "Bold", 18, vSub2);
-            hSpacer2(12);
-            const isDisplayStyle = ["super", "heading-1", "heading-2"].includes(styleName);
-            const isSmallStyle = ["eyebrow", "label", "caption"].includes(styleName);
-            const sampleText = isDisplayStyle ? "Make anything." : isSmallStyle ? "Everything you need to make anything you want." : "Everything you need to make anything.";
-            const bpFrame = figma.createFrame();
-            bpFrame.name = ".breakpoints";
-            bpFrame.layoutMode = "HORIZONTAL";
-            bpFrame.primaryAxisSizingMode = "AUTO";
-            bpFrame.counterAxisSizingMode = "AUTO";
-            bpFrame.itemSpacing = 1;
-            bpFrame.fills = [];
-            frame.appendChild(bpFrame);
-            bpFrame.layoutSizingHorizontal = "FILL";
-            for (const mode of sortedModes) {
-              const colFrame = figma.createFrame();
-              colFrame.name = mode.name.toUpperCase();
-              colFrame.layoutMode = "VERTICAL";
-              colFrame.primaryAxisSizingMode = "AUTO";
-              colFrame.counterAxisSizingMode = "AUTO";
-              colFrame.paddingTop = 24;
-              colFrame.paddingBottom = 24;
-              colFrame.paddingLeft = 24;
-              colFrame.paddingRight = 24;
-              colFrame.itemSpacing = 12;
-              colFrame.fills = [];
-              bpFrame.appendChild(colFrame);
-              colFrame.layoutSizingHorizontal = "FILL";
-              try {
-                colFrame.setExplicitVariableModeForCollection(coll, mode.modeId);
-              } catch (e) {
-              }
-              const modeLabel = figma.createText();
-              modeLabel.fontName = { family: "Adobe Clean", style: "Bold" };
-              modeLabel.fontSize = 11;
-              modeLabel.characters = mode.name.toUpperCase();
-              colFrame.appendChild(modeLabel);
-              modeLabel.layoutSizingHorizontal = "FILL";
-              if (vSub2) bfv(modeLabel, vSub2);
-              const textNode = figma.createText();
-              textNode.fontName = { family: "Adobe Clean", style: "Regular" };
-              textNode.fontSize = 16;
-              textNode.characters = sampleText;
-              colFrame.appendChild(textNode);
-              textNode.layoutSizingHorizontal = "FILL";
-              textNode.textAutoResize = "HEIGHT";
-              if (textStyle) {
-                try {
-                  await textNode.setTextStyleIdAsync(textStyle.id);
-                } catch (e) {
-                }
-              }
-              if (fsVar) try {
-                textNode.setBoundVariable("fontSize", fsVar);
-              } catch (e) {
-              }
-              if (lhVar) try {
-                textNode.setBoundVariable("lineHeight", lhVar);
-              } catch (e) {
-              }
-              if (lsVar) try {
-                textNode.setBoundVariable("letterSpacing", lsVar);
-              } catch (e) {
-              }
-              if (vKo2) bfv(textNode, vKo2);
-              const annProps = [];
-              if (fsVar) annProps.push({ type: "fontSize" });
-              if (lhVar) annProps.push({ type: "lineHeight" });
-              if (lsVar) annProps.push({ type: "letterSpacing" });
-              try {
-                textNode.annotations = [{ label: `s2a/typography/${styleName}`, properties: annProps }];
-              } catch (e) {
-              }
-            }
-            hSpacer2(24);
-            hDiv2();
-            hSpacer2(32);
-          }
-        } else {
-          for (const row of rows) {
-            const rowFrame = figma.createFrame();
-            rowFrame.name = (_L = row.path.split("/").pop()) != null ? _L : row.path;
-            rowFrame.layoutMode = "HORIZONTAL";
-            rowFrame.primaryAxisSizingMode = "AUTO";
-            rowFrame.counterAxisSizingMode = "AUTO";
-            rowFrame.paddingTop = 16;
-            rowFrame.paddingBottom = 16;
-            rowFrame.paddingLeft = 0;
-            rowFrame.paddingRight = 0;
-            rowFrame.itemSpacing = 40;
-            rowFrame.counterAxisAlignItems = "CENTER";
-            rowFrame.fills = [];
-            frame.appendChild(rowFrame);
-            rowFrame.layoutSizingHorizontal = "FILL";
-            const textCol = figma.createFrame();
-            textCol.name = ".text";
-            textCol.layoutMode = "VERTICAL";
-            textCol.primaryAxisSizingMode = "AUTO";
-            textCol.counterAxisSizingMode = "AUTO";
-            textCol.itemSpacing = 4;
-            textCol.fills = [];
-            rowFrame.appendChild(textCol);
-            textCol.layoutSizingHorizontal = "FILL";
-            const rTxt = (chars, style, size, v) => {
-              const n = figma.createText();
-              n.fontName = { family: "Adobe Clean", style };
-              n.fontSize = size;
-              n.characters = chars;
-              n.fills = [{ type: "SOLID", color: { r: 1, g: 1, b: 1 } }];
-              n.textAutoResize = "HEIGHT";
-              textCol.appendChild(n);
-              n.layoutSizingHorizontal = "FILL";
-              if (v) bfv(n, v);
-              return n;
-            };
-            rTxt(row.path, "Bold", 16, vSub2);
-            rTxt(row.cssVar, "Regular", 14, vBody2);
-            rTxt(row.alias ? row.value + "  \u2192  " + row.alias : row.value, "Regular", 14, vBody2);
-            const swatchCol = figma.createFrame();
-            swatchCol.name = ".swatch";
-            swatchCol.layoutMode = "VERTICAL";
-            swatchCol.counterAxisSizingMode = "FIXED";
-            swatchCol.primaryAxisAlignItems = "CENTER";
-            swatchCol.counterAxisAlignItems = "CENTER";
-            swatchCol.fills = [];
-            rowFrame.appendChild(swatchCol);
-            swatchCol.resize(200, 1);
-            swatchCol.primaryAxisSizingMode = "AUTO";
-            swatchCol.layoutSizingVertical = "HUG";
-            const annotLabel = row.cssVar;
-            if (row.resolvedType === "COLOR") {
-              const sw = figma.createRectangle();
-              sw.resize(200, 56);
-              sw.cornerRadius = 6;
-              const isTransparentBlack = gl.includes("transparent") && gl.includes("black");
-              const isTransparentWhite = gl.includes("transparent") && gl.includes("white");
-              const isTransparent = gl.includes("transparent");
-              const baseColor = isTransparentBlack ? { r: 1, g: 1, b: 1 } : isTransparentWhite ? { r: 0.2, g: 0.2, b: 0.2 } : isTransparent ? { r: 0.5, g: 0.5, b: 0.5 } : null;
-              const placeholder = { type: "SOLID", color: { r: 0.5, g: 0.5, b: 0.5 } };
-              sw.fills = baseColor ? [{ type: "SOLID", color: baseColor }, placeholder] : [placeholder];
-              swatchCol.appendChild(sw);
-              sw.layoutSizingHorizontal = "FILL";
-              try {
-                const f = [...sw.fills];
-                const bindIdx = baseColor ? 1 : 0;
-                f[bindIdx] = figma.variables.setBoundVariableForPaint(f[bindIdx], "color", row.variable);
-                sw.fills = f;
-              } catch (e) {
-              }
-              if (vBorder2) {
-                sw.strokes = [{ type: "SOLID", color: { r: 1, g: 1, b: 1 } }];
-                sw.strokeWeight = 1;
-                sw.strokeAlign = "INSIDE";
-                bindStroke2(sw, vBorder2);
-              }
-              sw.setPluginData("s2aTokenVar", annotLabel);
-              sw.setPluginData("s2aTokenProp", "fills");
-              try {
-                sw.annotations = [{ label: annotLabel, properties: [{ type: "fills" }] }];
-              } catch (e) {
-              }
-            } else if (row.resolvedType === "FLOAT") {
-              const num = (_M = row.rawNum) != null ? _M : 4;
-              if (gl.includes("radius")) {
-                const sw = figma.createRectangle();
-                sw.resize(80, 80);
-                sw.cornerRadius = Math.min(num, 40);
-                if (num > 0) {
-                  for (const corner of ["topLeftRadius", "topRightRadius", "bottomLeftRadius", "bottomRightRadius"]) {
-                    try {
-                      sw.setBoundVariable(corner, row.variable);
-                    } catch (e) {
-                    }
-                  }
-                }
-                sw.fills = [{ type: "SOLID", color: { r: 0.2, g: 0.2, b: 0.25 } }];
-                if (vBgSub2) bfv(sw, vBgSub2);
-                sw.strokes = [{ type: "SOLID", color: { r: 1, g: 1, b: 1 } }];
-                sw.strokeWeight = 1;
-                sw.strokeAlign = "INSIDE";
-                if (vBorder2) bindStroke2(sw, vBorder2);
-                sw.setPluginData("s2aTokenVar", annotLabel);
-                sw.setPluginData("s2aTokenProp", num > 0 ? "cornerRadius" : "fills");
-                swatchCol.appendChild(sw);
-                const crProp = num > 0 ? "cornerRadius" : "fills";
-                try {
-                  sw.annotations = [{ label: annotLabel, properties: [{ type: crProp }] }];
-                } catch (e) {
-                }
-              } else if (gl.includes("width") || gl.includes("stroke") || gl.includes("border")) {
-                const sw = figma.createRectangle();
-                sw.resize(80, 80);
-                sw.fills = [];
-                sw.cornerRadius = 4;
-                sw.strokes = [{ type: "SOLID", color: { r: 1, g: 1, b: 1 } }];
-                sw.strokeWeight = Math.max(1, Math.min(num, 20));
-                sw.strokeAlign = "CENTER";
-                if (vBorder2) bindStroke2(sw, vBorder2);
-                try {
-                  sw.setBoundVariable("strokeWeight", row.variable);
-                } catch (e) {
-                }
-                sw.setPluginData("s2aTokenVar", annotLabel);
-                sw.setPluginData("s2aTokenProp", "strokeWeight");
-                swatchCol.appendChild(sw);
-                try {
-                  sw.annotations = [{ label: annotLabel, properties: [{ type: "strokeWeight" }] }];
-                } catch (e) {
-                }
-              } else if (gl.includes("spacing") || gl.includes("gap") || gl.includes("padding") || gl.includes("margin")) {
-                const isBlockPadding = gl.includes("section-padding");
-                const swSize = Math.max(num, isBlockPadding ? 4 : 1);
-                const sw = figma.createRectangle();
-                sw.resize(swSize, isBlockPadding ? swSize : 32);
-                sw.cornerRadius = 4;
-                sw.fills = [{ type: "SOLID", color: { r: 0.3, g: 0.3, b: 0.35 } }];
-                if (vBgSub2) bfv(sw, vBgSub2);
-                try {
-                  sw.setBoundVariable("width", row.variable);
-                } catch (e) {
-                }
-                if (isBlockPadding) {
-                  try {
-                    sw.setBoundVariable("height", row.variable);
-                  } catch (e) {
-                  }
-                }
-                sw.setPluginData("s2aTokenVar", annotLabel);
-                sw.setPluginData("s2aTokenProp", "spacing");
-                swatchCol.appendChild(sw);
-                const annPropsSp = isBlockPadding ? [{ type: "width" }, { type: "height" }] : [{ type: "width" }];
-                try {
-                  sw.annotations = [{ label: annotLabel, properties: annPropsSp }];
-                } catch (e) {
-                }
-              } else if (gl.includes("opacity")) {
-                const swFrame = figma.createFrame();
-                swFrame.name = ".opacity-swatch";
-                swFrame.resize(160, 64);
-                swFrame.cornerRadius = 8;
-                swFrame.clipsContent = true;
-                swFrame.fills = [{ type: "SOLID", color: { r: 0.62, g: 0.62, b: 0.67 } }];
-                const fullBlock = figma.createRectangle();
-                fullBlock.resize(78, 64);
-                fullBlock.x = 0;
-                fullBlock.y = 0;
-                fullBlock.fills = [{ type: "SOLID", color: { r: 0.06, g: 0.06, b: 0.14 } }];
-                fullBlock.opacity = 1;
-                swFrame.appendChild(fullBlock);
-                const fadeBlock = figma.createRectangle();
-                fadeBlock.resize(78, 64);
-                fadeBlock.x = 82;
-                fadeBlock.y = 0;
-                fadeBlock.fills = [{ type: "SOLID", color: { r: 0.06, g: 0.06, b: 0.14 } }];
-                fadeBlock.opacity = Math.max(0, Math.min(1, num / 100));
-                swFrame.appendChild(fadeBlock);
-                try {
-                  fadeBlock.setBoundVariable("opacity", row.variable);
-                } catch (e) {
-                }
-                swatchCol.appendChild(swFrame);
-                swFrame.setPluginData("s2aTokenVar", annotLabel);
-                swFrame.setPluginData("s2aTokenProp", "opacity");
-                try {
-                  swFrame.annotations = [{ label: annotLabel, properties: [] }];
-                } catch (e) {
-                }
-              } else if (gl.includes("blur")) {
-                const swFrame = figma.createFrame();
-                swFrame.name = ".blur-swatch";
-                swFrame.resize(200, 80);
-                swFrame.cornerRadius = 8;
-                swFrame.clipsContent = true;
-                swFrame.fills = [{ type: "SOLID", color: { r: 0.06, g: 0.06, b: 0.08 } }];
-                const bar = figma.createRectangle();
-                bar.resize(160, 3);
-                bar.x = 20;
-                bar.y = 38;
-                bar.cornerRadius = 2;
-                bar.fills = [{ type: "SOLID", color: { r: 1, g: 1, b: 1 }, opacity: 0.9 }];
-                bar.effects = [{ type: "LAYER_BLUR", radius: num, visible: true }];
-                bar.constraints = { horizontal: "STRETCH", vertical: "CENTER" };
-                swFrame.appendChild(bar);
-                swatchCol.appendChild(swFrame);
-                swFrame.setPluginData("s2aTokenVar", annotLabel);
-                swFrame.setPluginData("s2aTokenProp", "blur");
-                try {
-                  swFrame.annotations = [{ label: annotLabel, properties: [] }];
-                } catch (e) {
-                }
-              } else {
-                const sw = figma.createRectangle();
-                sw.resize(64, 64);
-                sw.cornerRadius = 4;
-                sw.fills = [{ type: "SOLID", color: { r: 0.2, g: 0.2, b: 0.24 } }];
-                if (vBgSub2) bfv(sw, vBgSub2);
-                swatchCol.appendChild(sw);
-                try {
-                  sw.annotations = [{ label: annotLabel, properties: [{ type: "width" }, { type: "height" }] }];
-                } catch (e) {
-                }
-              }
-            }
-            hDiv2();
-          }
-        }
-        const finalH = frame.height;
-        sec.resizeWithoutConstraints(W, finalH);
-        bgRect.resize(W, finalH);
-        figma.viewport.scrollAndZoomIntoView([sec]);
-        figma.notify(rows.length + " tokens documented");
-        figma.ui.postMessage({ type: "token-docs:result", sectionId: sec.id, count: rows.length });
-      } catch (e) {
-        figma.ui.postMessage({ type: "token-docs:result", error: e.message || String(e) });
-      }
-      break;
-    }
-    case "spec:generate": {
-      try {
-        let makeDarkSection2 = function(name, w, x, y) {
-          const sec = figma.createSection();
-          sec.name = name;
-          sec.x = x;
-          sec.y = y;
-          sec.resizeWithoutConstraints(w, 800);
-          figma.currentPage.appendChild(sec);
-          const bg = figma.createRectangle();
-          bg.resize(w, 800);
-          bg.x = 0;
-          bg.y = 0;
-          bg.fills = [{ type: "SOLID", color: { r: 0.04, g: 0.04, b: 0.047 } }];
-          sec.insertChild(0, bg);
-          if (vBg) bfv(bg, vBg);
-          const frame = figma.createFrame();
-          frame.name = ".content";
-          frame.fills = [];
-          frame.clipsContent = false;
-          frame.layoutMode = "NONE";
-          frame.resize(w, 800);
-          frame.x = 0;
-          frame.y = 0;
-          sec.appendChild(frame);
-          if (coll && darkId) frame.setExplicitVariableModeForCollection(coll, darkId);
-          const M2 = 120, CW2 = w - 240;
-          let cy = 0;
-          function mkTxt(chars, family, style, size, v, ww) {
-            const n = figma.createText();
-            n.fontName = { family, style };
-            n.fontSize = size;
-            n.characters = chars;
-            n.fills = [{ type: "SOLID", color: { r: 1, g: 1, b: 1 } }];
-            n.x = M2;
-            n.y = cy;
-            if (ww) {
-              n.resize(ww, n.height);
-              n.textAutoResize = "HEIGHT";
-            } else n.textAutoResize = "WIDTH_AND_HEIGHT";
-            frame.appendChild(n);
-            if (v) bfv(n, v);
-            cy += n.height;
-            return n;
-          }
-          function gap(px) {
-            cy += px;
-          }
-          function divider() {
-            const r = figma.createRectangle();
-            r.resize(CW2, 1);
-            r.x = M2;
-            r.y = cy;
-            r.fills = [{ type: "SOLID", color: { r: 1, g: 1, b: 1 }, opacity: 0.12 }];
-            frame.appendChild(r);
-            if (vBorderSubtle) bfv(r, vBorderSubtle);
-            cy += 1;
-          }
-          function finish(bottomPad = 120) {
-            const finalH = cy + bottomPad;
-            sec.resizeWithoutConstraints(w, finalH);
-            bg.resize(w, finalH);
-            frame.resize(w, finalH);
-          }
-          function getCy() {
-            return cy;
-          }
-          function setCy(v2) {
-            cy = v2;
-          }
-          return { sec, frame, mkTxt, gap, divider, finish, getCy, setCy, M: M2, CW: CW2, BW: Math.min(1600, CW2) };
-        }, annotateTree2 = function(root) {
-          var _a2;
-          const isComposite = !!((_a2 = root.findOne) == null ? void 0 : _a2.call(root, (n) => n.type === "INSTANCE"));
-          function annotateNode(n) {
-            var _a3, _b2, _c2, _d2, _e2, _f2, _g2, _h2, _i2, _j2, _k2, _l2, _m2;
-            if (isComposite && n.type === "TEXT") return;
-            const bv = (_a3 = n.boundVariables) != null ? _a3 : {};
-            const anns = [];
-            if (((_c2 = (_b2 = bv.fills) == null ? void 0 : _b2.length) != null ? _c2 : 0) > 0)
-              anns.push({ labelMarkdown: n.type === "TEXT" ? "Color" : "Fill", properties: [{ type: "fills" }] });
-            if (((_e2 = (_d2 = bv.strokes) == null ? void 0 : _d2.length) != null ? _e2 : 0) > 0)
-              anns.push({ labelMarkdown: "Border", properties: [{ type: "strokes" }] });
-            if (((_f2 = bv.cornerRadius) == null ? void 0 : _f2.id) || ((_g2 = bv.topLeftRadius) == null ? void 0 : _g2.id))
-              anns.push({ labelMarkdown: "Radius", properties: [{ type: "cornerRadius" }] });
-            const sp = [];
-            if (bv.paddingTop || bv.paddingBottom || bv.paddingLeft || bv.paddingRight) sp.push({ type: "padding" });
-            if (bv.itemSpacing) sp.push({ type: "itemSpacing" });
-            if (sp.length) anns.push({ labelMarkdown: "Spacing", properties: sp });
-            if (!isComposite && n.type === "TEXT") {
-              const tp = [];
-              if (((_i2 = (_h2 = bv.fontSize) == null ? void 0 : _h2.length) != null ? _i2 : 0) > 0) tp.push({ type: "fontSize" });
-              if (((_k2 = (_j2 = bv.lineHeight) == null ? void 0 : _j2.length) != null ? _k2 : 0) > 0) tp.push({ type: "lineHeight" });
-              if (((_m2 = (_l2 = bv.letterSpacing) == null ? void 0 : _l2.length) != null ? _m2 : 0) > 0) tp.push({ type: "letterSpacing" });
-              if (tp.length) anns.push({ labelMarkdown: "Typography", properties: tp });
-            }
-            if (anns.length) {
-              try {
-                n.annotations = anns;
-              } catch (e) {
-              }
-            }
-          }
-          annotateNode(root);
-          function walkChildren(n) {
-            if (!("children" in n)) return;
-            for (const child of n.children) {
-              annotateNode(child);
-              if (child.type !== "INSTANCE") walkChildren(child);
-            }
-          }
-          walkChildren(root);
-        };
-        var makeDarkSection = makeDarkSection2, annotateTree = annotateTree2;
-        const setId = msg.setId;
-        const opts = (_N = msg.options) != null ? _N : { variants: true, tokens: true, children: true };
-        const specSetNode = await figma.getNodeByIdAsync(setId);
-        if (!specSetNode || specSetNode.type !== "COMPONENT_SET" && specSetNode.type !== "COMPONENT") {
-          figma.ui.postMessage({ type: "spec:result", error: "Select a component or component set first" });
-          break;
-        }
-        const specSet = specSetNode;
-        const variants = specSetNode.type === "COMPONENT_SET" ? specSetNode.children : [specSetNode];
-        await Promise.all([
-          figma.loadFontAsync({ family: "Adobe Clean Display", style: "Bold" }),
-          figma.loadFontAsync({ family: "Adobe Clean", style: "Regular" }),
-          figma.loadFontAsync({ family: "Adobe Clean", style: "Bold" })
-        ]);
-        const propDefs = specSet.componentPropertyDefinitions;
-        const axes = Object.entries(propDefs).filter(([, d]) => d.type === "VARIANT").map(([name, d]) => ({ name, values: d.variantOptions }));
-        const [vBg, vBorderSubtle, vBodySubtle, vSubheading, vKnockout] = await Promise.all([
-          figma.variables.getVariableByIdAsync(DARK_VAR.bgKnockout),
-          figma.variables.getVariableByIdAsync(DARK_VAR.borderSubtle),
-          figma.variables.getVariableByIdAsync(DARK_VAR.cBodySubtle),
-          figma.variables.getVariableByIdAsync(DARK_VAR.cSubheading),
-          figma.variables.getVariableByIdAsync(DARK_VAR.cKnockout)
-        ]);
-        await figma.loadAllPagesAsync();
-        const splitComp = figma.root.findOne(
-          (n) => n.type === "COMPONENT" && n.name === ".Surface Split"
-        );
-        const colls = await figma.variables.getLocalVariableCollectionsAsync();
-        const coll = colls.find((c) => c.id === DARK_VAR.collectionId);
-        const darkId = (_O = coll == null ? void 0 : coll.modes.find((m) => m.name === "Dark")) == null ? void 0 : _O.modeId;
-        const lightId = (_Q = (_P = coll == null ? void 0 : coll.modes.find((m) => m.name === "Light")) == null ? void 0 : _P.modeId) != null ? _Q : coll == null ? void 0 : coll.defaultModeId;
-        const originX = specSet.x + specSet.width + 200;
-        const originY = specSet.y;
-        const OW = 2400;
-        const s1 = makeDarkSection2(specSet.name, OW, originX, originY);
-        s1.setCy(160);
-        s1.mkTxt(specSet.name, "Adobe Clean Display", "Bold", 56, vKnockout, s1.CW);
-        s1.gap(24);
-        const subtitle = `${variants.length} variant${variants.length !== 1 ? "s" : ""}` + (axes.length ? "  \xB7  " + axes.map((a) => a.name).join("  \xB7  ") : "");
-        s1.mkTxt(subtitle, "Adobe Clean", "Regular", 20, vBodySubtle, s1.BW);
-        s1.gap(24);
-        const now = /* @__PURE__ */ new Date();
-        const monthName = now.toLocaleString("en-US", { month: "long" });
-        s1.mkTxt(`${monthName} ${now.getFullYear()}  \xB7  @matt`, "Adobe Clean", "Regular", 14, vBodySubtle, 600);
-        s1.gap(80);
-        s1.divider();
-        s1.gap(56);
-        specSet.x = s1.M;
-        specSet.y = s1.getCy();
-        s1.frame.appendChild(specSet);
-        if (coll && lightId) specSet.setExplicitVariableModeForCollection(coll, lightId);
-        if (splitComp && coll) {
-          const split = splitComp.createInstance();
-          split.name = ".Surface Split";
-          const csIdx = s1.frame.children.indexOf(specSet);
-          s1.frame.insertChild(csIdx, split);
-          const SP = 40;
-          split.resizeWithoutConstraints(specSet.width + SP * 2, specSet.height + SP * 2);
-          split.x = specSet.x - SP;
-          split.y = specSet.y - SP;
-          split.clearExplicitVariableModeForCollection(coll);
-        }
-        s1.setCy(s1.getCy() + specSet.height);
-        s1.gap(56);
-        s1.divider();
-        s1.gap(56);
-        s1.mkTxt("Properties", "Adobe Clean", "Bold", 18, vSubheading, s1.CW);
-        s1.gap(12);
-        if (axes.length) {
-          s1.mkTxt(axes.map((a) => `${a.name}: ${a.values.join(", ")}`).join("   \xB7   "), "Adobe Clean", "Regular", 18, vBodySubtle, s1.BW);
-          s1.gap(32);
-        }
-        if (opts.children) {
-          const childMap = /* @__PURE__ */ new Map();
-          const allInstances = [];
-          for (const v of variants)
-            for (const n of [v, ...v.findAll(() => true)])
-              if (n.type === "INSTANCE") allInstances.push(n);
-          const mains = await Promise.all(allInstances.map((inst) => inst.getMainComponentAsync().catch(() => null)));
-          for (const main of mains) {
-            if (((_R = main == null ? void 0 : main.parent) == null ? void 0 : _R.type) === "COMPONENT_SET") {
-              const isSelf = specSet.type === "COMPONENT_SET" ? main.parent.id === specSet.id : main.id === specSet.id;
-              if (!isSelf) childMap.set(main.parent.id, main.parent);
-            }
-          }
-          if (childMap.size > 0) {
-            s1.gap(24);
-            s1.mkTxt("Uses", "Adobe Clean", "Bold", 18, vSubheading, s1.CW);
-            s1.gap(12);
-            s1.mkTxt([...childMap.values()].map((cs) => cs.name).join("   \xB7   "), "Adobe Clean", "Regular", 18, vBodySubtle, s1.BW);
-          }
-        }
-        s1.finish();
-        const allCreated = [s1.sec];
-        if (opts.tokens) {
-          const maxCompW = Math.max(...variants.map((v) => v.width));
-          const VW = Math.max(800, maxCompW + 600);
-          const varSecX = originX + OW + 120;
-          let varSecY = originY;
-          for (const variant of variants) {
-            const readableName = variant.name.split(", ").map((p) => {
-              var _a2;
-              return (_a2 = p.split("=")[1]) != null ? _a2 : p;
-            }).join("  \xB7  ");
-            const vs = makeDarkSection2(`${specSet.name} \u2014 ${readableName}`, VW, varSecX, varSecY);
-            vs.setCy(60);
-            vs.mkTxt(readableName, "Adobe Clean", "Bold", 18, vSubheading);
-            vs.gap(6);
-            vs.mkTxt(specSet.name, "Adobe Clean", "Regular", 13, vBodySubtle);
-            vs.gap(24);
-            vs.divider();
-            const contentAreaY = vs.getCy();
-            const annotPad = Math.max(240, variant.height * 4);
-            vs.gap(annotPad);
-            const inst = variant.createInstance();
-            inst.x = vs.M;
-            inst.y = vs.getCy();
-            vs.frame.appendChild(inst);
-            if (coll && lightId) inst.setExplicitVariableModeForCollection(coll, lightId);
-            annotateTree2(inst);
-            vs.setCy(vs.getCy() + inst.height);
-            vs.gap(annotPad);
-            vs.finish(0);
-            if (splitComp && coll) {
-              const split = splitComp.createInstance();
-              split.name = ".Surface Split";
-              const instIdx = vs.frame.children.indexOf(inst);
-              vs.frame.insertChild(Math.max(0, instIdx), split);
-              split.resizeWithoutConstraints(VW, vs.sec.height - contentAreaY);
-              split.x = 0;
-              split.y = contentAreaY;
-              split.clearExplicitVariableModeForCollection(coll);
-            }
-            allCreated.push(vs.sec);
-            varSecY += vs.sec.height + 240;
-          }
-        }
-        figma.currentPage.selection = allCreated;
-        figma.viewport.scrollAndZoomIntoView(allCreated);
-        figma.ui.postMessage({ type: "spec:result", variantCount: variants.length });
-      } catch (e) {
-        figma.ui.postMessage({ type: "spec:result", error: e.message || String(e) });
-      }
-      break;
-    }
     case "bridge:command": {
       const requestId = msg.requestId;
       const method2 = msg.method;
@@ -1745,6 +647,215 @@ figma.ui.onmessage = async (msg) => {
         figma.ui.postMessage(__spreadValues({ type: "bridge:command-result", requestId, success: true }, result2));
       } catch (e) {
         figma.ui.postMessage({ type: "bridge:command-result", requestId, success: false, error: e.message || String(e) });
+      }
+      break;
+    }
+    case "bento:generate": {
+      try {
+        const setId = msg.setId;
+        const node = await figma.getNodeByIdAsync(setId);
+        if (!node || node.type !== "COMPONENT_SET") {
+          figma.ui.postMessage({ type: "bento:result", error: "Select a component set first" });
+          break;
+        }
+        const set = node;
+        await Promise.all([
+          figma.loadFontAsync({ family: "Adobe Clean Display", style: "Bold" }),
+          figma.loadFontAsync({ family: "Adobe Clean", style: "Regular" }),
+          figma.loadFontAsync({ family: "Adobe Clean", style: "Bold" })
+        ]);
+        await figma.loadAllPagesAsync();
+        const tplPage = figma.root.children.find((p) => p.name === "\u{1F4D0} Templates");
+        const template = tplPage == null ? void 0 : tplPage.children.find((c) => c.name === "Bento Doc Template");
+        if (!template) {
+          figma.ui.postMessage({ type: "bento:result", error: 'Template not found \u2014 add "Bento Doc Template" to the "\u{1F4D0} Templates" page' });
+          break;
+        }
+        const bColls = await figma.variables.getLocalVariableCollectionsAsync();
+        const themeColl = bColls.find((c) => c.id === "VariableCollectionId:6:17");
+        const darkModeId = (_w = themeColl == null ? void 0 : themeColl.modes.find((m) => m.name === "Dark")) == null ? void 0 : _w.modeId;
+        const [cLabel, cCaption, cBody] = await Promise.all([
+          figma.variables.getVariableByIdAsync("VariableID:2483:41392"),
+          // content/label
+          figma.variables.getVariableByIdAsync("VariableID:2483:41395"),
+          // content/caption
+          figma.variables.getVariableByIdAsync("VariableID:2483:41396")
+          // content/body-subtle
+        ]);
+        const meta = parseMetaFence(set.description || "");
+        const doc = template.clone();
+        doc.name = `${set.name} \xB7 Docs`;
+        const container = set.parent;
+        container.appendChild(doc);
+        doc.x = set.x + set.width + 200;
+        doc.y = set.y;
+        const find = (name) => doc.findOne((n) => n.name === name);
+        async function setText(name, value) {
+          const t = find(name);
+          if (!t || t.type !== "TEXT" || value == null) return;
+          const tn = t;
+          const fonts = tn.getRangeAllFontNames(0, Math.max(1, tn.characters.length));
+          for (const f of fonts) await figma.loadFontAsync(f);
+          tn.characters = value;
+        }
+        await setText("@hero-name", set.name);
+        await setText("@hero-desc", meta.description || "One-line description of what this component is and when to use it.");
+        await setText("@version", meta.version || "0.0.0");
+        await setText("@status", meta.status || "active");
+        await setText("@updated", meta.updated ? `updated ${meta.updated}` : "updated \u2014");
+        await setText("@changelog", meta.changelog || "changelog\n  \u2014");
+        if (meta.goodToKnow) await setText("@good-to-know", meta.goodToKnow);
+        if (meta.accessibility) await setText("@accessibility", meta.accessibility);
+        const variants = set.children.filter((c) => c.type === "COMPONENT");
+        const defaultVariant = pickDefaultVariant(variants);
+        const heroSlot = find("@slot-hero");
+        if (heroSlot && defaultVariant) {
+          clearBentoSlot(heroSlot);
+          heroSlot.clipsContent = false;
+          heroSlot.paddingTop = 20;
+          heroSlot.paddingBottom = 20;
+          heroSlot.counterAxisSizingMode = "AUTO";
+          heroSlot.appendChild(defaultVariant.createInstance());
+        }
+        if (defaultVariant) await setText("@anatomy", anatomyList(defaultVariant));
+        const propsSlot = find("@properties");
+        if (propsSlot) {
+          clearBentoSlot(propsSlot);
+          propsSlot.strokes = [];
+          propsSlot.dashPattern = [];
+          propsSlot.fills = [];
+          propsSlot.layoutMode = "VERTICAL";
+          propsSlot.primaryAxisAlignItems = "MIN";
+          propsSlot.counterAxisAlignItems = "MIN";
+          propsSlot.itemSpacing = 8;
+          propsSlot.paddingTop = 0;
+          propsSlot.paddingBottom = 0;
+          propsSlot.paddingLeft = 0;
+          propsSlot.paddingRight = 0;
+          for (const [rawName, def] of Object.entries(set.componentPropertyDefinitions)) {
+            const nm = rawName.split("#")[0];
+            const opts = def.variantOptions;
+            const line = `${nm}  \xB7  ${String(def.type).toLowerCase()}` + (opts ? "  \xB7  " + opts.join(" / ") : "");
+            const t = figma.createText();
+            t.fontName = { family: "Adobe Clean", style: "Regular" };
+            t.fontSize = 14;
+            t.characters = line;
+            t.textAutoResize = "HEIGHT";
+            propsSlot.appendChild(t);
+            t.layoutSizingHorizontal = "FILL";
+            if (cBody) bfv(t, cBody);
+          }
+          propsSlot.primaryAxisSizingMode = "AUTO";
+        }
+        const gridSlot = find("@slot-all-variants");
+        if (gridSlot && variants.length) {
+          clearBentoSlot(gridSlot);
+          gridSlot.strokes = [];
+          gridSlot.dashPattern = [];
+          gridSlot.fills = [];
+          gridSlot.layoutMode = "NONE";
+          gridSlot.clipsContent = false;
+          const items = variants.map((v) => ({
+            v,
+            props: parseVariantProps(v.name),
+            nx: 0,
+            ny: 0,
+            w: Math.round(v.width),
+            h: Math.round(v.height),
+            rx: Math.round(v.x),
+            ry: Math.round(v.y)
+          }));
+          const minX = Math.min(...items.map((i) => i.rx));
+          const minY = Math.min(...items.map((i) => i.ry));
+          for (const it of items) {
+            it.nx = it.rx - minX;
+            it.ny = it.ry - minY;
+          }
+          const propNames = Array.from(new Set(items.flatMap((i) => Object.keys(i.props))));
+          const varying = propNames.filter((p) => new Set(items.map((i) => i.props[p])).size > 1);
+          const yReps = clusterPositions(items.map((i) => i.ny), 6);
+          const rowOf = (ny) => {
+            var _a2;
+            return (_a2 = yReps.find((y) => Math.abs(y - ny) <= 6)) != null ? _a2 : ny;
+          };
+          const rowProps = varying.filter(
+            (p) => yReps.every((y) => new Set(items.filter((i) => rowOf(i.ny) === y).map((i) => i.props[p])).size === 1)
+          );
+          const colProps = varying.filter((p) => !rowProps.includes(p));
+          const GUTTER_Y = 34;
+          const rowLabels = [];
+          for (const y of yReps) {
+            const rep = items.find((i) => rowOf(i.ny) === y);
+            const txt = rowProps.map((p) => rep.props[p]).filter(Boolean).join(" \xB7 ");
+            if (!txt) continue;
+            const t = mkAxisLabel(txt, "Bold", 12, cLabel);
+            gridSlot.appendChild(t);
+            rowLabels.push({ t, y, h: rep.h });
+          }
+          const maxLW = rowLabels.length ? Math.max(...rowLabels.map((r) => r.t.width)) : 0;
+          const GUTTER_X = Math.max(56, Math.round(maxLW) + 24);
+          let maxRight = 0, maxBottom = 0;
+          for (const it of items) {
+            const inst = it.v.createInstance();
+            gridSlot.appendChild(inst);
+            inst.x = GUTTER_X + it.nx;
+            inst.y = GUTTER_Y + it.ny;
+            maxRight = Math.max(maxRight, inst.x + it.w);
+            maxBottom = Math.max(maxBottom, inst.y + it.h);
+          }
+          for (const r of rowLabels) {
+            r.t.x = GUTTER_X - 16 - r.t.width;
+            r.t.y = GUTTER_Y + r.y + Math.round(r.h / 2) - Math.round(r.t.height / 2);
+          }
+          const topY = Math.min(...yReps);
+          const topRow = items.filter((i) => rowOf(i.ny) === topY).sort((a, b) => a.nx - b.nx);
+          for (const it of topRow) {
+            const txt = colProps.map((p) => it.props[p]).filter(Boolean).join(" \xB7 ");
+            if (!txt) continue;
+            const t = mkAxisLabel(txt, "Regular", 11, cCaption);
+            gridSlot.appendChild(t);
+            t.x = GUTTER_X + it.nx;
+            t.y = GUTTER_Y - 22;
+          }
+          gridSlot.resize(Math.max(maxRight + 24, gridSlot.width), maxBottom + 24);
+        }
+        const slotsRow = doc.findOne((n) => n.name === "row: slots");
+        if (slotsRow) slotsRow.visible = setUsesNativeSlots(set);
+        const darkSlot = find("@slot-dark-preview");
+        if (darkSlot && gridSlot) {
+          clearBentoSlot(darkSlot);
+          darkSlot.strokes = [];
+          darkSlot.dashPattern = [];
+          darkSlot.fills = [];
+          darkSlot.layoutMode = "NONE";
+          darkSlot.clipsContent = false;
+          const gclone = gridSlot.clone();
+          darkSlot.appendChild(gclone);
+          gclone.x = 0;
+          gclone.y = 0;
+          if (themeColl && darkModeId) gclone.setExplicitVariableModeForCollection(themeColl, darkModeId);
+          darkSlot.resize(Math.max(darkSlot.width, gclone.width), gclone.height + 8);
+        }
+        for (const child of doc.children) {
+          if (child.type === "FRAME") {
+            const f = child;
+            if (f.layoutMode === "VERTICAL") f.primaryAxisSizingMode = "AUTO";
+            else if (f.layoutMode === "HORIZONTAL") f.counterAxisSizingMode = "AUTO";
+          }
+        }
+        doc.primaryAxisSizingMode = "AUTO";
+        const page = pageOfNode(set);
+        if (page && page !== figma.currentPage) await figma.setCurrentPageAsync(page);
+        figma.currentPage.selection = [doc];
+        figma.viewport.scrollAndZoomIntoView([doc]);
+        figma.ui.postMessage({
+          type: "bento:result",
+          nodeId: doc.id,
+          variantCount: variants.length,
+          warning: meta.hadFence ? void 0 : "No s2a:meta fence in the set description \u2014 used placeholders for version / changelog / prose"
+        });
+      } catch (e) {
+        figma.ui.postMessage({ type: "bento:result", error: e.message || String(e) });
       }
       break;
     }

--- a/apps/s2a-toolkit/dist/code.js
+++ b/apps/s2a-toolkit/dist/code.js
@@ -330,7 +330,7 @@ function pickDefaultVariant(variants) {
   }
   return best;
 }
-function clearBentoSlot(frame) {
+function clearDocSlot(frame) {
   for (const c of [...frame.children]) c.remove();
 }
 function anatomyList(comp) {
@@ -650,12 +650,12 @@ figma.ui.onmessage = async (msg) => {
       }
       break;
     }
-    case "bento:generate": {
+    case "doc:generate": {
       try {
         const setId = msg.setId;
         const node = await figma.getNodeByIdAsync(setId);
         if (!node || node.type !== "COMPONENT_SET") {
-          figma.ui.postMessage({ type: "bento:result", error: "Select a component set first" });
+          figma.ui.postMessage({ type: "doc:result", error: "Select a component set first" });
           break;
         }
         const set = node;
@@ -666,9 +666,9 @@ figma.ui.onmessage = async (msg) => {
         ]);
         await figma.loadAllPagesAsync();
         const tplPage = figma.root.children.find((p) => p.name === "\u{1F4D0} Templates");
-        const template = tplPage == null ? void 0 : tplPage.children.find((c) => c.name === "Bento Doc Template");
+        const template = tplPage == null ? void 0 : tplPage.children.find((c) => c.name === "Doc Template");
         if (!template) {
-          figma.ui.postMessage({ type: "bento:result", error: 'Template not found \u2014 add "Bento Doc Template" to the "\u{1F4D0} Templates" page' });
+          figma.ui.postMessage({ type: "doc:result", error: 'Template not found \u2014 add "Doc Template" to the "\u{1F4D0} Templates" page' });
           break;
         }
         const bColls = await figma.variables.getLocalVariableCollectionsAsync();
@@ -710,7 +710,7 @@ figma.ui.onmessage = async (msg) => {
         const defaultVariant = pickDefaultVariant(variants);
         const heroSlot = find("@slot-hero");
         if (heroSlot && defaultVariant) {
-          clearBentoSlot(heroSlot);
+          clearDocSlot(heroSlot);
           heroSlot.clipsContent = false;
           heroSlot.paddingTop = 20;
           heroSlot.paddingBottom = 20;
@@ -720,7 +720,7 @@ figma.ui.onmessage = async (msg) => {
         if (defaultVariant) await setText("@anatomy", anatomyList(defaultVariant));
         const propsSlot = find("@properties");
         if (propsSlot) {
-          clearBentoSlot(propsSlot);
+          clearDocSlot(propsSlot);
           propsSlot.strokes = [];
           propsSlot.dashPattern = [];
           propsSlot.fills = [];
@@ -749,7 +749,7 @@ figma.ui.onmessage = async (msg) => {
         }
         const gridSlot = find("@slot-all-variants");
         if (gridSlot && variants.length) {
-          clearBentoSlot(gridSlot);
+          clearDocSlot(gridSlot);
           gridSlot.strokes = [];
           gridSlot.dashPattern = [];
           gridSlot.fills = [];
@@ -823,7 +823,7 @@ figma.ui.onmessage = async (msg) => {
         if (slotsRow) slotsRow.visible = setUsesNativeSlots(set);
         const darkSlot = find("@slot-dark-preview");
         if (darkSlot && gridSlot) {
-          clearBentoSlot(darkSlot);
+          clearDocSlot(darkSlot);
           darkSlot.strokes = [];
           darkSlot.dashPattern = [];
           darkSlot.fills = [];
@@ -849,13 +849,13 @@ figma.ui.onmessage = async (msg) => {
         figma.currentPage.selection = [doc];
         figma.viewport.scrollAndZoomIntoView([doc]);
         figma.ui.postMessage({
-          type: "bento:result",
+          type: "doc:result",
           nodeId: doc.id,
           variantCount: variants.length,
           warning: meta.hadFence ? void 0 : "No s2a:meta fence in the set description \u2014 used placeholders for version / changelog / prose"
         });
       } catch (e) {
-        figma.ui.postMessage({ type: "bento:result", error: e.message || String(e) });
+        figma.ui.postMessage({ type: "doc:result", error: e.message || String(e) });
       }
       break;
     }

--- a/apps/s2a-toolkit/dist/ui-bundle.js
+++ b/apps/s2a-toolkit/dist/ui-bundle.js
@@ -65,10 +65,9 @@
     return Object.entries(lastUsed).sort((a, b) => b[1] - a[1]).slice(0, n).map(([id]) => FEATURES.find((f) => f.id === id)).filter(Boolean);
   }
   var annotateNodeId = null;
+  var llmCaptureNodeId = null;
   var selectSetId = null;
-  var specSetId = null;
-  var variablesCache = null;
-  var githubSettings = null;
+  var bentoSetId = null;
   var bridgeConnected = false;
   var bridgeWs = null;
   var bridgeWsPort = null;
@@ -77,22 +76,15 @@
   var bridgeReconnectAttempts = 0;
   var bridgeUserDisconnected = false;
   var activePanel = "home";
-  var settingsOpen = false;
   var isMini = false;
   var popoverOpen = false;
   var pendingRequests = /* @__PURE__ */ new Map();
   var requestCounter = 0;
   var panelEls = {
     home: document.getElementById("homePanel"),
-    tokens: document.getElementById("tokensPanel"),
-    tools: document.getElementById("toolsPanel"),
-    settings: document.getElementById("settingsPanel")
+    tools: document.getElementById("toolsPanel")
   };
   function switchPanel(panel) {
-    if (panel !== "settings") {
-      settingsOpen = false;
-      settingsBtn == null ? void 0 : settingsBtn.classList.remove("active");
-    }
     activePanel = panel;
     Object.entries(panelEls).forEach(([key, el]) => {
       el.classList.toggle("active", key === panel);
@@ -100,7 +92,6 @@
     document.querySelectorAll(".tab[data-panel]").forEach((tab) => {
       tab.classList.toggle("active", tab.dataset.panel === panel);
     });
-    if (panel === "settings") postToPlugin("get-settings");
     if (panel === "home") renderHomeView();
   }
   document.querySelectorAll(".tab[data-panel]").forEach((tab) => {
@@ -109,57 +100,7 @@
       if (p) switchPanel(p);
     });
   });
-  var settingsBtn = document.getElementById("settingsBtn");
-  settingsBtn == null ? void 0 : settingsBtn.addEventListener("click", () => {
-    if (settingsOpen) {
-      settingsOpen = false;
-      settingsBtn.classList.remove("active");
-      switchPanel(activePanel === "settings" ? "home" : activePanel);
-    } else {
-      settingsOpen = true;
-      settingsBtn.classList.add("active");
-      switchPanel("settings");
-    }
-  });
   var FEATURES = [
-    // Tokens
-    {
-      id: "tokens:refresh",
-      name: "Refresh variables",
-      description: "Re-fetch all Figma variables from the current file",
-      category: "Tokens",
-      uiAction: () => {
-        var _a13;
-        return (_a13 = document.getElementById("varRefreshBtn")) == null ? void 0 : _a13.click();
-      }
-    },
-    {
-      id: "tokens:export-local",
-      name: "Export tokens locally",
-      description: "Push token JSON to local dev server on port 9300",
-      category: "Tokens",
-      uiAction: () => {
-        var _a13;
-        return (_a13 = document.getElementById("varExportLocalBtn")) == null ? void 0 : _a13.click();
-      }
-    },
-    {
-      id: "tokens:export-github",
-      name: "Push tokens to GitHub",
-      description: "Commit token JSON to your configured repo",
-      category: "Tokens",
-      uiAction: () => {
-        var _a13;
-        return (_a13 = document.getElementById("varExportGithubBtn")) == null ? void 0 : _a13.click();
-      }
-    },
-    {
-      id: "tokens:doc-gen",
-      name: "Generate token docs",
-      description: "Build a Figma doc sheet for a token group",
-      category: "Tokens",
-      uiAction: () => switchPanel("tokens")
-    },
     // Tools
     {
       id: "tools:copy-link",
@@ -167,9 +108,16 @@
       description: "Copy a shareable link for the selected node(s)",
       category: "Tools",
       uiAction: () => {
-        var _a13;
-        return (_a13 = document.getElementById("copyNodeBtn")) == null ? void 0 : _a13.click();
+        var _a9;
+        return (_a9 = document.getElementById("copyNodeBtn")) == null ? void 0 : _a9.click();
       }
+    },
+    {
+      id: "tools:llm-capture",
+      name: "Send screenshot to LLM",
+      description: "Capture the selected node and send image + metadata to the local LLM bridge",
+      category: "Tools",
+      uiAction: () => switchPanel("tools")
     },
     {
       id: "tools:format-section",
@@ -202,9 +150,9 @@
       }
     },
     {
-      id: "tools:spec",
-      name: "Generate spec sheet",
-      description: "Scaffold a Figma spec doc for a component set",
+      id: "tools:bento",
+      name: "Generate bento doc",
+      description: "Build a full bento documentation page for the selected component set",
       category: "Tools",
       uiAction: () => switchPanel("tools")
     },
@@ -225,21 +173,20 @@
     }
   ];
   var QUICK_ACTION_IDS = [
+    "tools:llm-capture",
     "tools:copy-link",
-    "tokens:refresh",
     "tools:annotate",
     "tools:select-filter",
-    "tokens:export-local",
-    "tools:spec"
+    "tools:bento"
   ];
   function fireFeature(feat) {
-    var _a13;
+    var _a9;
     logEvent(feat.id);
     closePalette();
     if (feat.uiAction) {
       feat.uiAction();
     } else if (feat.pluginAction) {
-      postToPlugin(feat.pluginAction, (_a13 = feat.pluginPayload) != null ? _a13 : {});
+      postToPlugin(feat.pluginAction, (_a9 = feat.pluginPayload) != null ? _a9 : {});
     }
     if (activePanel === "home") renderHomeView();
   }
@@ -331,12 +278,12 @@
   }
   paletteInput.addEventListener("input", () => filterPalette(paletteInput.value));
   paletteInput.addEventListener("keydown", (e) => {
-    var _a13, _b;
+    var _a9, _b;
     if (e.key === "ArrowDown") {
       e.preventDefault();
       paletteSelected = Math.min(paletteSelected + 1, paletteFiltered.length - 1);
       renderPalette();
-      (_a13 = paletteList.querySelector(`[data-selected="true"]`)) == null ? void 0 : _a13.scrollIntoView({ block: "nearest" });
+      (_a9 = paletteList.querySelector(`[data-selected="true"]`)) == null ? void 0 : _a9.scrollIntoView({ block: "nearest" });
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       paletteSelected = Math.max(paletteSelected - 1, 0);
@@ -375,7 +322,7 @@
   var _copyFileName = null;
   var _copyAllNodes = [];
   function copyToClipboard(text) {
-    var _a13;
+    var _a9;
     const ta = document.createElement("textarea");
     ta.value = text;
     ta.style.cssText = "position:fixed;left:-9999px;top:-9999px;opacity:0";
@@ -388,7 +335,7 @@
     }
     document.body.removeChild(ta);
     try {
-      (_a13 = navigator.clipboard) == null ? void 0 : _a13.writeText(text).catch(() => {
+      (_a9 = navigator.clipboard) == null ? void 0 : _a9.writeText(text).catch(() => {
       });
     } catch (e) {
     }
@@ -432,6 +379,51 @@
     copyToClipboard(urls.join("\n"));
     const msg = urls.length > 1 ? `Copied ${urls.length} links` : "Copied link";
     postToPlugin("notify", { message: msg });
+  });
+  function setLlmCaptureStatus(msg, type = "") {
+    const el = document.getElementById("llmCaptureStatus");
+    el.textContent = msg;
+    el.className = "status" + (type ? " " + type : "");
+  }
+  function updateLlmCaptureSelection(sel) {
+    var _a9;
+    llmCaptureNodeId = (_a9 = sel == null ? void 0 : sel.id) != null ? _a9 : null;
+    const emptyEl = document.getElementById("llmCaptureSelectionEmpty");
+    const infoEl = document.getElementById("llmCaptureSelectionInfo");
+    const nameEl = document.getElementById("llmCaptureNodeName");
+    const typeEl = document.getElementById("llmCaptureNodeType");
+    const sendBtn = document.getElementById("llmCaptureSendBtn");
+    if (sel) {
+      emptyEl.style.display = "none";
+      infoEl.style.display = "flex";
+      nameEl.textContent = sel.name;
+      typeEl.textContent = sel.nodeType;
+      sendBtn.disabled = false;
+    } else {
+      emptyEl.style.display = "block";
+      infoEl.style.display = "none";
+      sendBtn.disabled = true;
+    }
+  }
+  async function pollLlmCaptureJob(jobId) {
+    for (; ; ) {
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+      const res = await fetch(`http://localhost:4002/jobs/${encodeURIComponent(jobId)}`);
+      if (!res.ok) throw new Error(`Job status failed (${res.status})`);
+      const job = await res.json();
+      if (job.phase) setLlmCaptureStatus(job.phase);
+      if (job.status === "done") return job.result;
+      if (job.status === "error") throw new Error(job.error || "LLM job failed");
+    }
+  }
+  var _a2;
+  (_a2 = document.getElementById("llmCaptureSendBtn")) == null ? void 0 : _a2.addEventListener("click", () => {
+    if (!llmCaptureNodeId) return;
+    const btn = document.getElementById("llmCaptureSendBtn");
+    btn.disabled = true;
+    btn.textContent = "Capturing\u2026";
+    setLlmCaptureStatus("Capturing selected node\u2026");
+    postToPlugin("llm-capture:selection", { maxDimension: 2048 });
   });
   var sectionBar = document.getElementById("sectionBar");
   var sectionBarName = document.getElementById("sectionBarName");
@@ -544,9 +536,6 @@
     sendBridgeCommand("REFRESH_VARIABLES", {}, 3e4).then((result) => {
       if (ws.readyState !== 1 || !(result == null ? void 0 : result.data)) return;
       ws.send(JSON.stringify({ type: "VARIABLES_DATA", data: result.data }));
-      renderVariables(result.data);
-      renderTokenGroups(result.data);
-      setVarMeta(result.data.variables.length + " variables");
     }).catch(() => {
     });
   }
@@ -687,215 +676,6 @@
     bridgeReconnectAttempts = 0;
     updateBridgeUi();
   }
-  function getTokenGroup(name) {
-    var _a13;
-    const parts = name.split("/").filter((p) => p !== "s2a");
-    if (parts.length >= 4 && parts[1] === "transparent") return parts[0] + " / " + parts[1] + " / " + parts[2];
-    if (parts.length >= 3) return parts[0] + " / " + parts[1];
-    return (_a13 = parts[0]) != null ? _a13 : name;
-  }
-  function setVarMeta(_text) {
-  }
-  function setVarStatus(msg, type = "") {
-    const el = document.getElementById("varStatus");
-    el.textContent = msg;
-    el.className = "status" + (type ? " " + type : "");
-  }
-  function updateExportButtons() {
-    const localBtn = document.getElementById("varExportLocalBtn");
-    const githubBtn = document.getElementById("varExportGithubBtn");
-    const hasVars = !!variablesCache;
-    const hasGhSettings = !!((githubSettings == null ? void 0 : githubSettings.token) && (githubSettings == null ? void 0 : githubSettings.owner) && (githubSettings == null ? void 0 : githubSettings.repo));
-    if (localBtn) localBtn.disabled = !hasVars;
-    if (githubBtn) githubBtn.disabled = !hasVars || !hasGhSettings;
-  }
-  function renderVariables(data) {
-    variablesCache = data;
-    const el = document.getElementById("varCollections");
-    if (!el) return;
-    if (data.variableCollections.length === 0) {
-      el.innerHTML = '<div class="empty-state">No collections found</div>';
-      return;
-    }
-    const byCol = {};
-    for (const v of data.variables) byCol[v.variableCollectionId] = (byCol[v.variableCollectionId] || 0) + 1;
-    el.innerHTML = data.variableCollections.map(
-      (c) => `<div class="collection-row">
-      <span class="collection-name">${esc(c.name)}</span>
-      <span class="collection-count">${byCol[c.id] || 0}</span>
-    </div>`
-    ).join("");
-    updateExportButtons();
-  }
-  function renderTokenGroups(data) {
-    const labelEl = document.getElementById("tokenGroupLabel");
-    const listEl = document.getElementById("tokenGroupList");
-    if (!listEl) return;
-    const semanticColls = data.variableCollections.filter(
-      (c) => /Semantic|Responsive/.test(c.name) || /Primitives/.test(c.name) && /Color/.test(c.name) || /Primitives/.test(c.name) && /Dimension/.test(c.name)
-    );
-    if (semanticColls.length === 0) {
-      listEl.innerHTML = "";
-      if (labelEl) labelEl.classList.add("hidden");
-      return;
-    }
-    const collIdToName = /* @__PURE__ */ new Map();
-    for (const c of data.variableCollections) collIdToName.set(c.id, c.name);
-    const collSet = new Set(semanticColls.map((c) => c.id));
-    const groups = /* @__PURE__ */ new Map();
-    for (const v of data.variables) {
-      if (!collSet.has(v.variableCollectionId)) continue;
-      const collName = collIdToName.get(v.variableCollectionId) || "";
-      const grp = getTokenGroup(v.name);
-      if (/Primitives/.test(collName) && /Dimension/.test(collName) && grp !== "opacity") continue;
-      const key = v.variableCollectionId + "::" + grp;
-      if (!groups.has(key)) {
-        groups.set(key, { collectionId: v.variableCollectionId, collectionName: collName, group: grp, count: 0 });
-      }
-      groups.get(key).count++;
-    }
-    const sorted = [...groups.values()].sort((a, b) => {
-      if (a.collectionName !== b.collectionName) return a.collectionName.localeCompare(b.collectionName);
-      return a.group.localeCompare(b.group);
-    });
-    if (labelEl) labelEl.classList.remove("hidden");
-    listEl.innerHTML = sorted.map(
-      (g) => `<div class="collection-row token-group-row" data-col="${esc(g.collectionId)}" data-group="${esc(g.group)}">
-      <span class="collection-name">${esc(g.group)}</span>
-      <span class="collection-count">${g.count}</span>
-      <button class="gen-btn" title="Generate docs for ${esc(g.group)}">\u2192</button>
-    </div>`
-    ).join("");
-    listEl.insertAdjacentHTML(
-      "beforeend",
-      `<div class="collection-row token-group-row" style="margin-top:6px;padding-top:6px;border-top:1px solid rgba(255,255,255,0.08)" data-col="text-styles" data-group="text-styles">
-      <span class="collection-name">Text Styles</span>
-      <span class="collection-count">\u2014</span>
-      <button class="gen-btn" title="Generate 4 breakpoint sections from native text styles">\u2192</button>
-    </div>`
-    );
-  }
-  var _a2;
-  (_a2 = document.getElementById("tokenGroupList")) == null ? void 0 : _a2.addEventListener("click", (e) => {
-    var _a13;
-    const btn = e.target.closest(".gen-btn");
-    if (!btn || btn.disabled) return;
-    const row = btn.closest(".token-group-row");
-    if (!row) return;
-    btn.disabled = true;
-    btn.textContent = "\u2026";
-    setVarStatus("Generating " + ((_a13 = row.dataset.group) != null ? _a13 : "") + "\u2026");
-    postToPlugin("token-docs:generate", { collectionId: row.dataset.col, group: row.dataset.group });
-  });
-  var _a3;
-  (_a3 = document.getElementById("varRefreshBtn")) == null ? void 0 : _a3.addEventListener("click", async () => {
-    const btn = document.getElementById("varRefreshBtn");
-    btn.textContent = "Refreshing\u2026";
-    btn.disabled = true;
-    setVarStatus("Loading\u2026");
-    try {
-      const result = await sendBridgeCommand("REFRESH_VARIABLES", {}, 3e4);
-      if (result == null ? void 0 : result.data) {
-        renderVariables(result.data);
-        renderTokenGroups(result.data);
-        setVarStatus(result.data.variables.length + " variables loaded", "ok");
-      } else {
-        setVarStatus("No data returned", "err");
-      }
-    } catch (e) {
-      setVarStatus(e.message || "Error", "err");
-    } finally {
-      btn.textContent = "Refresh";
-      btn.disabled = false;
-    }
-  });
-  var _a4;
-  (_a4 = document.getElementById("varExportLocalBtn")) == null ? void 0 : _a4.addEventListener("click", () => {
-    if (!variablesCache) {
-      setVarStatus("No variables \u2014 hit Refresh first", "err");
-      return;
-    }
-    const btn = document.getElementById("varExportLocalBtn");
-    btn.textContent = "Exporting\u2026";
-    btn.disabled = true;
-    setVarStatus("Sending to dev-server\u2026");
-    fetch("http://localhost:9300/export", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(variablesCache)
-    }).then((r) => r.json()).then((data) => {
-      if (data.ok) setVarStatus(`\u2713 ${data.variables} vars \u2192 dist/css/`, "ok");
-      else setVarStatus("\u274C " + (data.error || "Build failed"), "err");
-    }).catch(() => setVarStatus("\u274C Dev server not running \u2014 run: npm run dev-server", "err")).finally(() => {
-      btn.textContent = "Local";
-      updateExportButtons();
-    });
-  });
-  var _a5;
-  (_a5 = document.getElementById("varExportGithubBtn")) == null ? void 0 : _a5.addEventListener("click", async () => {
-    if (!variablesCache || !(githubSettings == null ? void 0 : githubSettings.token)) return;
-    const btn = document.getElementById("varExportGithubBtn");
-    btn.textContent = "Pushing\u2026";
-    btn.disabled = true;
-    setVarStatus("Pushing to GitHub\u2026");
-    try {
-      await pushToGitHub(variablesCache, githubSettings);
-      setVarStatus("\u2713 Committed to " + githubSettings.repo + " / " + githubSettings.branch, "ok");
-    } catch (e) {
-      setVarStatus("\u274C " + (e.message || "GitHub push failed"), "err");
-    } finally {
-      btn.textContent = "\u2191 GitHub";
-      updateExportButtons();
-    }
-  });
-  async function pushToGitHub(data, settings) {
-    const { token, owner, repo, branch, filePath } = settings;
-    const apiBase = `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}`;
-    const headers = {
-      Authorization: `token ${token}`,
-      Accept: "application/vnd.github.v3+json",
-      "Content-Type": "application/json"
-    };
-    let sha;
-    const getRes = await fetch(`${apiBase}?ref=${branch}`, { headers });
-    if (getRes.ok) sha = (await getRes.json()).sha;
-    else if (getRes.status !== 404) throw new Error((await getRes.json()).message || `GitHub ${getRes.status}`);
-    const content = btoa(unescape(encodeURIComponent(JSON.stringify(data, null, 2))));
-    const body = { message: "chore: sync tokens from Figma", content, branch };
-    if (sha) body.sha = sha;
-    const putRes = await fetch(apiBase, { method: "PUT", headers, body: JSON.stringify(body) });
-    if (!putRes.ok) throw new Error((await putRes.json()).message || `GitHub ${putRes.status}`);
-  }
-  function setSettingsStatus(msg, type = "") {
-    const el = document.getElementById("settingsStatus");
-    el.textContent = msg;
-    el.className = "status" + (type ? " " + type : "");
-  }
-  function applySettings(settings) {
-    githubSettings = settings;
-    if (!settings) return;
-    document.getElementById("ghToken").value = settings.token || "";
-    document.getElementById("ghOwner").value = settings.owner || "";
-    document.getElementById("ghRepo").value = settings.repo || "";
-    document.getElementById("ghBranch").value = settings.branch || "main";
-    document.getElementById("ghFilePath").value = settings.filePath || "packages/toolkit-tokens/json/figma-export.json";
-    updateExportButtons();
-  }
-  var _a6;
-  (_a6 = document.getElementById("saveSettingsBtn")) == null ? void 0 : _a6.addEventListener("click", () => {
-    const settings = {
-      token: document.getElementById("ghToken").value.trim(),
-      owner: document.getElementById("ghOwner").value.trim(),
-      repo: document.getElementById("ghRepo").value.trim(),
-      branch: document.getElementById("ghBranch").value.trim() || "main",
-      filePath: document.getElementById("ghFilePath").value.trim() || "packages/toolkit-tokens/json/figma-export.json"
-    };
-    if (!settings.token || !settings.owner || !settings.repo) {
-      setSettingsStatus("Token, owner, and repo are required", "err");
-      return;
-    }
-    postToPlugin("save-settings", { settings });
-  });
   function renderAxes(setId, setName, axes) {
     selectSetId = setId;
     const emptyEl = document.getElementById("selectEmpty");
@@ -929,8 +709,8 @@
     document.getElementById("selectEmpty").style.display = "block";
     document.getElementById("selectBody").style.display = "none";
   }
-  var _a7;
-  (_a7 = document.getElementById("selectApplyBtn")) == null ? void 0 : _a7.addEventListener("click", () => {
+  var _a3;
+  (_a3 = document.getElementById("selectApplyBtn")) == null ? void 0 : _a3.addEventListener("click", () => {
     if (!selectSetId) return;
     const filter = {};
     document.querySelectorAll(".chip.on[data-axis]").forEach((chip) => {
@@ -940,12 +720,12 @@
     });
     postToPlugin("select:apply-filter", { setId: selectSetId, filter });
   });
-  var _a8;
-  (_a8 = document.getElementById("selectAllBtn")) == null ? void 0 : _a8.addEventListener("click", () => {
+  var _a4;
+  (_a4 = document.getElementById("selectAllBtn")) == null ? void 0 : _a4.addEventListener("click", () => {
     document.querySelectorAll("#selectAxes .chip").forEach((c) => c.classList.add("on"));
   });
-  var _a9;
-  (_a9 = document.getElementById("selectNoneBtn")) == null ? void 0 : _a9.addEventListener("click", () => {
+  var _a5;
+  (_a5 = document.getElementById("selectNoneBtn")) == null ? void 0 : _a5.addEventListener("click", () => {
     document.querySelectorAll("#selectAxes .chip").forEach((c) => c.classList.remove("on"));
   });
   function setAnnotateStatus(msg, type = "") {
@@ -954,8 +734,8 @@
     el.className = "status" + (type ? " " + type : "");
   }
   function updateAnnotateSelection(sel) {
-    var _a13;
-    annotateNodeId = (_a13 = sel == null ? void 0 : sel.id) != null ? _a13 : null;
+    var _a9;
+    annotateNodeId = (_a9 = sel == null ? void 0 : sel.id) != null ? _a9 : null;
     const emptyEl = document.getElementById("annotateSelectionEmpty");
     const infoEl = document.getElementById("annotateSelectionInfo");
     const nameEl = document.getElementById("annotateNodeName");
@@ -976,8 +756,8 @@
   document.querySelectorAll("#annotateCats .chip").forEach((chip) => {
     chip.addEventListener("click", () => chip.classList.toggle("on"));
   });
-  var _a10;
-  (_a10 = document.getElementById("annotateApplyBtn")) == null ? void 0 : _a10.addEventListener("click", () => {
+  var _a6;
+  (_a6 = document.getElementById("annotateApplyBtn")) == null ? void 0 : _a6.addEventListener("click", () => {
     if (!annotateNodeId) return;
     const categories = Array.from(
       document.querySelectorAll("#annotateCats .chip.on")
@@ -992,64 +772,51 @@
     setAnnotateStatus("");
     postToPlugin("annotate:apply", { nodeId: annotateNodeId, categories });
   });
-  var _a11;
-  (_a11 = document.getElementById("annotateClearBtn")) == null ? void 0 : _a11.addEventListener("click", () => {
+  var _a7;
+  (_a7 = document.getElementById("annotateClearBtn")) == null ? void 0 : _a7.addEventListener("click", () => {
     if (!annotateNodeId) return;
     const btn = document.getElementById("annotateClearBtn");
     btn.disabled = true;
     setAnnotateStatus("Clearing\u2026");
     postToPlugin("annotate:clear", { nodeId: annotateNodeId });
   });
-  function setSpecStatus(msg, type = "") {
-    const el = document.getElementById("specStatus");
+  function setBentoStatus(msg, type = "") {
+    const el = document.getElementById("bentoStatus");
     el.textContent = msg;
     el.className = "status" + (type ? " " + type : "");
   }
-  function updateSpecSelection(sel) {
-    var _a13, _b;
-    const isValid = (sel == null ? void 0 : sel.nodeType) === "COMPONENT_SET" || (sel == null ? void 0 : sel.nodeType) === "COMPONENT";
-    specSetId = isValid ? (_a13 = sel == null ? void 0 : sel.id) != null ? _a13 : null : null;
-    const emptyEl = document.getElementById("specSelectionEmpty");
-    const infoEl = document.getElementById("specSelectionInfo");
-    const nameEl = document.getElementById("specSetName");
-    const countEl = document.getElementById("specSetCount");
-    const genBtn = document.getElementById("specGenerateBtn");
-    if (isValid && sel) {
+  function updateBentoSelection(sel) {
+    var _a9, _b;
+    const isSet = (sel == null ? void 0 : sel.nodeType) === "COMPONENT_SET";
+    bentoSetId = isSet ? (_a9 = sel == null ? void 0 : sel.id) != null ? _a9 : null : null;
+    const emptyEl = document.getElementById("bentoSelectionEmpty");
+    const infoEl = document.getElementById("bentoSelectionInfo");
+    const nameEl = document.getElementById("bentoSetName");
+    const countEl = document.getElementById("bentoSetCount");
+    const btn = document.getElementById("bentoGenerateBtn");
+    if (isSet && sel) {
       emptyEl.style.display = "none";
       infoEl.style.display = "flex";
       nameEl.textContent = sel.name;
-      countEl.textContent = sel.nodeType === "COMPONENT_SET" ? ((_b = sel.variantCount) != null ? _b : 0) + " variants" : "1 variant";
-      genBtn.disabled = false;
+      countEl.textContent = ((_b = sel.variantCount) != null ? _b : 0) + " variants";
+      btn.disabled = false;
     } else {
       emptyEl.style.display = "block";
       infoEl.style.display = "none";
-      genBtn.disabled = true;
+      btn.disabled = true;
     }
   }
-  document.querySelectorAll("#specOpts .chip").forEach((chip) => {
-    chip.addEventListener("click", () => chip.classList.toggle("on"));
-  });
-  var _a12;
-  (_a12 = document.getElementById("specGenerateBtn")) == null ? void 0 : _a12.addEventListener("click", () => {
-    if (!specSetId) return;
-    const on = new Set(
-      Array.from(document.querySelectorAll("#specOpts .chip.on")).map((c) => c.dataset.opt)
-    );
-    if (on.size === 0) {
-      setSpecStatus("Select at least one section to include", "err");
-      return;
-    }
-    const btn = document.getElementById("specGenerateBtn");
+  var _a8;
+  (_a8 = document.getElementById("bentoGenerateBtn")) == null ? void 0 : _a8.addEventListener("click", () => {
+    if (!bentoSetId) return;
+    const btn = document.getElementById("bentoGenerateBtn");
     btn.disabled = true;
     btn.textContent = "Generating\u2026";
-    setSpecStatus("");
-    postToPlugin("spec:generate", {
-      setId: specSetId,
-      options: { variants: on.has("variants"), tokens: on.has("tokens"), children: on.has("children") }
-    });
+    setBentoStatus("");
+    postToPlugin("bento:generate", { setId: bentoSetId });
   });
   window.addEventListener("message", (event) => {
-    var _a13, _b;
+    var _a9, _b, _c;
     const msg = event.data.pluginMessage;
     if (!msg) return;
     switch (msg.type) {
@@ -1066,25 +833,6 @@
           } else {
             p.reject(new Error(msg.error || "Unknown error"));
           }
-        }
-        break;
-      }
-      case "settings-loaded":
-        applySettings(msg.settings);
-        break;
-      case "settings-saved": {
-        if (msg.success) {
-          githubSettings = {
-            token: document.getElementById("ghToken").value.trim(),
-            owner: document.getElementById("ghOwner").value.trim(),
-            repo: document.getElementById("ghRepo").value.trim(),
-            branch: document.getElementById("ghBranch").value.trim() || "main",
-            filePath: document.getElementById("ghFilePath").value.trim() || "packages/toolkit-tokens/json/figma-export.json"
-          };
-          setSettingsStatus("Saved", "ok");
-          updateExportButtons();
-        } else {
-          setSettingsStatus("Save failed: " + msg.error, "err");
         }
         break;
       }
@@ -1109,29 +857,60 @@
             nodeType: msg.nodeType,
             variantCount: msg.variantCount
           };
+          updateLlmCaptureSelection(sel);
           updateAnnotateSelection(sel);
-          updateSpecSelection(sel);
+          updateBentoSelection(sel);
           updateCopyBtn(sel, msg.fileKey, msg.fileName, msg.allNodes);
           updateSectionBar(
             !!msg.isSection,
-            (_a13 = msg.sectionCount) != null ? _a13 : 0,
+            (_a9 = msg.sectionCount) != null ? _a9 : 0,
             (_b = msg.sectionName) != null ? _b : sel.name
           );
         } else {
+          updateLlmCaptureSelection(null);
           updateAnnotateSelection(null);
-          updateSpecSelection(null);
+          updateBentoSelection(null);
           updateCopyBtn(null, null);
           updateSectionBar(false, 0, "");
         }
         break;
       }
-      case "token-docs:result": {
-        document.querySelectorAll(".gen-btn").forEach((b) => {
-          b.disabled = false;
-          b.textContent = "\u2192";
+      case "llm-capture:result": {
+        const btn = document.getElementById("llmCaptureSendBtn");
+        const resetBtn = () => {
+          btn.disabled = !llmCaptureNodeId;
+          btn.textContent = "Send Screenshot";
+        };
+        if (msg.error) {
+          resetBtn();
+          setLlmCaptureStatus("\u274C " + msg.error, "err");
+          break;
+        }
+        const capture = msg.capture;
+        const prompt = (((_c = document.getElementById("llmCapturePrompt")) == null ? void 0 : _c.value) || "").trim();
+        setLlmCaptureStatus("Sending image + metadata to local LLM bridge\u2026");
+        btn.textContent = "Sending\u2026";
+        fetch("http://localhost:4002/llm/capture", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            capture,
+            prompt: prompt || "Inspect this Figma selection and summarize the layout, visual system, tokens, and implementation notes."
+          })
+        }).then(async (res) => {
+          const data = await res.json().catch(() => ({}));
+          if (!res.ok) throw new Error(data.error || `LLM bridge returned ${res.status}`);
+          if (data.jobId) return pollLlmCaptureJob(data.jobId);
+          return data;
+        }).then((result) => {
+          const label = (result == null ? void 0 : result.fileName) ? `\u2713 Sent \xB7 ${result.fileName}` : (result == null ? void 0 : result.title) ? `\u2713 Sent \xB7 ${result.title}` : "\u2713 Sent to LLM";
+          setLlmCaptureStatus(label, "ok");
+          resetBtn();
+        }).catch((e) => {
+          const hint = /Failed to fetch|NetworkError|Load failed/i.test(e.message || "") ? "Local LLM bridge is not running. Run: npm run figma-story" : e.message || "Capture failed";
+          setLlmCaptureStatus("\u274C " + hint, "err");
+          resetBtn();
         });
-        if (msg.error) setVarStatus("\u274C " + msg.error, "err");
-        else setVarStatus("\u2713 " + msg.count + " tokens documented", "ok");
         break;
       }
       case "format-section:done": {
@@ -1157,21 +936,21 @@
         setAnnotateStatus(n > 0 ? `Cleared ${n} annotation${n !== 1 ? "s" : ""}` : "Nothing to clear", "ok");
         break;
       }
-      case "spec:result": {
-        const btn = document.getElementById("specGenerateBtn");
-        btn.disabled = !specSetId;
-        btn.textContent = "Generate Spec";
-        if (msg.error) setSpecStatus("\u274C " + msg.error, "err");
+      case "bento:result": {
+        const btn = document.getElementById("bentoGenerateBtn");
+        btn.disabled = !bentoSetId;
+        btn.textContent = "Generate bento doc";
+        if (msg.error) setBentoStatus("\u274C " + msg.error, "err");
         else {
           const vars = msg.variantCount;
-          setSpecStatus(`\u2713 Spec generated \xB7 ${vars} variant${vars !== 1 ? "s" : ""}`, "ok");
+          const warn = msg.warning ? " \xB7 \u26A0 " + msg.warning : "";
+          setBentoStatus(`\u2713 Bento doc generated \xB7 ${vars} variant${vars !== 1 ? "s" : ""}${warn}`, "ok");
         }
         break;
       }
     }
   });
   postToPlugin("ui-ready");
-  postToPlugin("get-settings");
   postToPlugin("resize-for-view", { width: 320, height: 460 });
   renderHomeView();
   document.addEventListener("visibilitychange", () => {

--- a/apps/s2a-toolkit/dist/ui-bundle.js
+++ b/apps/s2a-toolkit/dist/ui-bundle.js
@@ -67,7 +67,7 @@
   var annotateNodeId = null;
   var llmCaptureNodeId = null;
   var selectSetId = null;
-  var bentoSetId = null;
+  var docSetId = null;
   var bridgeConnected = false;
   var bridgeWs = null;
   var bridgeWsPort = null;
@@ -150,9 +150,9 @@
       }
     },
     {
-      id: "tools:bento",
-      name: "Generate bento doc",
-      description: "Build a full bento documentation page for the selected component set",
+      id: "tools:doc",
+      name: "Generate component doc",
+      description: "Build a full component documentation page for the selected component set",
       category: "Tools",
       uiAction: () => switchPanel("tools")
     },
@@ -177,7 +177,7 @@
     "tools:copy-link",
     "tools:annotate",
     "tools:select-filter",
-    "tools:bento"
+    "tools:doc"
   ];
   function fireFeature(feat) {
     var _a9;
@@ -780,20 +780,20 @@
     setAnnotateStatus("Clearing\u2026");
     postToPlugin("annotate:clear", { nodeId: annotateNodeId });
   });
-  function setBentoStatus(msg, type = "") {
-    const el = document.getElementById("bentoStatus");
+  function setDocStatus(msg, type = "") {
+    const el = document.getElementById("docStatus");
     el.textContent = msg;
     el.className = "status" + (type ? " " + type : "");
   }
-  function updateBentoSelection(sel) {
+  function updateDocSelection(sel) {
     var _a9, _b;
     const isSet = (sel == null ? void 0 : sel.nodeType) === "COMPONENT_SET";
-    bentoSetId = isSet ? (_a9 = sel == null ? void 0 : sel.id) != null ? _a9 : null : null;
-    const emptyEl = document.getElementById("bentoSelectionEmpty");
-    const infoEl = document.getElementById("bentoSelectionInfo");
-    const nameEl = document.getElementById("bentoSetName");
-    const countEl = document.getElementById("bentoSetCount");
-    const btn = document.getElementById("bentoGenerateBtn");
+    docSetId = isSet ? (_a9 = sel == null ? void 0 : sel.id) != null ? _a9 : null : null;
+    const emptyEl = document.getElementById("docSelectionEmpty");
+    const infoEl = document.getElementById("docSelectionInfo");
+    const nameEl = document.getElementById("docSetName");
+    const countEl = document.getElementById("docSetCount");
+    const btn = document.getElementById("docGenerateBtn");
     if (isSet && sel) {
       emptyEl.style.display = "none";
       infoEl.style.display = "flex";
@@ -807,13 +807,13 @@
     }
   }
   var _a8;
-  (_a8 = document.getElementById("bentoGenerateBtn")) == null ? void 0 : _a8.addEventListener("click", () => {
-    if (!bentoSetId) return;
-    const btn = document.getElementById("bentoGenerateBtn");
+  (_a8 = document.getElementById("docGenerateBtn")) == null ? void 0 : _a8.addEventListener("click", () => {
+    if (!docSetId) return;
+    const btn = document.getElementById("docGenerateBtn");
     btn.disabled = true;
     btn.textContent = "Generating\u2026";
-    setBentoStatus("");
-    postToPlugin("bento:generate", { setId: bentoSetId });
+    setDocStatus("");
+    postToPlugin("doc:generate", { setId: docSetId });
   });
   window.addEventListener("message", (event) => {
     var _a9, _b, _c;
@@ -859,7 +859,7 @@
           };
           updateLlmCaptureSelection(sel);
           updateAnnotateSelection(sel);
-          updateBentoSelection(sel);
+          updateDocSelection(sel);
           updateCopyBtn(sel, msg.fileKey, msg.fileName, msg.allNodes);
           updateSectionBar(
             !!msg.isSection,
@@ -869,7 +869,7 @@
         } else {
           updateLlmCaptureSelection(null);
           updateAnnotateSelection(null);
-          updateBentoSelection(null);
+          updateDocSelection(null);
           updateCopyBtn(null, null);
           updateSectionBar(false, 0, "");
         }
@@ -936,15 +936,15 @@
         setAnnotateStatus(n > 0 ? `Cleared ${n} annotation${n !== 1 ? "s" : ""}` : "Nothing to clear", "ok");
         break;
       }
-      case "bento:result": {
-        const btn = document.getElementById("bentoGenerateBtn");
-        btn.disabled = !bentoSetId;
-        btn.textContent = "Generate bento doc";
-        if (msg.error) setBentoStatus("\u274C " + msg.error, "err");
+      case "doc:result": {
+        const btn = document.getElementById("docGenerateBtn");
+        btn.disabled = !docSetId;
+        btn.textContent = "Generate component doc";
+        if (msg.error) setDocStatus("\u274C " + msg.error, "err");
         else {
           const vars = msg.variantCount;
           const warn = msg.warning ? " \xB7 \u26A0 " + msg.warning : "";
-          setBentoStatus(`\u2713 Bento doc generated \xB7 ${vars} variant${vars !== 1 ? "s" : ""}${warn}`, "ok");
+          setDocStatus(`\u2713 Component doc generated \xB7 ${vars} variant${vars !== 1 ? "s" : ""}${warn}`, "ok");
         }
         break;
       }

--- a/apps/s2a-toolkit/dist/ui.html
+++ b/apps/s2a-toolkit/dist/ui.html
@@ -350,47 +350,6 @@ body {
   line-height: 1.7;
 }
 
-/* ── Variables / Tokens ─────────────────────────────────────────────────── */
-
-.collection-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 8px 0;
-  border-bottom: 1px solid var(--border);
-  gap: 8px;
-}
-.collection-row:last-child { border-bottom: none; }
-.collection-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-1); font-size: 12px; }
-.collection-count {
-  font-size: 10px;
-  color: var(--text-3);
-  font-variant-numeric: tabular-nums;
-  flex-shrink: 0;
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 1px 6px;
-}
-
-.gen-btn {
-  flex-shrink: 0;
-  width: 22px;
-  height: 22px;
-  padding: 0;
-  font-size: 12px;
-  background: transparent;
-  color: var(--text-3);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: color 0.1s, border-color 0.1s;
-}
-.gen-btn:hover:not(:disabled) { color: var(--text-1); border-color: var(--border-md); }
-.gen-btn:disabled { opacity: 0.35; cursor: default; }
 
 /* ── Select ─────────────────────────────────────────────────────────────── */
 
@@ -453,10 +412,6 @@ body {
 
 /* ── Settings ───────────────────────────────────────────────────────────── */
 
-.settings-hint { font-size: 11px; color: var(--text-2); margin-bottom: 14px; line-height: 1.5; }
-.settings-hint a { color: var(--accent); text-decoration: none; }
-.settings-hint a:hover { text-decoration: underline; }
-.settings-hint code { font-family: 'Menlo', monospace; font-size: 10px; background: var(--bg); padding: 1px 4px; border-radius: 3px; border: 1px solid var(--border); }
 
 .form-field { margin-bottom: 10px; }
 .form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
@@ -476,6 +431,12 @@ body {
 }
 .form-input:focus { border-color: var(--accent); }
 .form-input::placeholder { color: var(--text-3); }
+.form-textarea {
+  min-height: 68px;
+  resize: vertical;
+  line-height: 1.45;
+}
+.llm-field { margin-top: 10px; margin-bottom: 0; }
 
 /* ── Section bar btn ─────────────────────────────────────────────────────── */
 
@@ -490,7 +451,6 @@ body {
 
 /* ── Settings gear active ───────────────────────────────────────────────── */
 
-#settingsBtn.active { color: var(--accent); background: var(--accent-bg); }
 
 .hidden { display: none !important; }
 
@@ -671,6 +631,7 @@ body {
   background: var(--border);
   margin: 16px -12px;
 }
+
 </style>
 </head>
 <body>
@@ -700,12 +661,6 @@ body {
       <button class="bridge-pill" id="bridgeTabBtn" aria-label="Claude Code bridge status">
         <span class="bridge-dot" id="bridgeDot"></span>
         <span class="bridge-label" id="bridgePillLabel">Connect</span>
-      </button>
-      <button class="icon-btn full-only" id="settingsBtn" title="Settings" aria-label="Settings">
-        <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
-          <circle cx="7" cy="7" r="2" stroke="currentColor" stroke-width="1.25"/>
-          <path d="M7 1.5v1.2M7 11.3v1.2M1.5 7h1.2M11.3 7h1.2M3.2 3.2l.85.85M9.95 9.95l.85.85M3.2 10.8l.85-.85M9.95 4.05l.85-.85" stroke="currentColor" stroke-width="1.25" stroke-linecap="round"/>
-        </svg>
       </button>
       <button class="icon-btn" id="toggleMiniBtn" aria-label="Minimize plugin">
         <svg class="icon-collapse" width="13" height="13" viewBox="0 0 14 14" fill="none">
@@ -754,14 +709,6 @@ body {
       </svg>
       <span class="tab-label">Home</span>
     </button>
-    <!-- Tokens -->
-    <button class="tab" data-panel="tokens" aria-label="Tokens">
-      <svg class="tab-icon" width="13" height="13" viewBox="0 0 14 14" fill="none">
-        <rect x="1.5" y="3" width="11" height="2.5" rx="1.25" stroke="currentColor" stroke-width="1.2"/>
-        <rect x="1.5" y="8" width="7.5" height="2.5" rx="1.25" stroke="currentColor" stroke-width="1.2"/>
-      </svg>
-      <span class="tab-label">Tokens</span>
-    </button>
     <!-- Tools -->
     <button class="tab" data-panel="tools" aria-label="Tools">
       <svg class="tab-icon" width="13" height="13" viewBox="0 0 14 14" fill="none">
@@ -789,24 +736,31 @@ body {
       </div>
     </div>
 
-    <!-- Tokens (was Variables) -->
-    <div class="panel" id="tokensPanel">
-      <div class="section-label">Collections</div>
-      <div id="varCollections">
-        <div class="empty-state">Click Refresh to load collections</div>
-      </div>
-      <div class="section-label hidden" id="tokenGroupLabel" style="margin-top:14px;">Token groups</div>
-      <div id="tokenGroupList"></div>
-      <div class="btn-row">
-        <button class="btn btn-ghost" id="varRefreshBtn">Refresh</button>
-        <button class="btn btn-ghost" id="varExportLocalBtn" disabled>Local</button>
-        <button class="btn" id="varExportGithubBtn" disabled>↑ GitHub</button>
-      </div>
-      <div class="status" id="varStatus"></div>
-    </div>
-
     <!-- Tools — select + annotate + spec stacked -->
     <div class="panel" id="toolsPanel">
+
+      <!-- ── LLM capture ─────────────────────────────────────────────── -->
+      <div class="section-label">LLM capture</div>
+      <div class="sel-card">
+        <span class="sel-card-empty" id="llmCaptureSelectionEmpty">Select a frame or section</span>
+        <div class="sel-card-info" id="llmCaptureSelectionInfo" style="display:none;">
+          <span class="sel-icon">◈</span>
+          <div class="sel-meta">
+            <span class="sel-name" id="llmCaptureNodeName">—</span>
+            <span class="sel-type" id="llmCaptureNodeType">—</span>
+          </div>
+        </div>
+      </div>
+      <div class="form-field llm-field">
+        <label class="form-label" for="llmCapturePrompt">Prompt</label>
+        <textarea class="form-input form-textarea" id="llmCapturePrompt" rows="3" placeholder="Ask the LLM what to inspect or generate from this selection."></textarea>
+      </div>
+      <div class="btn-row">
+        <button class="btn" id="llmCaptureSendBtn" disabled style="flex:1;">Send Screenshot</button>
+      </div>
+      <div class="status" id="llmCaptureStatus"></div>
+
+      <div class="tools-divider"></div>
 
       <!-- ── Variant Filter ──────────────────────────────────────────── -->
       <div class="section-label">Variant filter</div>
@@ -854,62 +808,25 @@ body {
 
       <div class="tools-divider"></div>
 
-      <!-- ── Spec sheet ──────────────────────────────────────────────── -->
-      <div class="section-label">Spec sheet</div>
+      <!-- ── Bento doc ───────────────────────────────────────────────── -->
+      <div class="section-label">Bento doc</div>
       <div class="sel-card">
-        <span class="sel-card-empty" id="specSelectionEmpty">Select a component or set</span>
-        <div class="sel-card-info" id="specSelectionInfo" style="display:none;">
-          <span class="sel-icon">◈</span>
+        <span class="sel-card-empty" id="bentoSelectionEmpty">Select a component set</span>
+        <div class="sel-card-info" id="bentoSelectionInfo" style="display:none;">
+          <span class="sel-icon">▤</span>
           <div class="sel-meta">
-            <span class="sel-name" id="specSetName">—</span>
-            <span class="sel-type" id="specSetCount">—</span>
+            <span class="sel-name" id="bentoSetName">—</span>
+            <span class="sel-type" id="bentoSetCount">—</span>
           </div>
         </div>
       </div>
-      <div class="chip-grid" id="specOpts" style="margin-top:10px;">
-        <button class="chip on" data-opt="variants">Variants</button>
-        <button class="chip on" data-opt="tokens">Tokens</button>
-        <button class="chip on" data-opt="children">Children</button>
-      </div>
       <div class="btn-row">
-        <button class="btn" id="specGenerateBtn" disabled style="flex:1;">Generate Spec</button>
+        <button class="btn" id="bentoGenerateBtn" disabled style="flex:1;">Generate bento doc</button>
       </div>
-      <div class="status" id="specStatus"></div>
+      <div class="status" id="bentoStatus"></div>
 
       <!-- bottom padding for scroll clearance -->
       <div style="height:16px;"></div>
-    </div>
-
-    <!-- Settings (gear icon only) -->
-    <div class="panel" id="settingsPanel">
-      <div class="section-label">GitHub Export</div>
-      <p class="settings-hint">Tokens commit directly to your repo. Needs a <a href="https://github.com/settings/tokens" target="_blank">Personal Access Token</a> with <code>repo</code> scope.</p>
-      <div class="form-field">
-        <label class="form-label" for="ghToken">Token</label>
-        <input class="form-input" type="password" id="ghToken" placeholder="ghp_…" autocomplete="off" />
-      </div>
-      <div class="form-row">
-        <div class="form-field">
-          <label class="form-label" for="ghOwner">Owner</label>
-          <input class="form-input" type="text" id="ghOwner" placeholder="adobecom" />
-        </div>
-        <div class="form-field">
-          <label class="form-label" for="ghRepo">Repo</label>
-          <input class="form-input" type="text" id="ghRepo" placeholder="consonant-2" />
-        </div>
-      </div>
-      <div class="form-field">
-        <label class="form-label" for="ghBranch">Branch</label>
-        <input class="form-input" type="text" id="ghBranch" placeholder="main" />
-      </div>
-      <div class="form-field">
-        <label class="form-label" for="ghFilePath">File path</label>
-        <input class="form-input" type="text" id="ghFilePath" placeholder="packages/toolkit-tokens/json/figma-export.json" />
-      </div>
-      <div class="btn-row">
-        <button class="btn" id="saveSettingsBtn">Save</button>
-      </div>
-      <div class="status" id="settingsStatus"></div>
     </div>
 
   </div>
@@ -994,10 +911,9 @@ body {
     return Object.entries(lastUsed).sort((a, b) => b[1] - a[1]).slice(0, n).map(([id]) => FEATURES.find((f) => f.id === id)).filter(Boolean);
   }
   var annotateNodeId = null;
+  var llmCaptureNodeId = null;
   var selectSetId = null;
-  var specSetId = null;
-  var variablesCache = null;
-  var githubSettings = null;
+  var bentoSetId = null;
   var bridgeConnected = false;
   var bridgeWs = null;
   var bridgeWsPort = null;
@@ -1006,22 +922,15 @@ body {
   var bridgeReconnectAttempts = 0;
   var bridgeUserDisconnected = false;
   var activePanel = "home";
-  var settingsOpen = false;
   var isMini = false;
   var popoverOpen = false;
   var pendingRequests = /* @__PURE__ */ new Map();
   var requestCounter = 0;
   var panelEls = {
     home: document.getElementById("homePanel"),
-    tokens: document.getElementById("tokensPanel"),
-    tools: document.getElementById("toolsPanel"),
-    settings: document.getElementById("settingsPanel")
+    tools: document.getElementById("toolsPanel")
   };
   function switchPanel(panel) {
-    if (panel !== "settings") {
-      settingsOpen = false;
-      settingsBtn == null ? void 0 : settingsBtn.classList.remove("active");
-    }
     activePanel = panel;
     Object.entries(panelEls).forEach(([key, el]) => {
       el.classList.toggle("active", key === panel);
@@ -1029,7 +938,6 @@ body {
     document.querySelectorAll(".tab[data-panel]").forEach((tab) => {
       tab.classList.toggle("active", tab.dataset.panel === panel);
     });
-    if (panel === "settings") postToPlugin("get-settings");
     if (panel === "home") renderHomeView();
   }
   document.querySelectorAll(".tab[data-panel]").forEach((tab) => {
@@ -1038,57 +946,7 @@ body {
       if (p) switchPanel(p);
     });
   });
-  var settingsBtn = document.getElementById("settingsBtn");
-  settingsBtn == null ? void 0 : settingsBtn.addEventListener("click", () => {
-    if (settingsOpen) {
-      settingsOpen = false;
-      settingsBtn.classList.remove("active");
-      switchPanel(activePanel === "settings" ? "home" : activePanel);
-    } else {
-      settingsOpen = true;
-      settingsBtn.classList.add("active");
-      switchPanel("settings");
-    }
-  });
   var FEATURES = [
-    // Tokens
-    {
-      id: "tokens:refresh",
-      name: "Refresh variables",
-      description: "Re-fetch all Figma variables from the current file",
-      category: "Tokens",
-      uiAction: () => {
-        var _a13;
-        return (_a13 = document.getElementById("varRefreshBtn")) == null ? void 0 : _a13.click();
-      }
-    },
-    {
-      id: "tokens:export-local",
-      name: "Export tokens locally",
-      description: "Push token JSON to local dev server on port 9300",
-      category: "Tokens",
-      uiAction: () => {
-        var _a13;
-        return (_a13 = document.getElementById("varExportLocalBtn")) == null ? void 0 : _a13.click();
-      }
-    },
-    {
-      id: "tokens:export-github",
-      name: "Push tokens to GitHub",
-      description: "Commit token JSON to your configured repo",
-      category: "Tokens",
-      uiAction: () => {
-        var _a13;
-        return (_a13 = document.getElementById("varExportGithubBtn")) == null ? void 0 : _a13.click();
-      }
-    },
-    {
-      id: "tokens:doc-gen",
-      name: "Generate token docs",
-      description: "Build a Figma doc sheet for a token group",
-      category: "Tokens",
-      uiAction: () => switchPanel("tokens")
-    },
     // Tools
     {
       id: "tools:copy-link",
@@ -1096,9 +954,16 @@ body {
       description: "Copy a shareable link for the selected node(s)",
       category: "Tools",
       uiAction: () => {
-        var _a13;
-        return (_a13 = document.getElementById("copyNodeBtn")) == null ? void 0 : _a13.click();
+        var _a9;
+        return (_a9 = document.getElementById("copyNodeBtn")) == null ? void 0 : _a9.click();
       }
+    },
+    {
+      id: "tools:llm-capture",
+      name: "Send screenshot to LLM",
+      description: "Capture the selected node and send image + metadata to the local LLM bridge",
+      category: "Tools",
+      uiAction: () => switchPanel("tools")
     },
     {
       id: "tools:format-section",
@@ -1131,9 +996,9 @@ body {
       }
     },
     {
-      id: "tools:spec",
-      name: "Generate spec sheet",
-      description: "Scaffold a Figma spec doc for a component set",
+      id: "tools:bento",
+      name: "Generate bento doc",
+      description: "Build a full bento documentation page for the selected component set",
       category: "Tools",
       uiAction: () => switchPanel("tools")
     },
@@ -1154,21 +1019,20 @@ body {
     }
   ];
   var QUICK_ACTION_IDS = [
+    "tools:llm-capture",
     "tools:copy-link",
-    "tokens:refresh",
     "tools:annotate",
     "tools:select-filter",
-    "tokens:export-local",
-    "tools:spec"
+    "tools:bento"
   ];
   function fireFeature(feat) {
-    var _a13;
+    var _a9;
     logEvent(feat.id);
     closePalette();
     if (feat.uiAction) {
       feat.uiAction();
     } else if (feat.pluginAction) {
-      postToPlugin(feat.pluginAction, (_a13 = feat.pluginPayload) != null ? _a13 : {});
+      postToPlugin(feat.pluginAction, (_a9 = feat.pluginPayload) != null ? _a9 : {});
     }
     if (activePanel === "home") renderHomeView();
   }
@@ -1260,12 +1124,12 @@ body {
   }
   paletteInput.addEventListener("input", () => filterPalette(paletteInput.value));
   paletteInput.addEventListener("keydown", (e) => {
-    var _a13, _b;
+    var _a9, _b;
     if (e.key === "ArrowDown") {
       e.preventDefault();
       paletteSelected = Math.min(paletteSelected + 1, paletteFiltered.length - 1);
       renderPalette();
-      (_a13 = paletteList.querySelector(`[data-selected="true"]`)) == null ? void 0 : _a13.scrollIntoView({ block: "nearest" });
+      (_a9 = paletteList.querySelector(`[data-selected="true"]`)) == null ? void 0 : _a9.scrollIntoView({ block: "nearest" });
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       paletteSelected = Math.max(paletteSelected - 1, 0);
@@ -1304,7 +1168,7 @@ body {
   var _copyFileName = null;
   var _copyAllNodes = [];
   function copyToClipboard(text) {
-    var _a13;
+    var _a9;
     const ta = document.createElement("textarea");
     ta.value = text;
     ta.style.cssText = "position:fixed;left:-9999px;top:-9999px;opacity:0";
@@ -1317,7 +1181,7 @@ body {
     }
     document.body.removeChild(ta);
     try {
-      (_a13 = navigator.clipboard) == null ? void 0 : _a13.writeText(text).catch(() => {
+      (_a9 = navigator.clipboard) == null ? void 0 : _a9.writeText(text).catch(() => {
       });
     } catch (e) {
     }
@@ -1361,6 +1225,51 @@ body {
     copyToClipboard(urls.join("\n"));
     const msg = urls.length > 1 ? `Copied ${urls.length} links` : "Copied link";
     postToPlugin("notify", { message: msg });
+  });
+  function setLlmCaptureStatus(msg, type = "") {
+    const el = document.getElementById("llmCaptureStatus");
+    el.textContent = msg;
+    el.className = "status" + (type ? " " + type : "");
+  }
+  function updateLlmCaptureSelection(sel) {
+    var _a9;
+    llmCaptureNodeId = (_a9 = sel == null ? void 0 : sel.id) != null ? _a9 : null;
+    const emptyEl = document.getElementById("llmCaptureSelectionEmpty");
+    const infoEl = document.getElementById("llmCaptureSelectionInfo");
+    const nameEl = document.getElementById("llmCaptureNodeName");
+    const typeEl = document.getElementById("llmCaptureNodeType");
+    const sendBtn = document.getElementById("llmCaptureSendBtn");
+    if (sel) {
+      emptyEl.style.display = "none";
+      infoEl.style.display = "flex";
+      nameEl.textContent = sel.name;
+      typeEl.textContent = sel.nodeType;
+      sendBtn.disabled = false;
+    } else {
+      emptyEl.style.display = "block";
+      infoEl.style.display = "none";
+      sendBtn.disabled = true;
+    }
+  }
+  async function pollLlmCaptureJob(jobId) {
+    for (; ; ) {
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+      const res = await fetch(`http://localhost:4002/jobs/${encodeURIComponent(jobId)}`);
+      if (!res.ok) throw new Error(`Job status failed (${res.status})`);
+      const job = await res.json();
+      if (job.phase) setLlmCaptureStatus(job.phase);
+      if (job.status === "done") return job.result;
+      if (job.status === "error") throw new Error(job.error || "LLM job failed");
+    }
+  }
+  var _a2;
+  (_a2 = document.getElementById("llmCaptureSendBtn")) == null ? void 0 : _a2.addEventListener("click", () => {
+    if (!llmCaptureNodeId) return;
+    const btn = document.getElementById("llmCaptureSendBtn");
+    btn.disabled = true;
+    btn.textContent = "Capturing\u2026";
+    setLlmCaptureStatus("Capturing selected node\u2026");
+    postToPlugin("llm-capture:selection", { maxDimension: 2048 });
   });
   var sectionBar = document.getElementById("sectionBar");
   var sectionBarName = document.getElementById("sectionBarName");
@@ -1473,9 +1382,6 @@ body {
     sendBridgeCommand("REFRESH_VARIABLES", {}, 3e4).then((result) => {
       if (ws.readyState !== 1 || !(result == null ? void 0 : result.data)) return;
       ws.send(JSON.stringify({ type: "VARIABLES_DATA", data: result.data }));
-      renderVariables(result.data);
-      renderTokenGroups(result.data);
-      setVarMeta(result.data.variables.length + " variables");
     }).catch(() => {
     });
   }
@@ -1616,215 +1522,6 @@ body {
     bridgeReconnectAttempts = 0;
     updateBridgeUi();
   }
-  function getTokenGroup(name) {
-    var _a13;
-    const parts = name.split("/").filter((p) => p !== "s2a");
-    if (parts.length >= 4 && parts[1] === "transparent") return parts[0] + " / " + parts[1] + " / " + parts[2];
-    if (parts.length >= 3) return parts[0] + " / " + parts[1];
-    return (_a13 = parts[0]) != null ? _a13 : name;
-  }
-  function setVarMeta(_text) {
-  }
-  function setVarStatus(msg, type = "") {
-    const el = document.getElementById("varStatus");
-    el.textContent = msg;
-    el.className = "status" + (type ? " " + type : "");
-  }
-  function updateExportButtons() {
-    const localBtn = document.getElementById("varExportLocalBtn");
-    const githubBtn = document.getElementById("varExportGithubBtn");
-    const hasVars = !!variablesCache;
-    const hasGhSettings = !!((githubSettings == null ? void 0 : githubSettings.token) && (githubSettings == null ? void 0 : githubSettings.owner) && (githubSettings == null ? void 0 : githubSettings.repo));
-    if (localBtn) localBtn.disabled = !hasVars;
-    if (githubBtn) githubBtn.disabled = !hasVars || !hasGhSettings;
-  }
-  function renderVariables(data) {
-    variablesCache = data;
-    const el = document.getElementById("varCollections");
-    if (!el) return;
-    if (data.variableCollections.length === 0) {
-      el.innerHTML = '<div class="empty-state">No collections found</div>';
-      return;
-    }
-    const byCol = {};
-    for (const v of data.variables) byCol[v.variableCollectionId] = (byCol[v.variableCollectionId] || 0) + 1;
-    el.innerHTML = data.variableCollections.map(
-      (c) => `<div class="collection-row">
-      <span class="collection-name">${esc(c.name)}</span>
-      <span class="collection-count">${byCol[c.id] || 0}</span>
-    </div>`
-    ).join("");
-    updateExportButtons();
-  }
-  function renderTokenGroups(data) {
-    const labelEl = document.getElementById("tokenGroupLabel");
-    const listEl = document.getElementById("tokenGroupList");
-    if (!listEl) return;
-    const semanticColls = data.variableCollections.filter(
-      (c) => /Semantic|Responsive/.test(c.name) || /Primitives/.test(c.name) && /Color/.test(c.name) || /Primitives/.test(c.name) && /Dimension/.test(c.name)
-    );
-    if (semanticColls.length === 0) {
-      listEl.innerHTML = "";
-      if (labelEl) labelEl.classList.add("hidden");
-      return;
-    }
-    const collIdToName = /* @__PURE__ */ new Map();
-    for (const c of data.variableCollections) collIdToName.set(c.id, c.name);
-    const collSet = new Set(semanticColls.map((c) => c.id));
-    const groups = /* @__PURE__ */ new Map();
-    for (const v of data.variables) {
-      if (!collSet.has(v.variableCollectionId)) continue;
-      const collName = collIdToName.get(v.variableCollectionId) || "";
-      const grp = getTokenGroup(v.name);
-      if (/Primitives/.test(collName) && /Dimension/.test(collName) && grp !== "opacity") continue;
-      const key = v.variableCollectionId + "::" + grp;
-      if (!groups.has(key)) {
-        groups.set(key, { collectionId: v.variableCollectionId, collectionName: collName, group: grp, count: 0 });
-      }
-      groups.get(key).count++;
-    }
-    const sorted = [...groups.values()].sort((a, b) => {
-      if (a.collectionName !== b.collectionName) return a.collectionName.localeCompare(b.collectionName);
-      return a.group.localeCompare(b.group);
-    });
-    if (labelEl) labelEl.classList.remove("hidden");
-    listEl.innerHTML = sorted.map(
-      (g) => `<div class="collection-row token-group-row" data-col="${esc(g.collectionId)}" data-group="${esc(g.group)}">
-      <span class="collection-name">${esc(g.group)}</span>
-      <span class="collection-count">${g.count}</span>
-      <button class="gen-btn" title="Generate docs for ${esc(g.group)}">\u2192</button>
-    </div>`
-    ).join("");
-    listEl.insertAdjacentHTML(
-      "beforeend",
-      `<div class="collection-row token-group-row" style="margin-top:6px;padding-top:6px;border-top:1px solid rgba(255,255,255,0.08)" data-col="text-styles" data-group="text-styles">
-      <span class="collection-name">Text Styles</span>
-      <span class="collection-count">\u2014</span>
-      <button class="gen-btn" title="Generate 4 breakpoint sections from native text styles">\u2192</button>
-    </div>`
-    );
-  }
-  var _a2;
-  (_a2 = document.getElementById("tokenGroupList")) == null ? void 0 : _a2.addEventListener("click", (e) => {
-    var _a13;
-    const btn = e.target.closest(".gen-btn");
-    if (!btn || btn.disabled) return;
-    const row = btn.closest(".token-group-row");
-    if (!row) return;
-    btn.disabled = true;
-    btn.textContent = "\u2026";
-    setVarStatus("Generating " + ((_a13 = row.dataset.group) != null ? _a13 : "") + "\u2026");
-    postToPlugin("token-docs:generate", { collectionId: row.dataset.col, group: row.dataset.group });
-  });
-  var _a3;
-  (_a3 = document.getElementById("varRefreshBtn")) == null ? void 0 : _a3.addEventListener("click", async () => {
-    const btn = document.getElementById("varRefreshBtn");
-    btn.textContent = "Refreshing\u2026";
-    btn.disabled = true;
-    setVarStatus("Loading\u2026");
-    try {
-      const result = await sendBridgeCommand("REFRESH_VARIABLES", {}, 3e4);
-      if (result == null ? void 0 : result.data) {
-        renderVariables(result.data);
-        renderTokenGroups(result.data);
-        setVarStatus(result.data.variables.length + " variables loaded", "ok");
-      } else {
-        setVarStatus("No data returned", "err");
-      }
-    } catch (e) {
-      setVarStatus(e.message || "Error", "err");
-    } finally {
-      btn.textContent = "Refresh";
-      btn.disabled = false;
-    }
-  });
-  var _a4;
-  (_a4 = document.getElementById("varExportLocalBtn")) == null ? void 0 : _a4.addEventListener("click", () => {
-    if (!variablesCache) {
-      setVarStatus("No variables \u2014 hit Refresh first", "err");
-      return;
-    }
-    const btn = document.getElementById("varExportLocalBtn");
-    btn.textContent = "Exporting\u2026";
-    btn.disabled = true;
-    setVarStatus("Sending to dev-server\u2026");
-    fetch("http://localhost:9300/export", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(variablesCache)
-    }).then((r) => r.json()).then((data) => {
-      if (data.ok) setVarStatus(`\u2713 ${data.variables} vars \u2192 dist/css/`, "ok");
-      else setVarStatus("\u274C " + (data.error || "Build failed"), "err");
-    }).catch(() => setVarStatus("\u274C Dev server not running \u2014 run: npm run dev-server", "err")).finally(() => {
-      btn.textContent = "Local";
-      updateExportButtons();
-    });
-  });
-  var _a5;
-  (_a5 = document.getElementById("varExportGithubBtn")) == null ? void 0 : _a5.addEventListener("click", async () => {
-    if (!variablesCache || !(githubSettings == null ? void 0 : githubSettings.token)) return;
-    const btn = document.getElementById("varExportGithubBtn");
-    btn.textContent = "Pushing\u2026";
-    btn.disabled = true;
-    setVarStatus("Pushing to GitHub\u2026");
-    try {
-      await pushToGitHub(variablesCache, githubSettings);
-      setVarStatus("\u2713 Committed to " + githubSettings.repo + " / " + githubSettings.branch, "ok");
-    } catch (e) {
-      setVarStatus("\u274C " + (e.message || "GitHub push failed"), "err");
-    } finally {
-      btn.textContent = "\u2191 GitHub";
-      updateExportButtons();
-    }
-  });
-  async function pushToGitHub(data, settings) {
-    const { token, owner, repo, branch, filePath } = settings;
-    const apiBase = `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}`;
-    const headers = {
-      Authorization: `token ${token}`,
-      Accept: "application/vnd.github.v3+json",
-      "Content-Type": "application/json"
-    };
-    let sha;
-    const getRes = await fetch(`${apiBase}?ref=${branch}`, { headers });
-    if (getRes.ok) sha = (await getRes.json()).sha;
-    else if (getRes.status !== 404) throw new Error((await getRes.json()).message || `GitHub ${getRes.status}`);
-    const content = btoa(unescape(encodeURIComponent(JSON.stringify(data, null, 2))));
-    const body = { message: "chore: sync tokens from Figma", content, branch };
-    if (sha) body.sha = sha;
-    const putRes = await fetch(apiBase, { method: "PUT", headers, body: JSON.stringify(body) });
-    if (!putRes.ok) throw new Error((await putRes.json()).message || `GitHub ${putRes.status}`);
-  }
-  function setSettingsStatus(msg, type = "") {
-    const el = document.getElementById("settingsStatus");
-    el.textContent = msg;
-    el.className = "status" + (type ? " " + type : "");
-  }
-  function applySettings(settings) {
-    githubSettings = settings;
-    if (!settings) return;
-    document.getElementById("ghToken").value = settings.token || "";
-    document.getElementById("ghOwner").value = settings.owner || "";
-    document.getElementById("ghRepo").value = settings.repo || "";
-    document.getElementById("ghBranch").value = settings.branch || "main";
-    document.getElementById("ghFilePath").value = settings.filePath || "packages/toolkit-tokens/json/figma-export.json";
-    updateExportButtons();
-  }
-  var _a6;
-  (_a6 = document.getElementById("saveSettingsBtn")) == null ? void 0 : _a6.addEventListener("click", () => {
-    const settings = {
-      token: document.getElementById("ghToken").value.trim(),
-      owner: document.getElementById("ghOwner").value.trim(),
-      repo: document.getElementById("ghRepo").value.trim(),
-      branch: document.getElementById("ghBranch").value.trim() || "main",
-      filePath: document.getElementById("ghFilePath").value.trim() || "packages/toolkit-tokens/json/figma-export.json"
-    };
-    if (!settings.token || !settings.owner || !settings.repo) {
-      setSettingsStatus("Token, owner, and repo are required", "err");
-      return;
-    }
-    postToPlugin("save-settings", { settings });
-  });
   function renderAxes(setId, setName, axes) {
     selectSetId = setId;
     const emptyEl = document.getElementById("selectEmpty");
@@ -1858,8 +1555,8 @@ body {
     document.getElementById("selectEmpty").style.display = "block";
     document.getElementById("selectBody").style.display = "none";
   }
-  var _a7;
-  (_a7 = document.getElementById("selectApplyBtn")) == null ? void 0 : _a7.addEventListener("click", () => {
+  var _a3;
+  (_a3 = document.getElementById("selectApplyBtn")) == null ? void 0 : _a3.addEventListener("click", () => {
     if (!selectSetId) return;
     const filter = {};
     document.querySelectorAll(".chip.on[data-axis]").forEach((chip) => {
@@ -1869,12 +1566,12 @@ body {
     });
     postToPlugin("select:apply-filter", { setId: selectSetId, filter });
   });
-  var _a8;
-  (_a8 = document.getElementById("selectAllBtn")) == null ? void 0 : _a8.addEventListener("click", () => {
+  var _a4;
+  (_a4 = document.getElementById("selectAllBtn")) == null ? void 0 : _a4.addEventListener("click", () => {
     document.querySelectorAll("#selectAxes .chip").forEach((c) => c.classList.add("on"));
   });
-  var _a9;
-  (_a9 = document.getElementById("selectNoneBtn")) == null ? void 0 : _a9.addEventListener("click", () => {
+  var _a5;
+  (_a5 = document.getElementById("selectNoneBtn")) == null ? void 0 : _a5.addEventListener("click", () => {
     document.querySelectorAll("#selectAxes .chip").forEach((c) => c.classList.remove("on"));
   });
   function setAnnotateStatus(msg, type = "") {
@@ -1883,8 +1580,8 @@ body {
     el.className = "status" + (type ? " " + type : "");
   }
   function updateAnnotateSelection(sel) {
-    var _a13;
-    annotateNodeId = (_a13 = sel == null ? void 0 : sel.id) != null ? _a13 : null;
+    var _a9;
+    annotateNodeId = (_a9 = sel == null ? void 0 : sel.id) != null ? _a9 : null;
     const emptyEl = document.getElementById("annotateSelectionEmpty");
     const infoEl = document.getElementById("annotateSelectionInfo");
     const nameEl = document.getElementById("annotateNodeName");
@@ -1905,8 +1602,8 @@ body {
   document.querySelectorAll("#annotateCats .chip").forEach((chip) => {
     chip.addEventListener("click", () => chip.classList.toggle("on"));
   });
-  var _a10;
-  (_a10 = document.getElementById("annotateApplyBtn")) == null ? void 0 : _a10.addEventListener("click", () => {
+  var _a6;
+  (_a6 = document.getElementById("annotateApplyBtn")) == null ? void 0 : _a6.addEventListener("click", () => {
     if (!annotateNodeId) return;
     const categories = Array.from(
       document.querySelectorAll("#annotateCats .chip.on")
@@ -1921,64 +1618,51 @@ body {
     setAnnotateStatus("");
     postToPlugin("annotate:apply", { nodeId: annotateNodeId, categories });
   });
-  var _a11;
-  (_a11 = document.getElementById("annotateClearBtn")) == null ? void 0 : _a11.addEventListener("click", () => {
+  var _a7;
+  (_a7 = document.getElementById("annotateClearBtn")) == null ? void 0 : _a7.addEventListener("click", () => {
     if (!annotateNodeId) return;
     const btn = document.getElementById("annotateClearBtn");
     btn.disabled = true;
     setAnnotateStatus("Clearing\u2026");
     postToPlugin("annotate:clear", { nodeId: annotateNodeId });
   });
-  function setSpecStatus(msg, type = "") {
-    const el = document.getElementById("specStatus");
+  function setBentoStatus(msg, type = "") {
+    const el = document.getElementById("bentoStatus");
     el.textContent = msg;
     el.className = "status" + (type ? " " + type : "");
   }
-  function updateSpecSelection(sel) {
-    var _a13, _b;
-    const isValid = (sel == null ? void 0 : sel.nodeType) === "COMPONENT_SET" || (sel == null ? void 0 : sel.nodeType) === "COMPONENT";
-    specSetId = isValid ? (_a13 = sel == null ? void 0 : sel.id) != null ? _a13 : null : null;
-    const emptyEl = document.getElementById("specSelectionEmpty");
-    const infoEl = document.getElementById("specSelectionInfo");
-    const nameEl = document.getElementById("specSetName");
-    const countEl = document.getElementById("specSetCount");
-    const genBtn = document.getElementById("specGenerateBtn");
-    if (isValid && sel) {
+  function updateBentoSelection(sel) {
+    var _a9, _b;
+    const isSet = (sel == null ? void 0 : sel.nodeType) === "COMPONENT_SET";
+    bentoSetId = isSet ? (_a9 = sel == null ? void 0 : sel.id) != null ? _a9 : null : null;
+    const emptyEl = document.getElementById("bentoSelectionEmpty");
+    const infoEl = document.getElementById("bentoSelectionInfo");
+    const nameEl = document.getElementById("bentoSetName");
+    const countEl = document.getElementById("bentoSetCount");
+    const btn = document.getElementById("bentoGenerateBtn");
+    if (isSet && sel) {
       emptyEl.style.display = "none";
       infoEl.style.display = "flex";
       nameEl.textContent = sel.name;
-      countEl.textContent = sel.nodeType === "COMPONENT_SET" ? ((_b = sel.variantCount) != null ? _b : 0) + " variants" : "1 variant";
-      genBtn.disabled = false;
+      countEl.textContent = ((_b = sel.variantCount) != null ? _b : 0) + " variants";
+      btn.disabled = false;
     } else {
       emptyEl.style.display = "block";
       infoEl.style.display = "none";
-      genBtn.disabled = true;
+      btn.disabled = true;
     }
   }
-  document.querySelectorAll("#specOpts .chip").forEach((chip) => {
-    chip.addEventListener("click", () => chip.classList.toggle("on"));
-  });
-  var _a12;
-  (_a12 = document.getElementById("specGenerateBtn")) == null ? void 0 : _a12.addEventListener("click", () => {
-    if (!specSetId) return;
-    const on = new Set(
-      Array.from(document.querySelectorAll("#specOpts .chip.on")).map((c) => c.dataset.opt)
-    );
-    if (on.size === 0) {
-      setSpecStatus("Select at least one section to include", "err");
-      return;
-    }
-    const btn = document.getElementById("specGenerateBtn");
+  var _a8;
+  (_a8 = document.getElementById("bentoGenerateBtn")) == null ? void 0 : _a8.addEventListener("click", () => {
+    if (!bentoSetId) return;
+    const btn = document.getElementById("bentoGenerateBtn");
     btn.disabled = true;
     btn.textContent = "Generating\u2026";
-    setSpecStatus("");
-    postToPlugin("spec:generate", {
-      setId: specSetId,
-      options: { variants: on.has("variants"), tokens: on.has("tokens"), children: on.has("children") }
-    });
+    setBentoStatus("");
+    postToPlugin("bento:generate", { setId: bentoSetId });
   });
   window.addEventListener("message", (event) => {
-    var _a13, _b;
+    var _a9, _b, _c;
     const msg = event.data.pluginMessage;
     if (!msg) return;
     switch (msg.type) {
@@ -1995,25 +1679,6 @@ body {
           } else {
             p.reject(new Error(msg.error || "Unknown error"));
           }
-        }
-        break;
-      }
-      case "settings-loaded":
-        applySettings(msg.settings);
-        break;
-      case "settings-saved": {
-        if (msg.success) {
-          githubSettings = {
-            token: document.getElementById("ghToken").value.trim(),
-            owner: document.getElementById("ghOwner").value.trim(),
-            repo: document.getElementById("ghRepo").value.trim(),
-            branch: document.getElementById("ghBranch").value.trim() || "main",
-            filePath: document.getElementById("ghFilePath").value.trim() || "packages/toolkit-tokens/json/figma-export.json"
-          };
-          setSettingsStatus("Saved", "ok");
-          updateExportButtons();
-        } else {
-          setSettingsStatus("Save failed: " + msg.error, "err");
         }
         break;
       }
@@ -2038,29 +1703,60 @@ body {
             nodeType: msg.nodeType,
             variantCount: msg.variantCount
           };
+          updateLlmCaptureSelection(sel);
           updateAnnotateSelection(sel);
-          updateSpecSelection(sel);
+          updateBentoSelection(sel);
           updateCopyBtn(sel, msg.fileKey, msg.fileName, msg.allNodes);
           updateSectionBar(
             !!msg.isSection,
-            (_a13 = msg.sectionCount) != null ? _a13 : 0,
+            (_a9 = msg.sectionCount) != null ? _a9 : 0,
             (_b = msg.sectionName) != null ? _b : sel.name
           );
         } else {
+          updateLlmCaptureSelection(null);
           updateAnnotateSelection(null);
-          updateSpecSelection(null);
+          updateBentoSelection(null);
           updateCopyBtn(null, null);
           updateSectionBar(false, 0, "");
         }
         break;
       }
-      case "token-docs:result": {
-        document.querySelectorAll(".gen-btn").forEach((b) => {
-          b.disabled = false;
-          b.textContent = "\u2192";
+      case "llm-capture:result": {
+        const btn = document.getElementById("llmCaptureSendBtn");
+        const resetBtn = () => {
+          btn.disabled = !llmCaptureNodeId;
+          btn.textContent = "Send Screenshot";
+        };
+        if (msg.error) {
+          resetBtn();
+          setLlmCaptureStatus("\u274C " + msg.error, "err");
+          break;
+        }
+        const capture = msg.capture;
+        const prompt = (((_c = document.getElementById("llmCapturePrompt")) == null ? void 0 : _c.value) || "").trim();
+        setLlmCaptureStatus("Sending image + metadata to local LLM bridge\u2026");
+        btn.textContent = "Sending\u2026";
+        fetch("http://localhost:4002/llm/capture", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            capture,
+            prompt: prompt || "Inspect this Figma selection and summarize the layout, visual system, tokens, and implementation notes."
+          })
+        }).then(async (res) => {
+          const data = await res.json().catch(() => ({}));
+          if (!res.ok) throw new Error(data.error || `LLM bridge returned ${res.status}`);
+          if (data.jobId) return pollLlmCaptureJob(data.jobId);
+          return data;
+        }).then((result) => {
+          const label = (result == null ? void 0 : result.fileName) ? `\u2713 Sent \xB7 ${result.fileName}` : (result == null ? void 0 : result.title) ? `\u2713 Sent \xB7 ${result.title}` : "\u2713 Sent to LLM";
+          setLlmCaptureStatus(label, "ok");
+          resetBtn();
+        }).catch((e) => {
+          const hint = /Failed to fetch|NetworkError|Load failed/i.test(e.message || "") ? "Local LLM bridge is not running. Run: npm run figma-story" : e.message || "Capture failed";
+          setLlmCaptureStatus("\u274C " + hint, "err");
+          resetBtn();
         });
-        if (msg.error) setVarStatus("\u274C " + msg.error, "err");
-        else setVarStatus("\u2713 " + msg.count + " tokens documented", "ok");
         break;
       }
       case "format-section:done": {
@@ -2086,21 +1782,21 @@ body {
         setAnnotateStatus(n > 0 ? `Cleared ${n} annotation${n !== 1 ? "s" : ""}` : "Nothing to clear", "ok");
         break;
       }
-      case "spec:result": {
-        const btn = document.getElementById("specGenerateBtn");
-        btn.disabled = !specSetId;
-        btn.textContent = "Generate Spec";
-        if (msg.error) setSpecStatus("\u274C " + msg.error, "err");
+      case "bento:result": {
+        const btn = document.getElementById("bentoGenerateBtn");
+        btn.disabled = !bentoSetId;
+        btn.textContent = "Generate bento doc";
+        if (msg.error) setBentoStatus("\u274C " + msg.error, "err");
         else {
           const vars = msg.variantCount;
-          setSpecStatus(`\u2713 Spec generated \xB7 ${vars} variant${vars !== 1 ? "s" : ""}`, "ok");
+          const warn = msg.warning ? " \xB7 \u26A0 " + msg.warning : "";
+          setBentoStatus(`\u2713 Bento doc generated \xB7 ${vars} variant${vars !== 1 ? "s" : ""}${warn}`, "ok");
         }
         break;
       }
     }
   });
   postToPlugin("ui-ready");
-  postToPlugin("get-settings");
   postToPlugin("resize-for-view", { width: 320, height: 460 });
   renderHomeView();
   document.addEventListener("visibilitychange", () => {

--- a/apps/s2a-toolkit/dist/ui.html
+++ b/apps/s2a-toolkit/dist/ui.html
@@ -808,22 +808,22 @@ body {
 
       <div class="tools-divider"></div>
 
-      <!-- ── Bento doc ───────────────────────────────────────────────── -->
-      <div class="section-label">Bento doc</div>
+      <!-- ── Component doc ───────────────────────────────────────────────── -->
+      <div class="section-label">Component doc</div>
       <div class="sel-card">
-        <span class="sel-card-empty" id="bentoSelectionEmpty">Select a component set</span>
-        <div class="sel-card-info" id="bentoSelectionInfo" style="display:none;">
+        <span class="sel-card-empty" id="docSelectionEmpty">Select a component set</span>
+        <div class="sel-card-info" id="docSelectionInfo" style="display:none;">
           <span class="sel-icon">▤</span>
           <div class="sel-meta">
-            <span class="sel-name" id="bentoSetName">—</span>
-            <span class="sel-type" id="bentoSetCount">—</span>
+            <span class="sel-name" id="docSetName">—</span>
+            <span class="sel-type" id="docSetCount">—</span>
           </div>
         </div>
       </div>
       <div class="btn-row">
-        <button class="btn" id="bentoGenerateBtn" disabled style="flex:1;">Generate bento doc</button>
+        <button class="btn" id="docGenerateBtn" disabled style="flex:1;">Generate component doc</button>
       </div>
-      <div class="status" id="bentoStatus"></div>
+      <div class="status" id="docStatus"></div>
 
       <!-- bottom padding for scroll clearance -->
       <div style="height:16px;"></div>
@@ -913,7 +913,7 @@ body {
   var annotateNodeId = null;
   var llmCaptureNodeId = null;
   var selectSetId = null;
-  var bentoSetId = null;
+  var docSetId = null;
   var bridgeConnected = false;
   var bridgeWs = null;
   var bridgeWsPort = null;
@@ -996,9 +996,9 @@ body {
       }
     },
     {
-      id: "tools:bento",
-      name: "Generate bento doc",
-      description: "Build a full bento documentation page for the selected component set",
+      id: "tools:doc",
+      name: "Generate component doc",
+      description: "Build a full component documentation page for the selected component set",
       category: "Tools",
       uiAction: () => switchPanel("tools")
     },
@@ -1023,7 +1023,7 @@ body {
     "tools:copy-link",
     "tools:annotate",
     "tools:select-filter",
-    "tools:bento"
+    "tools:doc"
   ];
   function fireFeature(feat) {
     var _a9;
@@ -1626,20 +1626,20 @@ body {
     setAnnotateStatus("Clearing\u2026");
     postToPlugin("annotate:clear", { nodeId: annotateNodeId });
   });
-  function setBentoStatus(msg, type = "") {
-    const el = document.getElementById("bentoStatus");
+  function setDocStatus(msg, type = "") {
+    const el = document.getElementById("docStatus");
     el.textContent = msg;
     el.className = "status" + (type ? " " + type : "");
   }
-  function updateBentoSelection(sel) {
+  function updateDocSelection(sel) {
     var _a9, _b;
     const isSet = (sel == null ? void 0 : sel.nodeType) === "COMPONENT_SET";
-    bentoSetId = isSet ? (_a9 = sel == null ? void 0 : sel.id) != null ? _a9 : null : null;
-    const emptyEl = document.getElementById("bentoSelectionEmpty");
-    const infoEl = document.getElementById("bentoSelectionInfo");
-    const nameEl = document.getElementById("bentoSetName");
-    const countEl = document.getElementById("bentoSetCount");
-    const btn = document.getElementById("bentoGenerateBtn");
+    docSetId = isSet ? (_a9 = sel == null ? void 0 : sel.id) != null ? _a9 : null : null;
+    const emptyEl = document.getElementById("docSelectionEmpty");
+    const infoEl = document.getElementById("docSelectionInfo");
+    const nameEl = document.getElementById("docSetName");
+    const countEl = document.getElementById("docSetCount");
+    const btn = document.getElementById("docGenerateBtn");
     if (isSet && sel) {
       emptyEl.style.display = "none";
       infoEl.style.display = "flex";
@@ -1653,13 +1653,13 @@ body {
     }
   }
   var _a8;
-  (_a8 = document.getElementById("bentoGenerateBtn")) == null ? void 0 : _a8.addEventListener("click", () => {
-    if (!bentoSetId) return;
-    const btn = document.getElementById("bentoGenerateBtn");
+  (_a8 = document.getElementById("docGenerateBtn")) == null ? void 0 : _a8.addEventListener("click", () => {
+    if (!docSetId) return;
+    const btn = document.getElementById("docGenerateBtn");
     btn.disabled = true;
     btn.textContent = "Generating\u2026";
-    setBentoStatus("");
-    postToPlugin("bento:generate", { setId: bentoSetId });
+    setDocStatus("");
+    postToPlugin("doc:generate", { setId: docSetId });
   });
   window.addEventListener("message", (event) => {
     var _a9, _b, _c;
@@ -1705,7 +1705,7 @@ body {
           };
           updateLlmCaptureSelection(sel);
           updateAnnotateSelection(sel);
-          updateBentoSelection(sel);
+          updateDocSelection(sel);
           updateCopyBtn(sel, msg.fileKey, msg.fileName, msg.allNodes);
           updateSectionBar(
             !!msg.isSection,
@@ -1715,7 +1715,7 @@ body {
         } else {
           updateLlmCaptureSelection(null);
           updateAnnotateSelection(null);
-          updateBentoSelection(null);
+          updateDocSelection(null);
           updateCopyBtn(null, null);
           updateSectionBar(false, 0, "");
         }
@@ -1782,15 +1782,15 @@ body {
         setAnnotateStatus(n > 0 ? `Cleared ${n} annotation${n !== 1 ? "s" : ""}` : "Nothing to clear", "ok");
         break;
       }
-      case "bento:result": {
-        const btn = document.getElementById("bentoGenerateBtn");
-        btn.disabled = !bentoSetId;
-        btn.textContent = "Generate bento doc";
-        if (msg.error) setBentoStatus("\u274C " + msg.error, "err");
+      case "doc:result": {
+        const btn = document.getElementById("docGenerateBtn");
+        btn.disabled = !docSetId;
+        btn.textContent = "Generate component doc";
+        if (msg.error) setDocStatus("\u274C " + msg.error, "err");
         else {
           const vars = msg.variantCount;
           const warn = msg.warning ? " \xB7 \u26A0 " + msg.warning : "";
-          setBentoStatus(`\u2713 Bento doc generated \xB7 ${vars} variant${vars !== 1 ? "s" : ""}${warn}`, "ok");
+          setDocStatus(`\u2713 Component doc generated \xB7 ${vars} variant${vars !== 1 ? "s" : ""}${warn}`, "ok");
         }
         break;
       }

--- a/apps/s2a-toolkit/manifest.json
+++ b/apps/s2a-toolkit/manifest.json
@@ -11,6 +11,7 @@
   "networkAccess": {
     "allowedDomains": [
       "http://localhost:6006",
+      "http://localhost:4002",
       "http://localhost:9300",
       "http://localhost:9400",
       "https://api.github.com",

--- a/apps/s2a-toolkit/server/figma-story-server.js
+++ b/apps/s2a-toolkit/server/figma-story-server.js
@@ -45,12 +45,16 @@ const CORS = {
 // ── Figma URL parser ──────────────────────────────────────────────────────────
 
 function parseFigmaUrl(url) {
-  const fileMatch = url.match(/figma\.com\/(?:design|file)\/([^/?#]+)/);
-  if (!fileMatch) throw new Error('Not a valid Figma URL — must contain /design/ or /file/');
-  const fileKey = fileMatch[1];
-  const nodeParam = new URL(url).searchParams.get('node-id');
+  const urlObj = new URL(url);
+  const branchPathMatch = urlObj.pathname.match(/\/(?:design|file|board|slides)\/([a-zA-Z0-9]+)\/branch\/([a-zA-Z0-9]+)/);
+  const fileMatch = urlObj.pathname.match(/\/(?:design|file|board|slides)\/([a-zA-Z0-9]+)/);
+  if (!fileMatch) throw new Error('Not a valid Figma URL — must contain /design/, /file/, /board/, or /slides/');
+  const mainFileKey = fileMatch[1];
+  const branchKey = branchPathMatch?.[2] || urlObj.searchParams.get('branch-id') || null;
+  const fileKey = branchKey || mainFileKey;
+  const nodeParam = urlObj.searchParams.get('node-id');
   const nodeId = nodeParam ? nodeParam.replace(/-/g, ':') : null;
-  return { fileKey, nodeId };
+  return { fileKey, mainFileKey, branchKey, nodeId };
 }
 
 // ── HTTP helpers ──────────────────────────────────────────────────────────────
@@ -327,11 +331,11 @@ async function extractFigmaStructure(nodeId) {
 }
 
 /** Calls Story UI's stream endpoint, collects all chunks, returns final result */
-async function generateViaStoryUI({ prompt, imageBase64, considerations = buildLiveContext() }) {
+async function generateViaStoryUI({ prompt, imageBase64, mediaType = 'image/png', considerations = buildLiveContext() }) {
   const body = {
     prompt,
     visionMode: true,
-    images: [`data:image/png;base64,${imageBase64}`],
+    images: [`data:${mediaType};base64,${imageBase64}`],
     considerations,
     framework: 'web-components',
     autoDetectFramework: false,
@@ -1832,6 +1836,66 @@ Rewrite the complete story file incorporating the changes above. Keep everything
     return;
   }
 
+  // Plugin endpoint — screenshot + shallow metadata sent directly from Figma
+  if (req.method === 'POST' && req.url === '/llm/capture') {
+    let body = '';
+    req.on('data', c => { body += c; });
+    req.on('end', () => {
+      let capture, prompt;
+      try { ({ capture, prompt } = JSON.parse(body)); }
+      catch { res.writeHead(400, CORS); res.end(JSON.stringify({ error: 'Invalid JSON' })); return; }
+
+      if (!capture?.imageBase64) {
+        res.writeHead(400, { ...CORS, 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Missing capture.imageBase64' }));
+        return;
+      }
+
+      const nodeName = capture.node?.name || 'selected Figma node';
+      const jobId = createJob();
+      res.writeHead(202, { ...CORS, 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, jobId }));
+
+      (async () => {
+        try {
+          updateJob(jobId, { status: 'running', phase: 'Sending screenshot to LLM…' });
+          console.log(`[llm-capture] "${nodeName}" jobId=${jobId}, ${Math.round((capture.byteLength || 0) / 1024)}KB`);
+          const metadata = {
+            fileName: capture.fileName,
+            fileKey: capture.fileKey,
+            page: capture.page,
+            node: capture.node,
+            export: {
+              mediaType: capture.mediaType || 'image/jpeg',
+              scale: capture.scale,
+              maxDimension: capture.maxDimension,
+              byteLength: capture.byteLength,
+            },
+          };
+          const fullPrompt = `${prompt || 'Inspect this Figma selection and summarize what matters for implementation.'}
+
+Use the screenshot as the visual source of truth. Use this Figma metadata for structure and provenance:
+
+${JSON.stringify(metadata, null, 2)}
+
+Return concise implementation notes. If generating a Storybook story, use S2A components and semantic tokens only.`;
+
+          const result = await generateViaStoryUI({
+            prompt: fullPrompt,
+            imageBase64: capture.imageBase64,
+            mediaType: capture.mediaType || 'image/jpeg',
+          });
+          updateJob(jobId, { status: 'done', phase: 'Done', result });
+          console.log(`[llm-capture] job ${jobId} done`);
+        } catch (e) {
+          console.error(`[llm-capture] job ${jobId} error:`, e.message);
+          updateJob(jobId, { status: 'error', phase: 'Failed', error: e.message });
+        }
+      })();
+    });
+    return;
+  }
+
   // Poll job status
   if (req.method === 'GET' && req.url?.startsWith('/jobs/')) {
     const jobId = req.url.slice('/jobs/'.length);
@@ -1945,6 +2009,7 @@ server.listen(PORT, 'localhost', () => {
   console.log(`\n[Figma→Story] http://localhost:${PORT}`);
   console.log(`  GET  /                     — chat UI`);
   console.log(`  POST /prototype/generate   — plugin: selection + prompt + branch → story + PR (no API key needed)`);
+  console.log(`  POST /llm/capture          — plugin: screenshot + metadata → Story UI vision`);
   console.log(`  POST /figma/generate       — screenshot via Figma REST API`);
   console.log(`  POST /figma/generate-deep  — deep extraction via Desktop Bridge (ws:${bridgePort})`);
   console.log(`  POST /prompt/generate      — text-only generation`);

--- a/apps/s2a-toolkit/src/code.ts
+++ b/apps/s2a-toolkit/src/code.ts
@@ -252,7 +252,7 @@ function bytesToBase64(bytes: Uint8Array): string {
   return btoa(bin);
 }
 
-// ── Bento doc generator helpers ────────────────────────────────────────────────
+// ── Component doc generator helpers ────────────────────────────────────────────────
 
 function parseVariantProps(name: string): Record<string, string> {
   const props: Record<string, string> = {};
@@ -263,15 +263,15 @@ function parseVariantProps(name: string): Record<string, string> {
   return props;
 }
 
-interface BentoMeta {
+interface DocMeta {
   version: string; status: string; updated: string; changelog: string;
   goodToKnow: string; accessibility: string; description: string; hadFence: boolean;
 }
 
 // Parse the `— s2a:meta —` fence plus the `## Good to know` / `## Accessibility`
 // prose blocks out of a component set's description. Tolerates a missing fence.
-function parseMetaFence(desc: string): BentoMeta {
-  const out: BentoMeta = {
+function parseMetaFence(desc: string): DocMeta {
+  const out: DocMeta = {
     version: '', status: '', updated: '', changelog: '',
     goodToKnow: '', accessibility: '', description: '', hadFence: false,
   };
@@ -330,7 +330,7 @@ function pickDefaultVariant(variants: ComponentNode[]): ComponentNode | undefine
   return best;
 }
 
-function clearBentoSlot(frame: FrameNode): void {
+function clearDocSlot(frame: FrameNode): void {
   for (const c of [...frame.children]) c.remove();
 }
 
@@ -677,12 +677,12 @@ figma.ui.onmessage = async (msg: { type: string; [key: string]: unknown }) => {
       break;
     }
 
-    case 'bento:generate': {
+    case 'doc:generate': {
       try {
         const setId = msg.setId as string;
         const node = await figma.getNodeByIdAsync(setId);
         if (!node || node.type !== 'COMPONENT_SET') {
-          figma.ui.postMessage({ type: 'bento:result', error: 'Select a component set first' });
+          figma.ui.postMessage({ type: 'doc:result', error: 'Select a component set first' });
           break;
         }
         const set = node as ComponentSetNode;
@@ -697,9 +697,9 @@ figma.ui.onmessage = async (msg: { type: string; [key: string]: unknown }) => {
         // loadAllPagesAsync required before root/page traversal in dynamic-page mode.
         await figma.loadAllPagesAsync();
         const tplPage  = figma.root.children.find(p => p.name === '📐 Templates') as PageNode | undefined;
-        const template = tplPage?.children.find(c => c.name === 'Bento Doc Template') as FrameNode | undefined;
+        const template = tplPage?.children.find(c => c.name === 'Doc Template') as FrameNode | undefined;
         if (!template) {
-          figma.ui.postMessage({ type: 'bento:result', error: 'Template not found — add "Bento Doc Template" to the "📐 Templates" page' });
+          figma.ui.postMessage({ type: 'doc:result', error: 'Template not found — add "Doc Template" to the "📐 Templates" page' });
           break;
         }
 
@@ -751,7 +751,7 @@ figma.ui.onmessage = async (msg: { type: string; [key: string]: unknown }) => {
         // Hero slot — a live instance of the default variant.
         const heroSlot = find('@slot-hero') as FrameNode | null;
         if (heroSlot && defaultVariant) {
-          clearBentoSlot(heroSlot);
+          clearDocSlot(heroSlot);
           heroSlot.clipsContent = false;
           heroSlot.paddingTop = 20; heroSlot.paddingBottom = 20;
           heroSlot.counterAxisSizingMode = 'AUTO'; // hug the instance height
@@ -764,7 +764,7 @@ figma.ui.onmessage = async (msg: { type: string; [key: string]: unknown }) => {
         // Properties — one stacked row per property definition.
         const propsSlot = find('@properties') as FrameNode | null;
         if (propsSlot) {
-          clearBentoSlot(propsSlot);
+          clearDocSlot(propsSlot);
           propsSlot.strokes = []; propsSlot.dashPattern = []; propsSlot.fills = [];
           propsSlot.layoutMode = 'VERTICAL';
           propsSlot.primaryAxisAlignItems = 'MIN';
@@ -797,7 +797,7 @@ figma.ui.onmessage = async (msg: { type: string; [key: string]: unknown }) => {
         // RouterNavItem — readable since headers follow the row that defines x).
         const gridSlot = find('@slot-all-variants') as FrameNode | null;
         if (gridSlot && variants.length) {
-          clearBentoSlot(gridSlot);
+          clearDocSlot(gridSlot);
           gridSlot.strokes = []; gridSlot.dashPattern = []; gridSlot.fills = [];
           gridSlot.layoutMode = 'NONE'; gridSlot.clipsContent = false;
 
@@ -869,7 +869,7 @@ figma.ui.onmessage = async (msg: { type: string; [key: string]: unknown }) => {
         // Dark-mode preview — clone the finished grid and pin the clone to Dark.
         const darkSlot = find('@slot-dark-preview') as FrameNode | null;
         if (darkSlot && gridSlot) {
-          clearBentoSlot(darkSlot);
+          clearDocSlot(darkSlot);
           darkSlot.strokes = []; darkSlot.dashPattern = []; darkSlot.fills = [];
           darkSlot.layoutMode = 'NONE'; darkSlot.clipsContent = false;
           const gclone = gridSlot.clone();
@@ -896,14 +896,14 @@ figma.ui.onmessage = async (msg: { type: string; [key: string]: unknown }) => {
         figma.viewport.scrollAndZoomIntoView([doc]);
 
         figma.ui.postMessage({
-          type: 'bento:result',
+          type: 'doc:result',
           nodeId: doc.id,
           variantCount: variants.length,
           warning: meta.hadFence ? undefined
             : 'No s2a:meta fence in the set description — used placeholders for version / changelog / prose',
         });
       } catch (e: any) {
-        figma.ui.postMessage({ type: 'bento:result', error: e.message || String(e) });
+        figma.ui.postMessage({ type: 'doc:result', error: e.message || String(e) });
       }
       break;
     }

--- a/apps/s2a-toolkit/src/code.ts
+++ b/apps/s2a-toolkit/src/code.ts
@@ -26,31 +26,6 @@ function serializeCollection(c: VariableCollection): Record<string, unknown> {
   };
 }
 
-// ── Token group helpers ───────────────────────────────────────────────────────
-
-function tokenGroup(name: string): string {
-  const parts = name.split('/').filter(p => p !== 's2a');
-  if (parts.length >= 4 && parts[1] === 'transparent') return parts[0] + ' / ' + parts[1] + ' / ' + parts[2];
-  if (parts.length >= 3) return parts[0] + ' / ' + parts[1];
-  return parts[0] ?? name;
-}
-
-function fmtTokenValue(val: unknown): string {
-  if (val === null || val === undefined) return '—';
-  if (typeof val === 'number') return String(val);
-  if (typeof val === 'string') return val;
-  if (typeof val === 'boolean') return String(val);
-  if (typeof val === 'object' && 'r' in (val as any)) {
-    const c = val as { r: number; g: number; b: number; a?: number };
-    const h = (n: number) => Math.round(n * 255).toString(16).padStart(2, '0');
-    if (c.a !== undefined && Math.abs(c.a - 1) > 0.004) {
-      return 'rgba(' + Math.round(c.r*255) + ', ' + Math.round(c.g*255) + ', ' + Math.round(c.b*255) + ', ' + (Math.round(c.a*100)/100) + ')';
-    }
-    return '#' + h(c.r) + h(c.g) + h(c.b);
-  }
-  return JSON.stringify(val);
-}
-
 // ── Dark section style ────────────────────────────────────────────────────────
 
 const DARK_VAR = {
@@ -267,6 +242,143 @@ function serializeNodeForProto(node: SceneNode, depth = 0): Record<string, unkno
   return base;
 }
 
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = '';
+  const chunkSize = 8192;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, Math.min(i + chunkSize, bytes.length));
+    bin += String.fromCharCode.apply(null, Array.from(chunk));
+  }
+  return btoa(bin);
+}
+
+// ── Bento doc generator helpers ────────────────────────────────────────────────
+
+function parseVariantProps(name: string): Record<string, string> {
+  const props: Record<string, string> = {};
+  for (const part of name.split(',')) {
+    const eq = part.indexOf('=');
+    if (eq !== -1) props[part.slice(0, eq).trim()] = part.slice(eq + 1).trim();
+  }
+  return props;
+}
+
+interface BentoMeta {
+  version: string; status: string; updated: string; changelog: string;
+  goodToKnow: string; accessibility: string; description: string; hadFence: boolean;
+}
+
+// Parse the `— s2a:meta —` fence plus the `## Good to know` / `## Accessibility`
+// prose blocks out of a component set's description. Tolerates a missing fence.
+function parseMetaFence(desc: string): BentoMeta {
+  const out: BentoMeta = {
+    version: '', status: '', updated: '', changelog: '',
+    goodToKnow: '', accessibility: '', description: '', hadFence: false,
+  };
+  if (!desc) return out;
+  const lines = desc.split('\n');
+  let idx = 0;
+  if (/s2a:meta/i.test(lines[0] || '')) {
+    out.hadFence = true;
+    let end = 1;
+    while (end < lines.length && lines[end].trim() !== '') end++;
+    const changelog: string[] = [];
+    let inChangelog = false;
+    for (const line of lines.slice(1, end)) {
+      const kv = line.match(/^([A-Za-z][\w-]*)\s*:\s*(.*)$/);
+      if (kv && !/^\s/.test(line)) {
+        inChangelog = false;
+        const k = kv[1].toLowerCase(); const v = kv[2].trim();
+        if (k === 'version') out.version = v;
+        else if (k === 'status') out.status = v;
+        else if (k === 'updated') out.updated = v;
+        else if (k === 'changelog') { inChangelog = true; if (v) changelog.push(v); }
+      } else if (inChangelog) {
+        changelog.push(line.trim());
+      }
+    }
+    if (changelog.length) out.changelog = 'changelog\n  ' + changelog.join('\n  ');
+    idx = end + 1;
+  }
+  const rest = lines.slice(idx).join('\n').trim();
+  const gtk  = rest.match(/##\s*Good to know\s*\n([\s\S]*?)(?=\n##\s|$)/i);
+  const a11y = rest.match(/##\s*Accessibility\s*\n([\s\S]*?)(?=\n##\s|$)/i);
+  if (gtk)  out.goodToKnow    = gtk[1].trim();
+  if (a11y) out.accessibility = a11y[1].trim();
+  out.description = rest.split(/\n##\s/)[0].split(/\n\s*\n/)[0].trim();
+  return out;
+}
+
+function pageOfNode(node: BaseNode): PageNode | null {
+  let p: BaseNode | null = node;
+  while (p && p.type !== 'PAGE') p = p.parent;
+  return (p as PageNode) ?? null;
+}
+
+// Prefer the variant whose values look like the default / resting state.
+function pickDefaultVariant(variants: ComponentNode[]): ComponentNode | undefined {
+  if (!variants.length) return undefined;
+  const DEFAULTISH = new Set([
+    'default', 'resting', 'standard', 'md', 'solid', 'hug', 'block', 'horizontal', 'on-light',
+  ]);
+  let best = variants[0]; let bestScore = -1;
+  for (const v of variants) {
+    const score = Object.values(parseVariantProps(v.name))
+      .filter(x => DEFAULTISH.has(x.toLowerCase())).length;
+    if (score > bestScore) { best = v; bestScore = score; }
+  }
+  return best;
+}
+
+function clearBentoSlot(frame: FrameNode): void {
+  for (const c of [...frame.children]) c.remove();
+}
+
+// Dot-named layer tree of a variant → an indented anatomy list.
+function anatomyList(comp: ComponentNode): string {
+  const lines: string[] = [];
+  function walk(node: SceneNode, depth: number): void {
+    if (node !== comp && (node.name.startsWith('.') || node.name.startsWith('['))) {
+      lines.push('  '.repeat(Math.max(0, depth - 1)) + node.name);
+    }
+    if ('children' in node && depth < 4) {
+      for (const c of (node as FrameNode).children) walk(c, depth + 1);
+    }
+  }
+  walk(comp, 0);
+  return lines.length ? lines.join('\n') : '.root';
+}
+
+function setUsesNativeSlots(set: ComponentSetNode): boolean {
+  const v = set.children[0];
+  if (v && 'findOne' in v) {
+    try { return !!(v as ComponentNode).findOne(n => (n.type as string) === 'SLOT'); }
+    catch { /* older API — treat as no slots */ }
+  }
+  return false;
+}
+
+// Cluster numeric positions into representative buckets within a tolerance —
+// lets the axis-labeler treat near-equal x/y (sub-pixel drift) as one row/column.
+function clusterPositions(vals: number[], tol: number): number[] {
+  const sorted = Array.from(new Set(vals)).sort((a, b) => a - b);
+  const reps: number[] = [];
+  for (const v of sorted) if (!reps.some(r => Math.abs(r - v) <= tol)) reps.push(v);
+  return reps;
+}
+
+function mkAxisLabel(chars: string, style: string, size: number, colorVar: Variable | null): TextNode {
+  const t = figma.createText();
+  t.name = 'axis-label';
+  t.fontName = { family: 'Adobe Clean', style };
+  t.fontSize = size;
+  t.characters = chars;
+  t.textAutoResize = 'WIDTH_AND_HEIGHT';
+  t.fills = [{ type: 'SOLID', color: { r: 0, g: 0, b: 0 } }];
+  if (colorVar) bfv(t, colorVar);
+  return t;
+}
+
 figma.on('selectionchange', notifySelection);
 
 figma.on('currentpagechange', () => {
@@ -323,26 +435,6 @@ figma.ui.onmessage = async (msg: { type: string; [key: string]: unknown }) => {
       break;
     }
 
-    case 'get-settings': {
-      try {
-        const settings = await figma.clientStorage.getAsync('github-settings');
-        figma.ui.postMessage({ type: 'settings-loaded', settings: settings ?? null });
-      } catch {
-        figma.ui.postMessage({ type: 'settings-loaded', settings: null });
-      }
-      break;
-    }
-
-    case 'save-settings': {
-      try {
-        await figma.clientStorage.setAsync('github-settings', msg.settings);
-        figma.ui.postMessage({ type: 'settings-saved', success: true });
-      } catch (e: any) {
-        figma.ui.postMessage({ type: 'settings-saved', success: false, error: e.message || String(e) });
-      }
-      break;
-    }
-
     case 'notify': {
       figma.notify(msg.message as string);
       break;
@@ -374,6 +466,44 @@ figma.ui.onmessage = async (msg: { type: string; [key: string]: unknown }) => {
       const w = (msg.width as number) || 320;
       const h = (msg.height as number) || 480;
       figma.ui.resize(w, h);
+      break;
+    }
+
+    case 'llm-capture:selection': {
+      const node = figma.currentPage.selection[0];
+      if (!node) {
+        figma.ui.postMessage({ type: 'llm-capture:result', error: 'Select a frame, section, component, or instance first' });
+        break;
+      }
+      if (!('exportAsync' in node)) {
+        figma.ui.postMessage({ type: 'llm-capture:result', error: `${node.type} cannot be exported as an image` });
+        break;
+      }
+
+      try {
+        const maxDimension = Math.max(256, Math.min((msg.maxDimension as number) || 2048, 4096));
+        const width = 'width' in node ? (node as any).width : maxDimension;
+        const height = 'height' in node ? (node as any).height : maxDimension;
+        const scale = Math.min(1, maxDimension / Math.max(width, height));
+        const bytes = await (node as any).exportAsync({
+          format: 'JPG',
+          constraint: { type: 'SCALE', value: scale },
+        });
+        const capture = {
+          imageBase64: bytesToBase64(bytes),
+          mediaType: 'image/jpeg',
+          scale,
+          maxDimension,
+          byteLength: bytes.length,
+          node: serializeNodeForProto(node),
+          fileKey: figma.fileKey || null,
+          fileName: figma.root.name,
+          page: { id: figma.currentPage.id, name: figma.currentPage.name },
+        };
+        figma.ui.postMessage({ type: 'llm-capture:result', capture });
+      } catch (e: any) {
+        figma.ui.postMessage({ type: 'llm-capture:result', error: e.message || String(e) });
+      }
       break;
     }
 
@@ -534,1273 +664,6 @@ figma.ui.onmessage = async (msg: { type: string; [key: string]: unknown }) => {
       break;
     }
 
-    case 'token-docs:generate': {
-      const collectionId = msg.collectionId as string;
-      const group        = msg.group as string;
-      try {
-        // ── Text Styles path — 4 breakpoint sections from native text styles ──
-        if (collectionId === 'text-styles') {
-          const tsAllColls = await figma.variables.getLocalVariableCollectionsAsync();
-          const responsiveColl = tsAllColls.find(c => /Responsive/.test(c.name));
-          if (!responsiveColl) throw new Error('Responsive variable collection not found');
-
-          const MODE_ORDER_TS = ['sm', 'md', 'lg', 'xl'];
-          const tsSortedModes = [...responsiveColl.modes].sort((a, b) =>
-            MODE_ORDER_TS.indexOf(a.name.toLowerCase()) - MODE_ORDER_TS.indexOf(b.name.toLowerCase())
-          );
-
-          const tsAllVars = await figma.variables.getLocalVariablesAsync();
-          const allTypoVars = tsAllVars.filter(v =>
-            v.variableCollectionId === responsiveColl.id &&
-            v.name.toLowerCase().includes('/typography/')
-          );
-
-          // Resolve a variable's value for a specific mode, following up to 3 levels of aliases
-          const resolveVarMode = async (v: Variable, modeId: string): Promise<number | null> => {
-            let cur: any = v.valuesByMode[modeId];
-            for (let depth = 0; depth < 3; depth++) {
-              if (typeof cur === 'number') return cur;
-              if (cur && typeof cur === 'object' && cur.type === 'VARIABLE_ALIAS') {
-                try {
-                  const ref = await figma.variables.getVariableByIdAsync(cur.id);
-                  if (!ref) break;
-                  cur = ref.valuesByMode[Object.keys(ref.valuesByMode)[0]];
-                } catch { break; }
-              } else { break; }
-            }
-            return typeof cur === 'number' ? cur : null;
-          };
-
-          const tsTextStyles = await figma.getLocalTextStylesAsync();
-          const TS_STYLE_ORDER = [
-            'super', 'heading-1', 'heading-2', 'heading-3', 'heading-4', 'heading-5', 'heading-6',
-            'body-lg', 'body-md', 'body-sm', 'body-xs', 'eyebrow', 'label', 'caption',
-          ];
-          const typoStyles = tsTextStyles
-            .filter(s => s.name.startsWith('s2a/typography/'))
-            .sort((a, b) => {
-              const an = a.name.replace('s2a/typography/', '');
-              const bn = b.name.replace('s2a/typography/', '');
-              const ai = TS_STYLE_ORDER.indexOf(an);
-              const bi = TS_STYLE_ORDER.indexOf(bn);
-              if (ai !== -1 && bi !== -1) return ai - bi;
-              if (ai !== -1) return -1;
-              if (bi !== -1) return 1;
-              return a.name.localeCompare(b.name);
-            });
-          if (typoStyles.length === 0) throw new Error('No s2a/typography/* text styles found in this file');
-
-          await Promise.all([
-            figma.loadFontAsync({ family: 'Adobe Clean Display', style: 'Bold' }),
-            figma.loadFontAsync({ family: 'Adobe Clean Display', style: 'Black' }).catch(() => {}),
-            figma.loadFontAsync({ family: 'Adobe Clean', style: 'Bold' }),
-            figma.loadFontAsync({ family: 'Adobe Clean', style: 'Regular' }),
-            figma.loadFontAsync({ family: 'Adobe Clean', style: 'ExtraBold' }).catch(() => {}),
-          ]);
-
-          const themeColl = tsAllColls.find(c => c.id === DARK_VAR.collectionId)!;
-          const tsDarkId  = themeColl.modes.find(m => m.name === 'Dark')!.modeId;
-
-          const [tsVBg, tsVBorder, tsVBody, tsVSub, tsVKo] = await Promise.all([
-            figma.variables.getVariableByIdAsync(DARK_VAR.bgKnockout),
-            figma.variables.getVariableByIdAsync(DARK_VAR.borderSubtle),
-            figma.variables.getVariableByIdAsync(DARK_VAR.cBodySubtle),
-            figma.variables.getVariableByIdAsync(DARK_VAR.cSubheading),
-            figma.variables.getVariableByIdAsync(DARK_VAR.cKnockout),
-          ]);
-
-          const tsPage     = figma.currentPage;
-          const tsSections = tsPage.children.filter(n => n.type === 'SECTION') as SectionNode[];
-          const tsLastSec  = tsSections.reduce<SectionNode | null>(
-            (a, b) => (!a || b.y + b.height > a.y + a.height ? b : a), null
-          );
-          let tsPlaceY = tsLastSec ? tsLastSec.y + tsLastSec.height + 80 : 0;
-          const tsPlaceX = tsLastSec?.x ?? 0;
-          const TS_W = 2400, TS_M = 120;
-          const createdSections: SectionNode[] = [];
-
-          for (const mode of tsSortedModes) {
-            const sec = figma.createSection();
-            sec.name = `typography — ${mode.name}`;
-            sec.x = tsPlaceX; sec.y = tsPlaceY;
-            sec.resizeWithoutConstraints(TS_W, 800);
-
-            const bgRect = figma.createRectangle();
-            bgRect.resize(TS_W, 800); bgRect.x = 0; bgRect.y = 0;
-            bgRect.fills = [{ type: 'SOLID', color: { r: 0.04, g: 0.04, b: 0.047 } }];
-            sec.appendChild(bgRect);
-            if (tsVBg) bfv(bgRect, tsVBg);
-
-            const frame = figma.createFrame();
-            frame.name = '.content';
-            frame.fills = []; frame.clipsContent = false;
-            frame.layoutMode = 'VERTICAL';
-            frame.resize(TS_W, 800);
-            frame.primaryAxisSizingMode   = 'AUTO';
-            frame.counterAxisSizingMode   = 'FIXED';
-            frame.paddingTop    = 160; frame.paddingBottom = 120;
-            frame.paddingLeft   = TS_M; frame.paddingRight  = TS_M;
-            frame.itemSpacing   = 0;
-            frame.counterAxisAlignItems = 'MIN';
-            frame.x = 0; frame.y = 0;
-            sec.appendChild(frame);
-            frame.setExplicitVariableModeForCollection(themeColl, tsDarkId);
-            // Bind this section's text to the correct responsive breakpoint
-            try { frame.setExplicitVariableModeForCollection(responsiveColl, mode.modeId); } catch {}
-
-            const hT = (chars: string, family: string, style: string, size: number, v: Variable | null): TextNode => {
-              const n = figma.createText();
-              n.fontName = { family, style };
-              n.fontSize = size;
-              n.characters = chars;
-              n.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];
-              n.textAutoResize = 'HEIGHT';
-              frame.appendChild(n);
-              n.layoutSizingHorizontal = 'FILL';
-              if (v) bfv(n, v);
-              return n;
-            };
-            const hSp = (h: number): void => {
-              const sp = figma.createFrame();
-              sp.fills = []; sp.resize(TS_W - TS_M * 2, h);
-              sp.primaryAxisSizingMode = 'FIXED';
-              frame.appendChild(sp);
-              sp.layoutSizingHorizontal = 'FILL';
-            };
-            const hDv = (): void => {
-              const r = figma.createRectangle();
-              r.resize(TS_W - TS_M * 2, 1);
-              r.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 }, opacity: 0.12 }];
-              frame.appendChild(r);
-              r.layoutSizingHorizontal = 'FILL';
-              if (tsVBorder) bfv(r, tsVBorder);
-            };
-
-            // Section header
-            hT(`typography — ${mode.name}`, 'Adobe Clean Display', 'Bold', 56, tsVKo);
-            hSp(24);
-            hT(`S2A Responsive · ${mode.name.toUpperCase()} breakpoint`, 'Adobe Clean', 'Regular', 20, tsVBody);
-            hSp(24);
-            hT('May 2026  ·  @matt', 'Adobe Clean', 'Regular', 14, tsVBody);
-            hSp(80);
-            hDv();
-            hSp(56);
-
-            // One row per text style
-            for (const ts of typoStyles) {
-              const styleName = ts.name.replace('s2a/typography/', '');
-              const fsVar = allTypoVars.find(v => v.name === `s2a/typography/font-size/${styleName}`) ?? null;
-              const lhVar = allTypoVars.find(v => v.name === `s2a/typography/line-height/${styleName}`) ?? null;
-              const lsVar = allTypoVars.find(v => v.name === `s2a/typography/letter-spacing/${styleName}`) ?? null;
-
-              const isDisplayStyle = ['super', 'heading-1', 'heading-2'].includes(styleName);
-              const isSmallStyle   = ['eyebrow', 'label', 'caption'].includes(styleName);
-              const sampleText = isDisplayStyle ? 'Make anything.'
-                : isSmallStyle ? 'Everything you need to make anything you want.'
-                : 'Everything you need to make anything.';
-
-              // Style name label
-              hT(styleName, 'Adobe Clean', 'Bold', 11, tsVSub);
-              hSp(8);
-
-              // Text sample — inherits the section's responsive mode, displays at breakpoint scale
-              const textNode = figma.createText();
-              textNode.fontName = { family: 'Adobe Clean', style: 'Regular' };
-              textNode.fontSize = 16;
-              textNode.characters = sampleText;
-              frame.appendChild(textNode);
-              textNode.layoutSizingHorizontal = 'FILL';
-              textNode.textAutoResize = 'HEIGHT';
-              try { await textNode.setTextStyleIdAsync(ts.id); } catch {}
-              if (fsVar) try { (textNode as any).setBoundVariable('fontSize', fsVar); } catch {}
-              if (lhVar) try { (textNode as any).setBoundVariable('lineHeight', lhVar); } catch {}
-              if (lsVar) try { (textNode as any).setBoundVariable('letterSpacing', lsVar); } catch {}
-              if (tsVKo) bfv(textNode, tsVKo);
-              // Variable bindings stay so the Annotate panel can read them on demand —
-              // annotations are not pre-wired here to keep sections visually clean.
-
-              // Resolved primitive values for this breakpoint — always shown, dashes if alias chain fails
-              const fs = fsVar ? await resolveVarMode(fsVar, mode.modeId) : null;
-              const lh = lhVar ? await resolveVarMode(lhVar, mode.modeId) : null;
-              const ls = lsVar ? await resolveVarMode(lsVar, mode.modeId) : null;
-              hSp(8);
-              const fmtPx = (n: number | null) => n !== null ? n + 'px' : '—';
-              const fmtLs = (n: number | null) => n === null ? '—' : n === 0 ? '0' : n.toFixed(2) + 'px';
-              const vNode = figma.createText();
-              vNode.fontName = { family: 'Adobe Clean', style: 'Regular' };
-              vNode.fontSize = 13;
-              vNode.characters = `font-size ${fmtPx(fs)}  ·  line-height ${fmtPx(lh)}  ·  letter-spacing ${fmtLs(ls)}`;
-              frame.appendChild(vNode);
-              vNode.layoutSizingHorizontal = 'FILL';
-              vNode.textAutoResize = 'HEIGHT';
-              if (tsVBody) bfv(vNode, tsVBody);
-
-              hSp(32);
-              hDv();
-              hSp(32);
-            }
-
-            const finalH = frame.height;
-            sec.resizeWithoutConstraints(TS_W, finalH);
-            bgRect.resize(TS_W, finalH);
-
-            tsPlaceY += finalH + 80;
-            createdSections.push(sec);
-          }
-
-          if (createdSections.length > 0) figma.viewport.scrollAndZoomIntoView(createdSections);
-          figma.notify(`${createdSections.length} typography breakpoint sections generated`);
-          figma.ui.postMessage({ type: 'token-docs:result', sectionId: createdSections[0]?.id ?? '', count: createdSections.length });
-          break;
-        }
-
-        // ── Section-padding path — 4 breakpoint sections ─────────────────
-        if (group.toLowerCase().includes('section-padding')) {
-          const spAllColls = await figma.variables.getLocalVariableCollectionsAsync();
-          const spColl = spAllColls.find(c => c.id === collectionId);
-          if (!spColl) throw new Error('Collection not found: ' + collectionId);
-
-          const MODE_ORDER_SP = ['sm', 'md', 'lg', 'xl'];
-          const spSortedModes = [...spColl.modes].sort((a, b) =>
-            MODE_ORDER_SP.indexOf(a.name.toLowerCase()) - MODE_ORDER_SP.indexOf(b.name.toLowerCase())
-          );
-
-          const spAllVars = await figma.variables.getLocalVariablesAsync();
-          const spVars = spAllVars.filter(v =>
-            v.variableCollectionId === collectionId &&
-            v.name.toLowerCase().includes('section-padding')
-          );
-          if (spVars.length === 0) throw new Error('No section-padding variables found in collection');
-
-          const SP_SIZE_ORDER = ['none', '2xs', 'xs', 'sm', 'md', 'lg', 'xl', '2xl'];
-          const sortedSpVars = [...spVars].sort((a, b) => {
-            const an = a.name.split('/').pop() ?? '';
-            const bn = b.name.split('/').pop() ?? '';
-            const ai = SP_SIZE_ORDER.indexOf(an);
-            const bi = SP_SIZE_ORDER.indexOf(bn);
-            if (ai !== -1 && bi !== -1) return ai - bi;
-            if (ai !== -1) return -1;
-            if (bi !== -1) return 1;
-            return a.name.localeCompare(b.name);
-          });
-
-          const resolveSpMode = async (v: Variable, modeId: string): Promise<number | null> => {
-            let cur: any = v.valuesByMode[modeId];
-            for (let depth = 0; depth < 3; depth++) {
-              if (typeof cur === 'number') return cur;
-              if (cur && typeof cur === 'object' && cur.type === 'VARIABLE_ALIAS') {
-                try {
-                  const ref = await figma.variables.getVariableByIdAsync(cur.id);
-                  if (!ref) break;
-                  cur = ref.valuesByMode[Object.keys(ref.valuesByMode)[0]];
-                } catch { break; }
-              } else { break; }
-            }
-            return typeof cur === 'number' ? cur : null;
-          };
-
-          await Promise.all([
-            figma.loadFontAsync({ family: 'Adobe Clean Display', style: 'Bold' }),
-            figma.loadFontAsync({ family: 'Adobe Clean', style: 'Bold' }),
-            figma.loadFontAsync({ family: 'Adobe Clean', style: 'Regular' }),
-          ]);
-
-          const spThemeColl = spAllColls.find(c => c.id === DARK_VAR.collectionId)!;
-          const spDarkId    = spThemeColl.modes.find(m => m.name === 'Dark')!.modeId;
-
-          const [spVBg, spVBorder, spVBody, spVSub, spVKo, spVBgSub] = await Promise.all([
-            figma.variables.getVariableByIdAsync(DARK_VAR.bgKnockout),
-            figma.variables.getVariableByIdAsync(DARK_VAR.borderSubtle),
-            figma.variables.getVariableByIdAsync(DARK_VAR.cBodySubtle),
-            figma.variables.getVariableByIdAsync(DARK_VAR.cSubheading),
-            figma.variables.getVariableByIdAsync(DARK_VAR.cKnockout),
-            figma.variables.getVariableByIdAsync(DARK_VAR.bgSubtle),
-          ]);
-
-          const spPage     = figma.currentPage;
-          const spSections = spPage.children.filter(n => n.type === 'SECTION') as SectionNode[];
-          const spLastSec  = spSections.reduce<SectionNode | null>(
-            (a, b) => (!a || b.y + b.height > a.y + a.height ? b : a), null
-          );
-          let spPlaceY = spLastSec ? spLastSec.y + spLastSec.height + 80 : 0;
-          const spPlaceX = spLastSec?.x ?? 0;
-          const SP_W = 2400, SP_M = 120;
-          const spCreated: SectionNode[] = [];
-
-          for (const mode of spSortedModes) {
-            const sec = figma.createSection();
-            sec.name = `viewport / section-padding — ${mode.name}`;
-            sec.x = spPlaceX; sec.y = spPlaceY;
-            sec.resizeWithoutConstraints(SP_W, 800);
-
-            const bgRect = figma.createRectangle();
-            bgRect.resize(SP_W, 800); bgRect.x = 0; bgRect.y = 0;
-            bgRect.fills = [{ type: 'SOLID', color: { r: 0.04, g: 0.04, b: 0.047 } }];
-            sec.appendChild(bgRect);
-            if (spVBg) bfv(bgRect, spVBg);
-
-            const frame = figma.createFrame();
-            frame.name = '.content';
-            frame.fills = []; frame.clipsContent = false;
-            frame.layoutMode = 'VERTICAL';
-            frame.resize(SP_W, 800);
-            frame.primaryAxisSizingMode   = 'AUTO';
-            frame.counterAxisSizingMode   = 'FIXED';
-            frame.paddingTop    = 160; frame.paddingBottom = 120;
-            frame.paddingLeft   = SP_M; frame.paddingRight  = SP_M;
-            frame.itemSpacing   = 0;
-            frame.counterAxisAlignItems = 'MIN';
-            frame.x = 0; frame.y = 0;
-            sec.appendChild(frame);
-            frame.setExplicitVariableModeForCollection(spThemeColl, spDarkId);
-            try { frame.setExplicitVariableModeForCollection(spColl, mode.modeId); } catch {}
-
-            const spHT = (chars: string, family: string, style: string, size: number, v: Variable | null): TextNode => {
-              const n = figma.createText();
-              n.fontName = { family, style };
-              n.fontSize = size;
-              n.characters = chars;
-              n.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];
-              n.textAutoResize = 'HEIGHT';
-              frame.appendChild(n);
-              n.layoutSizingHorizontal = 'FILL';
-              if (v) bfv(n, v);
-              return n;
-            };
-            const spHSp = (h: number): void => {
-              const sp = figma.createFrame();
-              sp.fills = []; sp.resize(SP_W - SP_M * 2, h);
-              sp.primaryAxisSizingMode = 'FIXED';
-              frame.appendChild(sp);
-              sp.layoutSizingHorizontal = 'FILL';
-            };
-            const spHDv = (): void => {
-              const r = figma.createRectangle();
-              r.resize(SP_W - SP_M * 2, 1);
-              r.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 }, opacity: 0.12 }];
-              frame.appendChild(r);
-              r.layoutSizingHorizontal = 'FILL';
-              if (spVBorder) bfv(r, spVBorder);
-            };
-
-            // Section header
-            spHT(`viewport / section-padding — ${mode.name}`, 'Adobe Clean Display', 'Bold', 56, spVKo);
-            spHSp(24);
-            spHT(`S2A Responsive · ${mode.name.toUpperCase()} breakpoint`, 'Adobe Clean', 'Regular', 20, spVBody);
-            spHSp(24);
-            spHT('May 2026  ·  @matt', 'Adobe Clean', 'Regular', 14, spVBody);
-            spHSp(80);
-            spHDv();
-            spHSp(56);
-
-            for (const sv of sortedSpVars) {
-              const sizeName   = sv.name.split('/').pop() ?? sv.name;
-              const cssVar     = '--' + sv.name.replace(/^s2a\//, 's2a-').replace(/\//g, '-');
-              const resolvedPx = await resolveSpMode(sv, mode.modeId);
-              const fmtPx      = (n: number | null) => n !== null ? n + 'px' : '—';
-
-              // Horizontal row: info (left, fills) + swatch (right)
-              const rowFrame = figma.createFrame();
-              rowFrame.name = sizeName;
-              rowFrame.fills = [];
-              rowFrame.layoutMode = 'HORIZONTAL';
-              rowFrame.primaryAxisSizingMode   = 'FIXED';
-              rowFrame.counterAxisSizingMode   = 'AUTO';
-              rowFrame.counterAxisAlignItems   = 'CENTER';
-              rowFrame.itemSpacing = 32;
-              rowFrame.resize(SP_W - SP_M * 2, 40);
-              frame.appendChild(rowFrame);
-              rowFrame.layoutSizingHorizontal = 'FILL';
-
-              // Info column
-              const infoCol = figma.createFrame();
-              infoCol.name = 'info';
-              infoCol.fills = [];
-              infoCol.layoutMode = 'VERTICAL';
-              infoCol.primaryAxisSizingMode = 'AUTO';
-              infoCol.counterAxisSizingMode = 'AUTO';
-              infoCol.itemSpacing = 4;
-              rowFrame.appendChild(infoCol);
-              infoCol.layoutSizingHorizontal = 'FILL';
-
-              const nameNode = figma.createText();
-              nameNode.fontName = { family: 'Adobe Clean', style: 'Bold' };
-              nameNode.fontSize = 14;
-              nameNode.characters = sizeName;
-              nameNode.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];
-              nameNode.textAutoResize = 'WIDTH_AND_HEIGHT';
-              infoCol.appendChild(nameNode);
-              if (spVKo) bfv(nameNode, spVKo);
-
-              const metaNode = figma.createText();
-              metaNode.fontName = { family: 'Adobe Clean', style: 'Regular' };
-              metaNode.fontSize = 12;
-              metaNode.characters = `${cssVar}  ·  ${fmtPx(resolvedPx)}`;
-              metaNode.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];
-              metaNode.textAutoResize = 'WIDTH_AND_HEIGHT';
-              infoCol.appendChild(metaNode);
-              if (spVBody) bfv(metaNode, spVBody);
-
-              // Swatch column
-              const swatchCol = figma.createFrame();
-              swatchCol.name = 'swatch';
-              swatchCol.fills = [];
-              swatchCol.layoutMode = 'HORIZONTAL';
-              swatchCol.primaryAxisSizingMode = 'AUTO';
-              swatchCol.counterAxisSizingMode = 'AUTO';
-              swatchCol.counterAxisAlignItems = 'CENTER';
-              rowFrame.appendChild(swatchCol);
-
-              const swSizePx = resolvedPx !== null && resolvedPx > 0 ? Math.min(resolvedPx, 120) : null;
-              const swDisplay = swSizePx ?? 4;
-              const sw = figma.createRectangle();
-              sw.resize(swDisplay, swDisplay);
-              sw.cornerRadius = 4;
-              sw.fills = [{ type: 'SOLID', color: { r: 0.3, g: 0.3, b: 0.35 } }];
-              swatchCol.appendChild(sw);
-              if (spVBgSub) bfv(sw, spVBgSub);
-              if (swSizePx !== null) {
-                try { (sw as any).setBoundVariable('width', sv); } catch {}
-                try { (sw as any).setBoundVariable('height', sv); } catch {}
-              }
-              sw.setPluginData('s2aTokenVar', sv.name);
-              sw.setPluginData('s2aTokenProp', 'spacing');
-
-              spHSp(16);
-            }
-
-            spHDv();
-            spHSp(56);
-
-            const finalH = frame.height;
-            sec.resizeWithoutConstraints(SP_W, finalH);
-            bgRect.resize(SP_W, finalH);
-
-            spPlaceY += finalH + 80;
-            spCreated.push(sec);
-          }
-
-          if (spCreated.length > 0) figma.viewport.scrollAndZoomIntoView(spCreated);
-          figma.notify(`${spCreated.length} section-padding breakpoint sections generated`);
-          figma.ui.postMessage({ type: 'token-docs:result', sectionId: spCreated[0]?.id ?? '', count: spCreated.length });
-          break;
-        }
-
-        // ── Data collection ─────────────────────────────────────────────
-        const allVars   = await figma.variables.getLocalVariablesAsync();
-        const groupVars = allVars.filter(v =>
-          v.variableCollectionId === collectionId && tokenGroup(v.name) === group
-        );
-        if (groupVars.length === 0) throw new Error('No variables found for group: ' + group);
-
-        const allColls      = await figma.variables.getLocalVariableCollectionsAsync();
-        const coll          = allColls.find(c => c.id === collectionId);
-        if (!coll) throw new Error('Collection not found: ' + collectionId);
-        const defaultModeId = coll.defaultModeId;
-
-        const rows: Array<{
-          path: string; cssVar: string; value: string; alias: string;
-          variable: Variable; resolvedType: VariableResolvedDataType; rawNum?: number;
-        }> = [];
-
-        for (const v of groupVars) {
-          const rawVal = v.valuesByMode[defaultModeId];
-          let value = '', alias = '';
-          let rawNum: number | undefined;
-          if (rawVal && typeof rawVal === 'object' && 'type' in rawVal && (rawVal as any).type === 'VARIABLE_ALIAS') {
-            try {
-              const refVar = await figma.variables.getVariableByIdAsync((rawVal as any).id);
-              if (refVar) {
-                alias = refVar.name;
-                const refModeId = Object.keys(refVar.valuesByMode)[0];
-                const refVal    = refVar.valuesByMode[refModeId];
-                value = fmtTokenValue(refVal);
-                if (typeof refVal === 'number') rawNum = refVal as number;
-              }
-            } catch {}
-          } else {
-            value = fmtTokenValue(rawVal);
-            if (typeof rawVal === 'number') rawNum = rawVal as number;
-          }
-          rows.push({
-            path: v.name,
-            cssVar: '--' + v.name.replace(/\//g, '-'),
-            value, alias,
-            variable: v, resolvedType: v.resolvedType, rawNum,
-          });
-        }
-        // Canonical t-shirt size order, then raw numeric, then alphabetical
-        const TSHIRT: Record<string, number> = {
-          'none': 0, 'base': 1, '5xs': 2, '4xs': 3, '3xs': 4, '2xs': 5, 'xs': 6,
-          'sm': 7, 'md': 8, 'lg': 9, 'xl': 10, '2xl': 11, '3xl': 12, '4xl': 13, '5xl': 14,
-          'round': 98, 'pill': 98, 'full': 98, 'circle': 99,
-        };
-        rows.sort((a, b) => {
-          const ak = (a.path.split('/').pop() ?? '').toLowerCase();
-          const bk = (b.path.split('/').pop() ?? '').toLowerCase();
-          const ao = ak in TSHIRT ? TSHIRT[ak] : -1;
-          const bo = bk in TSHIRT ? TSHIRT[bk] : -1;
-          if (ao !== -1 && bo !== -1) return ao - bo;           // both t-shirt → canonical order
-          if (ao !== -1) return -1;                              // only a is t-shirt → a first
-          if (bo !== -1) return 1;                              // only b is t-shirt → b first
-          if (a.rawNum !== undefined && b.rawNum !== undefined) return a.rawNum - b.rawNum; // numeric
-          return a.path.localeCompare(b.path);                  // fallback alphabetical
-        });
-
-        // ── Fonts + token variables ──────────────────────────────────────
-        await Promise.all([
-          figma.loadFontAsync({ family: 'Adobe Clean Display', style: 'Bold' }),
-          figma.loadFontAsync({ family: 'Adobe Clean Display', style: 'Black' }).catch(() => {}),
-          figma.loadFontAsync({ family: 'Adobe Clean', style: 'Bold' }),
-          figma.loadFontAsync({ family: 'Adobe Clean', style: 'Regular' }),
-          figma.loadFontAsync({ family: 'Adobe Clean', style: 'ExtraBold' }).catch(() => {}),
-        ]);
-
-        const [vBg2, vBorder2, vBody2, vSub2, vKo2, vBgSub2] = await Promise.all([
-          figma.variables.getVariableByIdAsync(DARK_VAR.bgKnockout),
-          figma.variables.getVariableByIdAsync(DARK_VAR.borderSubtle),
-          figma.variables.getVariableByIdAsync(DARK_VAR.cBodySubtle),
-          figma.variables.getVariableByIdAsync(DARK_VAR.cSubheading),
-          figma.variables.getVariableByIdAsync(DARK_VAR.cKnockout),
-          figma.variables.getVariableByIdAsync(DARK_VAR.bgSubtle),
-        ]);
-
-        const themeColl = allColls.find(c => c.id === DARK_VAR.collectionId)!;
-        const darkId    = themeColl.modes.find(m => m.name === 'Dark')!.modeId;
-
-        // ── Placement ────────────────────────────────────────────────────
-        const page = figma.currentPage;
-        const pageSections = page.children.filter(n => n.type === 'SECTION') as SectionNode[];
-        const lastSec = pageSections.reduce<SectionNode | null>(
-          (a, b) => (!a || b.y + b.height > a.y + a.height ? b : a), null
-        );
-        const placeX = lastSec?.x ?? 0;
-        const placeY = lastSec ? lastSec.y + lastSec.height + 80 : 0;
-
-        const W = 2400, M = 120;
-
-        // ── Section skeleton ─────────────────────────────────────────────
-        const sec = figma.createSection();
-        sec.name = group;
-        sec.x = placeX; sec.y = placeY;
-        sec.resizeWithoutConstraints(W, 800);
-
-        const bgRect = figma.createRectangle();
-        bgRect.resize(W, 800); bgRect.x = 0; bgRect.y = 0;
-        bgRect.fills = [{ type: 'SOLID', color: { r: 0.04, g: 0.04, b: 0.047 } }];
-        sec.appendChild(bgRect);
-        if (vBg2) bfv(bgRect, vBg2);
-
-        // .content: VERTICAL auto-layout so height auto-sizes to content
-        const frame = figma.createFrame();
-        frame.name = '.content';
-        frame.fills = []; frame.clipsContent = false;
-        frame.layoutMode = 'VERTICAL';
-        frame.resize(W, 800);
-        frame.primaryAxisSizingMode   = 'AUTO';
-        frame.counterAxisSizingMode   = 'FIXED';
-        frame.paddingTop    = 160;
-        frame.paddingBottom = 120;
-        frame.paddingLeft   = M;
-        frame.paddingRight  = M;
-        frame.itemSpacing   = 0;
-        frame.counterAxisAlignItems = 'MIN';
-        frame.x = 0; frame.y = 0;
-        sec.appendChild(frame);
-        frame.setExplicitVariableModeForCollection(themeColl, darkId);
-
-        // ── Helpers ──────────────────────────────────────────────────────
-        function hTxt(chars: string, family: string, style: string, size: number, v: Variable | null, fixedW?: number): TextNode {
-          const n = figma.createText();
-          n.fontName = { family, style };
-          n.fontSize = size;
-          n.characters = chars;
-          n.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];
-          if (fixedW) n.resize(fixedW, n.height);
-          n.textAutoResize = 'HEIGHT';
-          frame.appendChild(n);
-          if (!fixedW) n.layoutSizingHorizontal = 'FILL';
-          if (v) bfv(n, v);
-          return n;
-        }
-
-        function hSpacer(h: number): void {
-          const sp = figma.createFrame();
-          sp.fills = []; sp.resize(W - M * 2, h);
-          sp.primaryAxisSizingMode = 'FIXED';
-          frame.appendChild(sp);
-          sp.layoutSizingHorizontal = 'FILL';
-        }
-
-        function hDiv(): void {
-          const r = figma.createRectangle();
-          r.resize(W - M * 2, 1);
-          r.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 }, opacity: 0.12 }];
-          frame.appendChild(r);
-          r.layoutSizingHorizontal = 'FILL';
-          if (vBorder2) bfv(r, vBorder2);
-        }
-
-        function bindStroke(node: SceneNode, v: Variable): void {
-          const ss: Paint[] = [...((node as any).strokes ?? [])];
-          if (!ss.length) return;
-          ss[0] = figma.variables.setBoundVariableForPaint(ss[0] as SolidPaint, 'color', v);
-          (node as any).strokes = ss;
-        }
-
-        // ── Header ───────────────────────────────────────────────────────
-        hTxt(group, 'Adobe Clean Display', 'Bold', 56, vKo2);
-        hSpacer(24);
-        hTxt(coll.name, 'Adobe Clean', 'Regular', 20, vBody2, 1600);
-        hSpacer(24);
-        hTxt('May 2026  ·  @matt', 'Adobe Clean', 'Regular', 14, vBody2, 600);
-        hSpacer(80);
-        hDiv();
-        hSpacer(56);
-
-        // ── Token rows ───────────────────────────────────────────────────
-        const gl = group.toLowerCase();
-        const isTypography = gl.includes('typography');
-
-        if (isTypography) {
-          // Sort modes: sm → md → lg → xl
-          const MODE_ORDER = ['sm', 'md', 'lg', 'xl'];
-          const sortedModes = [...coll.modes].sort((a, b) =>
-            MODE_ORDER.indexOf(a.name.toLowerCase()) - MODE_ORDER.indexOf(b.name.toLowerCase())
-          );
-
-          // All typography vars across font-size / line-height / letter-spacing
-          const allTypoVars = allVars.filter(v =>
-            v.variableCollectionId === collectionId &&
-            v.name.toLowerCase().includes('/typography/')
-          );
-
-          const textStyles = await figma.getLocalTextStylesAsync();
-
-          const STYLE_ORDER = [
-            'super', 'heading-1', 'heading-2', 'heading-3', 'heading-4', 'heading-5', 'heading-6',
-            'body-lg', 'body-md', 'body-sm', 'body-xs', 'eyebrow', 'label', 'caption',
-          ];
-          const availableStyles = STYLE_ORDER.filter(s =>
-            allTypoVars.some(v => v.name.endsWith(`/${s}`))
-          );
-
-          for (const styleName of availableStyles) {
-            const fsVar = allTypoVars.find(v => v.name === `s2a/typography/font-size/${styleName}`) ?? null;
-            const lhVar = allTypoVars.find(v => v.name === `s2a/typography/line-height/${styleName}`) ?? null;
-            const lsVar = allTypoVars.find(v => v.name === `s2a/typography/letter-spacing/${styleName}`) ?? null;
-            const textStyle = textStyles.find(s => s.name === `s2a/typography/${styleName}`) ?? null;
-
-            // Style label
-            hTxt(styleName, 'Adobe Clean', 'Bold', 18, vSub2);
-            hSpacer(12);
-
-            // Sample text — shorter for large display styles to keep the layout readable
-            const isDisplayStyle = ['super', 'heading-1', 'heading-2'].includes(styleName);
-            const isSmallStyle = ['eyebrow', 'label', 'caption'].includes(styleName);
-            const sampleText = isDisplayStyle ? 'Make anything.'
-              : isSmallStyle ? 'Everything you need to make anything you want.'
-              : 'Everything you need to make anything.';
-
-            // 4 columns — one per breakpoint, each with an explicit mode override so
-            // Figma renders the text at the actual scale for that breakpoint
-            const bpFrame = figma.createFrame();
-            bpFrame.name = '.breakpoints';
-            bpFrame.layoutMode = 'HORIZONTAL';
-            bpFrame.primaryAxisSizingMode = 'AUTO';
-            bpFrame.counterAxisSizingMode = 'AUTO';
-            bpFrame.itemSpacing = 1;
-            bpFrame.fills = [];
-            frame.appendChild(bpFrame);
-            bpFrame.layoutSizingHorizontal = 'FILL';
-
-            for (const mode of sortedModes) {
-              const colFrame = figma.createFrame();
-              colFrame.name = mode.name.toUpperCase();
-              colFrame.layoutMode = 'VERTICAL';
-              colFrame.primaryAxisSizingMode = 'AUTO';
-              colFrame.counterAxisSizingMode = 'AUTO';
-              colFrame.paddingTop = 24; colFrame.paddingBottom = 24;
-              colFrame.paddingLeft = 24; colFrame.paddingRight = 24;
-              colFrame.itemSpacing = 12;
-              colFrame.fills = [];
-              bpFrame.appendChild(colFrame);
-              colFrame.layoutSizingHorizontal = 'FILL';
-              // Explicit mode forces this column's text to resolve at the correct breakpoint
-              try { colFrame.setExplicitVariableModeForCollection(coll, mode.modeId); } catch {}
-
-              const modeLabel = figma.createText();
-              modeLabel.fontName = { family: 'Adobe Clean', style: 'Bold' };
-              modeLabel.fontSize = 11;
-              modeLabel.characters = mode.name.toUpperCase();
-              colFrame.appendChild(modeLabel);
-              modeLabel.layoutSizingHorizontal = 'FILL';
-              if (vSub2) bfv(modeLabel, vSub2);
-
-              const textNode = figma.createText();
-              textNode.fontName = { family: 'Adobe Clean', style: 'Regular' };
-              textNode.fontSize = 16;
-              textNode.characters = sampleText;
-              colFrame.appendChild(textNode);
-              textNode.layoutSizingHorizontal = 'FILL';
-              textNode.textAutoResize = 'HEIGHT';
-              if (textStyle) { try { await textNode.setTextStyleIdAsync(textStyle.id); } catch {} }
-              if (fsVar) try { (textNode as any).setBoundVariable('fontSize', fsVar); } catch {}
-              if (lhVar) try { (textNode as any).setBoundVariable('lineHeight', lhVar); } catch {}
-              if (lsVar) try { (textNode as any).setBoundVariable('letterSpacing', lsVar); } catch {}
-              if (vKo2) bfv(textNode, vKo2);
-              const annProps: Array<{ type: string }> = [];
-              if (fsVar) annProps.push({ type: 'fontSize' });
-              if (lhVar) annProps.push({ type: 'lineHeight' });
-              if (lsVar) annProps.push({ type: 'letterSpacing' });
-              try { textNode.annotations = [{ label: `s2a/typography/${styleName}`, properties: annProps as any }]; } catch {}
-            }
-
-            hSpacer(24);
-            hDiv();
-            hSpacer(32);
-          }
-        } else {
-
-        for (const row of rows) {
-          // Row: HORIZONTAL frame, fills content width, text col + swatch col
-          const rowFrame = figma.createFrame();
-          rowFrame.name = row.path.split('/').pop() ?? row.path;
-          rowFrame.layoutMode = 'HORIZONTAL';
-          rowFrame.primaryAxisSizingMode = 'AUTO';
-          rowFrame.counterAxisSizingMode = 'AUTO';
-          rowFrame.paddingTop = 16; rowFrame.paddingBottom = 16;
-          rowFrame.paddingLeft = 0; rowFrame.paddingRight = 0;
-          rowFrame.itemSpacing = 40;
-          rowFrame.counterAxisAlignItems = 'CENTER';
-          rowFrame.fills = [];
-          frame.appendChild(rowFrame);
-          rowFrame.layoutSizingHorizontal = 'FILL';
-
-          // Text column: VERTICAL, fills remaining width
-          const textCol = figma.createFrame();
-          textCol.name = '.text';
-          textCol.layoutMode = 'VERTICAL';
-          textCol.primaryAxisSizingMode = 'AUTO';
-          textCol.counterAxisSizingMode = 'AUTO';
-          textCol.itemSpacing = 4;
-          textCol.fills = [];
-          rowFrame.appendChild(textCol);
-          textCol.layoutSizingHorizontal = 'FILL';
-
-          const rTxt = (chars: string, style: string, size: number, v: Variable | null): TextNode => {
-            const n = figma.createText();
-            n.fontName = { family: 'Adobe Clean', style };
-            n.fontSize = size;
-            n.characters = chars;
-            n.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];
-            n.textAutoResize = 'HEIGHT';
-            textCol.appendChild(n);
-            n.layoutSizingHorizontal = 'FILL';
-            if (v) bfv(n, v);
-            return n;
-          };
-
-          rTxt(row.path, 'Bold', 16, vSub2);
-          rTxt(row.cssVar, 'Regular', 14, vBody2);
-          rTxt(row.alias ? row.value + '  →  ' + row.alias : row.value, 'Regular', 14, vBody2);
-
-          // Swatch column: fixed 200px wide, hugs content height, centers children
-          const swatchCol = figma.createFrame();
-          swatchCol.name = '.swatch';
-          swatchCol.layoutMode = 'VERTICAL';
-          swatchCol.counterAxisSizingMode = 'FIXED';
-          swatchCol.primaryAxisAlignItems = 'CENTER';
-          swatchCol.counterAxisAlignItems = 'CENTER';
-          swatchCol.fills = [];
-          rowFrame.appendChild(swatchCol);
-          // Must set after appendChild — Figma resets sizing on insertion
-          swatchCol.resize(200, 1);
-          swatchCol.primaryAxisSizingMode = 'AUTO';
-          swatchCol.layoutSizingVertical = 'HUG';
-
-          // Annotation label = CSS variable name (the token designers + engineers reference)
-          const annotLabel = row.cssVar;
-
-          if (row.resolvedType === 'COLOR') {
-            const sw = figma.createRectangle();
-            sw.resize(200, 56);
-            sw.cornerRadius = 6;
-            // Transparent token groups need a contrast base so alpha is visible.
-            // Use white base for black-alpha tokens, dark gray for white-alpha tokens,
-            // a 50% gray split for generic transparent groups, nothing for solid colors.
-            const isTransparentBlack = gl.includes('transparent') && gl.includes('black');
-            const isTransparentWhite = gl.includes('transparent') && gl.includes('white');
-            const isTransparent = gl.includes('transparent');
-            const baseColor = isTransparentBlack ? { r: 1,   g: 1,   b: 1   }
-                            : isTransparentWhite ? { r: 0.2, g: 0.2, b: 0.2 }
-                            : isTransparent      ? { r: 0.5, g: 0.5, b: 0.5 }
-                            : null;
-            const placeholder: SolidPaint = { type: 'SOLID', color: { r: 0.5, g: 0.5, b: 0.5 } };
-            sw.fills = baseColor
-              ? [{ type: 'SOLID', color: baseColor }, placeholder]  // base + variable layer
-              : [placeholder];
-            swatchCol.appendChild(sw);
-            sw.layoutSizingHorizontal = 'FILL';
-            try {
-              const f = [...sw.fills] as SolidPaint[];
-              const bindIdx = baseColor ? 1 : 0;
-              f[bindIdx] = figma.variables.setBoundVariableForPaint(f[bindIdx], 'color', row.variable);
-              sw.fills = f;
-            } catch {}
-            if (vBorder2) {
-              sw.strokes = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];
-              sw.strokeWeight = 1;
-              sw.strokeAlign = 'INSIDE';
-              bindStroke(sw, vBorder2);
-            }
-            sw.setPluginData('s2aTokenVar', annotLabel);
-            sw.setPluginData('s2aTokenProp', 'fills');
-            try { sw.annotations = [{ label: annotLabel, properties: [{ type: 'fills' }] }]; } catch {}
-          } else if (row.resolvedType === 'FLOAT') {
-            const num = row.rawNum ?? 4;
-            if (gl.includes('radius')) {
-              const sw = figma.createRectangle();
-              sw.resize(80, 80);
-              sw.cornerRadius = Math.min(num, 40);
-              // Bind all four corners — 'cornerRadius' is not a valid bindable field
-              if (num > 0) {
-                for (const corner of ['topLeftRadius', 'topRightRadius', 'bottomLeftRadius', 'bottomRightRadius']) {
-                  try { (sw as any).setBoundVariable(corner, row.variable); } catch {}
-                }
-              }
-              sw.fills = [{ type: 'SOLID', color: { r: 0.2, g: 0.2, b: 0.25 } }];
-              if (vBgSub2) bfv(sw, vBgSub2);
-              sw.strokes = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];
-              sw.strokeWeight = 1; sw.strokeAlign = 'INSIDE';
-              if (vBorder2) bindStroke(sw, vBorder2);
-              sw.setPluginData('s2aTokenVar', annotLabel);
-              sw.setPluginData('s2aTokenProp', num > 0 ? 'cornerRadius' : 'fills');
-              swatchCol.appendChild(sw);
-              const crProp = num > 0 ? 'cornerRadius' : 'fills';
-              try { sw.annotations = [{ label: annotLabel, properties: [{ type: crProp }] }]; } catch {}
-            } else if (gl.includes('width') || gl.includes('stroke') || gl.includes('border')) {
-              const sw = figma.createRectangle();
-              sw.resize(80, 80);
-              sw.fills = []; sw.cornerRadius = 4;
-              sw.strokes = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];
-              sw.strokeWeight = Math.max(1, Math.min(num, 20));
-              sw.strokeAlign = 'CENTER';
-              if (vBorder2) bindStroke(sw, vBorder2);
-              try { (sw as any).setBoundVariable('strokeWeight', row.variable); } catch {}
-              sw.setPluginData('s2aTokenVar', annotLabel);
-              sw.setPluginData('s2aTokenProp', 'strokeWeight');
-              swatchCol.appendChild(sw);
-              try { sw.annotations = [{ label: annotLabel, properties: [{ type: 'strokeWeight' }] }]; } catch {}
-            } else if (gl.includes('spacing') || gl.includes('gap') || gl.includes('padding') || gl.includes('margin')) {
-              // Block/section padding tokens represent 2D space — show as a square
-              const isBlockPadding = gl.includes('section-padding');
-              const swSize = Math.max(num, isBlockPadding ? 4 : 1);
-              const sw = figma.createRectangle();
-              sw.resize(swSize, isBlockPadding ? swSize : 32);
-              sw.cornerRadius = 4;
-              sw.fills = [{ type: 'SOLID', color: { r: 0.3, g: 0.3, b: 0.35 } }];
-              if (vBgSub2) bfv(sw, vBgSub2);
-              try { (sw as any).setBoundVariable('width', row.variable); } catch {}
-              if (isBlockPadding) { try { (sw as any).setBoundVariable('height', row.variable); } catch {} }
-              sw.setPluginData('s2aTokenVar', annotLabel);
-              sw.setPluginData('s2aTokenProp', 'spacing');
-              swatchCol.appendChild(sw);
-              const annPropsSp = isBlockPadding
-                ? [{ type: 'width' }, { type: 'height' }]
-                : [{ type: 'width' }];
-              try { sw.annotations = [{ label: annotLabel, properties: annPropsSp }]; } catch {}
-            } else if (gl.includes('opacity')) {
-              // Split swatch: left = 100% (reference), right = token opacity
-              // Medium-gray bg bleeds through the right side to show the fade
-              const swFrame = figma.createFrame();
-              swFrame.name = '.opacity-swatch';
-              swFrame.resize(160, 64);
-              swFrame.cornerRadius = 8;
-              swFrame.clipsContent = true;
-              swFrame.fills = [{ type: 'SOLID', color: { r: 0.62, g: 0.62, b: 0.67 } }];
-              const fullBlock = figma.createRectangle();
-              fullBlock.resize(78, 64); fullBlock.x = 0; fullBlock.y = 0;
-              fullBlock.fills = [{ type: 'SOLID', color: { r: 0.06, g: 0.06, b: 0.14 } }];
-              fullBlock.opacity = 1;
-              swFrame.appendChild(fullBlock);
-              const fadeBlock = figma.createRectangle();
-              fadeBlock.resize(78, 64); fadeBlock.x = 82; fadeBlock.y = 0;
-              fadeBlock.fills = [{ type: 'SOLID', color: { r: 0.06, g: 0.06, b: 0.14 } }];
-              fadeBlock.opacity = Math.max(0, Math.min(1, num / 100));
-              swFrame.appendChild(fadeBlock);
-              try { (fadeBlock as any).setBoundVariable('opacity', row.variable); } catch {}
-              swatchCol.appendChild(swFrame);
-              swFrame.setPluginData('s2aTokenVar', annotLabel);
-              swFrame.setPluginData('s2aTokenProp', 'opacity');
-              try { swFrame.annotations = [{ label: annotLabel, properties: [] }]; } catch {}
-            } else if (gl.includes('blur')) {
-              const swFrame = figma.createFrame();
-              swFrame.name = '.blur-swatch';
-              swFrame.resize(200, 80);
-              swFrame.cornerRadius = 8;
-              swFrame.clipsContent = true;
-              swFrame.fills = [{ type: 'SOLID', color: { r: 0.06, g: 0.06, b: 0.08 } }];
-              const bar = figma.createRectangle();
-              bar.resize(160, 3);
-              bar.x = 20; bar.y = 38;
-              bar.cornerRadius = 2;
-              bar.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 }, opacity: 0.9 }];
-              bar.effects = [{ type: 'LAYER_BLUR', radius: num, visible: true }];
-              bar.constraints = { horizontal: 'STRETCH', vertical: 'CENTER' };
-              swFrame.appendChild(bar);
-              swatchCol.appendChild(swFrame);
-              swFrame.setPluginData('s2aTokenVar', annotLabel);
-              swFrame.setPluginData('s2aTokenProp', 'blur');
-              try { swFrame.annotations = [{ label: annotLabel, properties: [] }]; } catch {}
-            } else {
-              const sw = figma.createRectangle();
-              sw.resize(64, 64);
-              sw.cornerRadius = 4;
-              sw.fills = [{ type: 'SOLID', color: { r: 0.2, g: 0.2, b: 0.24 } }];
-              if (vBgSub2) bfv(sw, vBgSub2);
-              swatchCol.appendChild(sw);
-              try { sw.annotations = [{ label: annotLabel, properties: [{ type: 'width' }, { type: 'height' }] }]; } catch {}
-            }
-          }
-
-          hDiv();
-        }
-        } // end else (non-typography)
-
-        // ── Sync section to auto-sized content frame ─────────────────────
-        const finalH = frame.height;
-        sec.resizeWithoutConstraints(W, finalH);
-        bgRect.resize(W, finalH);
-
-        figma.viewport.scrollAndZoomIntoView([sec]);
-        figma.notify(rows.length + ' tokens documented');
-        figma.ui.postMessage({ type: 'token-docs:result', sectionId: sec.id, count: rows.length });
-      } catch (e: any) {
-        figma.ui.postMessage({ type: 'token-docs:result', error: e.message || String(e) });
-      }
-      break;
-    }
-
-    case 'spec:generate': {
-      try {
-      const setId = msg.setId as string;
-      const opts  = (msg.options as { variants: boolean; tokens: boolean; children: boolean })
-                 ?? { variants: true, tokens: true, children: true };
-
-      const specSetNode = await figma.getNodeByIdAsync(setId);
-      if (!specSetNode || (specSetNode.type !== 'COMPONENT_SET' && specSetNode.type !== 'COMPONENT')) {
-        figma.ui.postMessage({ type: 'spec:result', error: 'Select a component or component set first' });
-        break;
-      }
-      const specSet  = specSetNode as ComponentSetNode | ComponentNode;
-      const variants: ComponentNode[] = specSetNode.type === 'COMPONENT_SET'
-        ? ((specSetNode as ComponentSetNode).children as ComponentNode[])
-        : [specSetNode as ComponentNode];
-
-      await Promise.all([
-        figma.loadFontAsync({ family: 'Adobe Clean Display', style: 'Bold' }),
-        figma.loadFontAsync({ family: 'Adobe Clean', style: 'Regular' }),
-        figma.loadFontAsync({ family: 'Adobe Clean', style: 'Bold' }),
-      ]);
-
-      // ── Property axes ──────────────────────────────────────────────────────
-      const propDefs = specSet.componentPropertyDefinitions;
-      const axes = Object.entries(propDefs)
-        .filter(([, d]) => d.type === 'VARIANT')
-        .map(([name, d]) => ({ name, values: (d as any).variantOptions as string[] }));
-
-      // ── Token prefetch ─────────────────────────────────────────────────────
-      const [vBg, vBorderSubtle, vBodySubtle, vSubheading, vKnockout] = await Promise.all([
-        figma.variables.getVariableByIdAsync(DARK_VAR.bgKnockout),
-        figma.variables.getVariableByIdAsync(DARK_VAR.borderSubtle),
-        figma.variables.getVariableByIdAsync(DARK_VAR.cBodySubtle),
-        figma.variables.getVariableByIdAsync(DARK_VAR.cSubheading),
-        figma.variables.getVariableByIdAsync(DARK_VAR.cKnockout),
-      ]);
-
-      // Search the whole document for the .Surface Split component
-      // loadAllPagesAsync required before root.findOne in dynamic-page mode
-      await figma.loadAllPagesAsync();
-      const splitComp = figma.root.findOne(
-        (n: BaseNode) => n.type === 'COMPONENT' && (n as ComponentNode).name === '.Surface Split'
-      ) as ComponentNode | null;
-
-      const colls = await figma.variables.getLocalVariableCollectionsAsync();
-      const coll  = colls.find(c => c.id === DARK_VAR.collectionId)!;
-      const darkId  = coll?.modes.find(m => m.name === 'Dark')?.modeId;
-      const lightId = coll?.modes.find(m => m.name === 'Light')?.modeId ?? coll?.defaultModeId;
-
-      // ── Shared dark section factory ────────────────────────────────────────
-      // Returns { sec, frame, mkTxt, gap, divider, finish }
-      // `finish` resizes sec/bg/frame to the current cursor y + bottom pad.
-      function makeDarkSection(name: string, w: number, x: number, y: number) {
-        const sec = figma.createSection();
-        sec.name = name;
-        sec.x = x; sec.y = y;
-        sec.resizeWithoutConstraints(w, 800);
-        figma.currentPage.appendChild(sec);
-
-        const bg = figma.createRectangle();
-        bg.resize(w, 800); bg.x = 0; bg.y = 0;
-        bg.fills = [{ type: 'SOLID', color: { r: 0.04, g: 0.04, b: 0.047 } }];
-        sec.insertChild(0, bg);
-        if (vBg) bfv(bg, vBg);
-
-        const frame = figma.createFrame();
-        frame.name = '.content';
-        frame.fills = []; frame.clipsContent = false; frame.layoutMode = 'NONE';
-        frame.resize(w, 800); frame.x = 0; frame.y = 0;
-        sec.appendChild(frame);
-        if (coll && darkId) frame.setExplicitVariableModeForCollection(coll, darkId);
-
-        const M2 = 120, CW2 = w - 240;
-        let cy = 0;
-
-        function mkTxt(chars: string, family: string, style: string, size: number, v: Variable | null, ww?: number): TextNode {
-          const n = figma.createText();
-          n.fontName = { family, style }; n.fontSize = size;
-          n.characters = chars;
-          n.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];
-          n.x = M2; n.y = cy;
-          if (ww) { n.resize(ww, n.height); n.textAutoResize = 'HEIGHT'; }
-          else n.textAutoResize = 'WIDTH_AND_HEIGHT';
-          frame.appendChild(n);
-          if (v) bfv(n, v);
-          cy += n.height;
-          return n;
-        }
-
-        function gap(px: number): void { cy += px; }
-
-        function divider(): void {
-          const r = figma.createRectangle();
-          r.resize(CW2, 1); r.x = M2; r.y = cy;
-          r.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 }, opacity: 0.12 }];
-          frame.appendChild(r);
-          if (vBorderSubtle) bfv(r, vBorderSubtle);
-          cy += 1;
-        }
-
-        function finish(bottomPad = 120): void {
-          const finalH = cy + bottomPad;
-          sec.resizeWithoutConstraints(w, finalH);
-          bg.resize(w, finalH);
-          frame.resize(w, finalH);
-        }
-
-        function getCy(): number { return cy; }
-        function setCy(v2: number): void { cy = v2; }
-
-        return { sec, frame, mkTxt, gap, divider, finish, getCy, setCy, M: M2, CW: CW2, BW: Math.min(1600, CW2) };
-      }
-
-      // ── Helper: annotate own structural tokens, skip sub-component internals ─
-      //
-      // Atom   (no nested instances): annotate everything — fills, strokes,
-      //        radius, spacing, text color, typography.
-      //
-      // Molecule / Organism (has nested instances): annotate ONLY structural
-      //        properties on frames and rects (fills, strokes, radius, padding,
-      //        gap). Skip all TEXT nodes — their typography and color are already
-      //        documented in the sub-component spec sections.
-      function annotateTree(root: BaseNode): void {
-        // Detect molecule/organism: any INSTANCE descendant inside root
-        const isComposite = !!(root as any).findOne?.((n: BaseNode) => n.type === 'INSTANCE');
-
-        function annotateNode(n: BaseNode): void {
-          // Molecules/organisms: skip text nodes entirely
-          if (isComposite && n.type === 'TEXT') return;
-
-          const bv: Record<string, any> = (n as any).boundVariables ?? {};
-          const anns: Array<{ labelMarkdown: string; properties: Array<{ type: string }> }> = [];
-
-          if ((bv.fills?.length ?? 0) > 0)
-            anns.push({ labelMarkdown: n.type === 'TEXT' ? 'Color' : 'Fill', properties: [{ type: 'fills' }] });
-          if ((bv.strokes?.length ?? 0) > 0)
-            anns.push({ labelMarkdown: 'Border', properties: [{ type: 'strokes' }] });
-          if (bv.cornerRadius?.id || bv.topLeftRadius?.id)
-            anns.push({ labelMarkdown: 'Radius', properties: [{ type: 'cornerRadius' }] });
-
-          const sp: Array<{ type: string }> = [];
-          if (bv.paddingTop || bv.paddingBottom || bv.paddingLeft || bv.paddingRight) sp.push({ type: 'padding' });
-          if (bv.itemSpacing) sp.push({ type: 'itemSpacing' });
-          if (sp.length) anns.push({ labelMarkdown: 'Spacing', properties: sp });
-
-          // Typography only on atoms
-          if (!isComposite && n.type === 'TEXT') {
-            const tp: Array<{ type: string }> = [];
-            if ((bv.fontSize?.length      ?? 0) > 0) tp.push({ type: 'fontSize' });
-            if ((bv.lineHeight?.length    ?? 0) > 0) tp.push({ type: 'lineHeight' });
-            if ((bv.letterSpacing?.length ?? 0) > 0) tp.push({ type: 'letterSpacing' });
-            if (tp.length) anns.push({ labelMarkdown: 'Typography', properties: tp });
-          }
-
-          if (anns.length) { try { (n as any).annotations = anns; } catch {} }
-        }
-
-        annotateNode(root);
-        function walkChildren(n: BaseNode): void {
-          if (!('children' in n)) return;
-          for (const child of (n as any).children) {
-            annotateNode(child);
-            if (child.type !== 'INSTANCE') walkChildren(child);
-          }
-        }
-        walkChildren(root);
-      }
-
-      // ── Layout origin ──────────────────────────────────────────────────────
-      const originX = specSet.x + specSet.width + 200;
-      const originY = specSet.y;
-
-      // ══════════════════════════════════════════════════════════════════════
-      // SECTION 1 — Overview: all variants, no annotations
-      // ══════════════════════════════════════════════════════════════════════
-      const OW = 2400;
-      const s1 = makeDarkSection(specSet.name, OW, originX, originY);
-      s1.setCy(160);
-
-      s1.mkTxt(specSet.name, 'Adobe Clean Display', 'Bold', 56, vKnockout, s1.CW);
-      s1.gap(24);
-
-      const subtitle = `${variants.length} variant${variants.length !== 1 ? 's' : ''}` +
-        (axes.length ? '  ·  ' + axes.map(a => a.name).join('  ·  ') : '');
-      s1.mkTxt(subtitle, 'Adobe Clean', 'Regular', 20, vBodySubtle, s1.BW);
-      s1.gap(24);
-
-      const now = new Date();
-      const monthName = now.toLocaleString('en-US', { month: 'long' });
-      s1.mkTxt(`${monthName} ${now.getFullYear()}  ·  @matt`, 'Adobe Clean', 'Regular', 14, vBodySubtle, 600);
-      s1.gap(80); s1.divider(); s1.gap(56);
-
-      // Move the original component set into the doc section — no duplicate
-      specSet.x = s1.M; specSet.y = s1.getCy();
-      s1.frame.appendChild(specSet);
-      // Reset to Light so it doesn't inherit the frame's Dark override
-      if (coll && lightId) specSet.setExplicitVariableModeForCollection(coll, lightId);
-
-      // Surface Split behind the component set (warm charcoal / deep-black backdrop)
-      if (splitComp && coll) {
-        const split = splitComp.createInstance();
-        split.name = '.Surface Split';
-        const csIdx = s1.frame.children.indexOf(specSet);
-        s1.frame.insertChild(csIdx, split);
-        const SP = 40;
-        split.resizeWithoutConstraints(specSet.width + SP * 2, specSet.height + SP * 2);
-        split.x = specSet.x - SP; split.y = specSet.y - SP;
-        split.clearExplicitVariableModeForCollection(coll);
-      }
-
-      s1.setCy(s1.getCy() + specSet.height);
-      s1.gap(56); s1.divider(); s1.gap(56);
-
-      // Properties table
-      s1.mkTxt('Properties', 'Adobe Clean', 'Bold', 18, vSubheading, s1.CW);
-      s1.gap(12);
-      if (axes.length) {
-        s1.mkTxt(axes.map(a => `${a.name}: ${a.values.join(', ')}`).join('   ·   '), 'Adobe Clean', 'Regular', 18, vBodySubtle, s1.BW);
-        s1.gap(32);
-      }
-
-      // Child components
-      if (opts.children) {
-        const childMap = new Map<string, ComponentSetNode>();
-        const allInstances: InstanceNode[] = [];
-        for (const v of variants)
-          for (const n of [v as BaseNode, ...v.findAll(() => true)])
-            if (n.type === 'INSTANCE') allInstances.push(n as InstanceNode);
-        const mains = await Promise.all(allInstances.map(inst => inst.getMainComponentAsync().catch(() => null)));
-        for (const main of mains) {
-          if (main?.parent?.type === 'COMPONENT_SET') {
-            const isSelf = specSet.type === 'COMPONENT_SET'
-              ? main.parent.id === specSet.id
-              : main.id === specSet.id;
-            if (!isSelf) childMap.set(main.parent.id, main.parent as ComponentSetNode);
-          }
-        }
-
-        if (childMap.size > 0) {
-          s1.gap(24);
-          s1.mkTxt('Uses', 'Adobe Clean', 'Bold', 18, vSubheading, s1.CW);
-          s1.gap(12);
-          s1.mkTxt([...childMap.values()].map(cs => cs.name).join('   ·   '), 'Adobe Clean', 'Regular', 18, vBodySubtle, s1.BW);
-        }
-      }
-
-      s1.finish();
-      const allCreated: SectionNode[] = [s1.sec];
-
-      // ══════════════════════════════════════════════════════════════════════
-      // SECTIONS 2+ — One per variant, with native annotations
-      // ══════════════════════════════════════════════════════════════════════
-      if (opts.tokens) {
-        // Compact width: enough room for the component + annotation bubbles
-        const maxCompW = Math.max(...variants.map(v => v.width));
-        const VW = Math.max(800, maxCompW + 600);
-        const varSecX = originX + OW + 120;
-        let varSecY = originY;
-
-        for (const variant of variants) {
-          // Simplify the variant name to readable values only
-          // "State=default, Size=md" → "default  ·  md"
-          const readableName = variant.name
-            .split(', ')
-            .map(p => p.split('=')[1] ?? p)
-            .join('  ·  ');
-
-          const vs = makeDarkSection(`${specSet.name} — ${readableName}`, VW, varSecX, varSecY);
-          vs.setCy(60);
-
-          // Variant label
-          vs.mkTxt(readableName, 'Adobe Clean', 'Bold', 18, vSubheading);
-          vs.gap(6);
-          vs.mkTxt(specSet.name, 'Adobe Clean', 'Regular', 13, vBodySubtle);
-          vs.gap(24); vs.divider();
-
-          // Track where content area starts — Surface Split fills from here to section bottom
-          const contentAreaY = vs.getCy();
-
-          // Single instance — annotated
-          // Large padding so annotation bubbles have room to spread
-          const annotPad = Math.max(240, variant.height * 4);
-          vs.gap(annotPad);
-          const inst = variant.createInstance();
-          inst.x = vs.M; inst.y = vs.getCy();
-          vs.frame.appendChild(inst);
-          // Reset to Light so instance doesn't inherit the frame's Dark override
-          if (coll && lightId) inst.setExplicitVariableModeForCollection(coll, lightId);
-          annotateTree(inst);
-          vs.setCy(vs.getCy() + inst.height);
-          vs.gap(annotPad);
-
-          vs.finish(0);
-
-          // Surface Split backdrop — inserted behind the instance, spans content area
-          if (splitComp && coll) {
-            const split = splitComp.createInstance();
-            split.name = '.Surface Split';
-            const instIdx = vs.frame.children.indexOf(inst);
-            vs.frame.insertChild(Math.max(0, instIdx), split);
-            split.resizeWithoutConstraints(VW, vs.sec.height - contentAreaY);
-            split.x = 0; split.y = contentAreaY;
-            split.clearExplicitVariableModeForCollection(coll);
-          }
-
-          allCreated.push(vs.sec);
-          varSecY += vs.sec.height + 240;
-        }
-      }
-
-      figma.currentPage.selection = allCreated;
-      figma.viewport.scrollAndZoomIntoView(allCreated);
-      figma.ui.postMessage({ type: 'spec:result', variantCount: variants.length });
-      } catch (e: any) {
-        figma.ui.postMessage({ type: 'spec:result', error: e.message || String(e) });
-      }
-      break;
-    }
-
     case 'bridge:command': {
       const requestId = msg.requestId as string;
       const method = msg.method as string;
@@ -1813,5 +676,237 @@ figma.ui.onmessage = async (msg: { type: string; [key: string]: unknown }) => {
       }
       break;
     }
+
+    case 'bento:generate': {
+      try {
+        const setId = msg.setId as string;
+        const node = await figma.getNodeByIdAsync(setId);
+        if (!node || node.type !== 'COMPONENT_SET') {
+          figma.ui.postMessage({ type: 'bento:result', error: 'Select a component set first' });
+          break;
+        }
+        const set = node as ComponentSetNode;
+
+        await Promise.all([
+          figma.loadFontAsync({ family: 'Adobe Clean Display', style: 'Bold' }),
+          figma.loadFontAsync({ family: 'Adobe Clean', style: 'Regular' }),
+          figma.loadFontAsync({ family: 'Adobe Clean', style: 'Bold' }),
+        ]);
+
+        // Find the clean template (by name, not id — ids differ per file).
+        // loadAllPagesAsync required before root/page traversal in dynamic-page mode.
+        await figma.loadAllPagesAsync();
+        const tplPage  = figma.root.children.find(p => p.name === '📐 Templates') as PageNode | undefined;
+        const template = tplPage?.children.find(c => c.name === 'Bento Doc Template') as FrameNode | undefined;
+        if (!template) {
+          figma.ui.postMessage({ type: 'bento:result', error: 'Template not found — add "Bento Doc Template" to the "📐 Templates" page' });
+          break;
+        }
+
+        // Theme collection (for the dark preview) + axis-label colors.
+        const bColls    = await figma.variables.getLocalVariableCollectionsAsync();
+        const themeColl = bColls.find(c => c.id === 'VariableCollectionId:6:17');
+        const darkModeId = themeColl?.modes.find(m => m.name === 'Dark')?.modeId;
+        const [cLabel, cCaption, cBody] = await Promise.all([
+          figma.variables.getVariableByIdAsync('VariableID:2483:41392'), // content/label
+          figma.variables.getVariableByIdAsync('VariableID:2483:41395'), // content/caption
+          figma.variables.getVariableByIdAsync('VariableID:2483:41396'), // content/body-subtle
+        ]);
+
+        const meta = parseMetaFence(set.description || '');
+
+        // Clone the template and place it next to the set (same coordinate space).
+        const doc = template.clone();
+        doc.name = `${set.name} · Docs`;
+        const container = set.parent as BaseNode & ChildrenMixin;
+        container.appendChild(doc);
+        doc.x = set.x + set.width + 200;
+        doc.y = set.y;
+
+        const find = (name: string) => doc.findOne(n => n.name === name) as SceneNode | null;
+
+        // Set a named text node's characters — load its own fonts first (else it throws).
+        async function setText(name: string, value: string): Promise<void> {
+          const t = find(name);
+          if (!t || t.type !== 'TEXT' || value == null) return;
+          const tn = t as TextNode;
+          const fonts = tn.getRangeAllFontNames(0, Math.max(1, tn.characters.length));
+          for (const f of fonts) await figma.loadFontAsync(f);
+          tn.characters = value;
+        }
+
+        // Hero + versioning text (all from the meta fence / description).
+        await setText('@hero-name', set.name);
+        await setText('@hero-desc', meta.description || 'One-line description of what this component is and when to use it.');
+        await setText('@version',   meta.version || '0.0.0');
+        await setText('@status',    meta.status || 'active');
+        await setText('@updated',   meta.updated ? `updated ${meta.updated}` : 'updated —');
+        await setText('@changelog', meta.changelog || 'changelog\n  —');
+        if (meta.goodToKnow)    await setText('@good-to-know', meta.goodToKnow);
+        if (meta.accessibility) await setText('@accessibility', meta.accessibility);
+
+        const variants = set.children.filter(c => c.type === 'COMPONENT') as ComponentNode[];
+        const defaultVariant = pickDefaultVariant(variants);
+
+        // Hero slot — a live instance of the default variant.
+        const heroSlot = find('@slot-hero') as FrameNode | null;
+        if (heroSlot && defaultVariant) {
+          clearBentoSlot(heroSlot);
+          heroSlot.clipsContent = false;
+          heroSlot.paddingTop = 20; heroSlot.paddingBottom = 20;
+          heroSlot.counterAxisSizingMode = 'AUTO'; // hug the instance height
+          heroSlot.appendChild(defaultVariant.createInstance());
+        }
+
+        // Anatomy — dot-named layer tree of the default variant.
+        if (defaultVariant) await setText('@anatomy', anatomyList(defaultVariant));
+
+        // Properties — one stacked row per property definition.
+        const propsSlot = find('@properties') as FrameNode | null;
+        if (propsSlot) {
+          clearBentoSlot(propsSlot);
+          propsSlot.strokes = []; propsSlot.dashPattern = []; propsSlot.fills = [];
+          propsSlot.layoutMode = 'VERTICAL';
+          propsSlot.primaryAxisAlignItems = 'MIN';
+          propsSlot.counterAxisAlignItems = 'MIN';
+          propsSlot.itemSpacing = 8;
+          propsSlot.paddingTop = 0; propsSlot.paddingBottom = 0;
+          propsSlot.paddingLeft = 0; propsSlot.paddingRight = 0;
+          for (const [rawName, def] of Object.entries(set.componentPropertyDefinitions)) {
+            const nm   = rawName.split('#')[0];
+            const opts = (def as { variantOptions?: string[] }).variantOptions;
+            const line = `${nm}  ·  ${String(def.type).toLowerCase()}` + (opts ? '  ·  ' + opts.join(' / ') : '');
+            const t = figma.createText();
+            t.fontName = { family: 'Adobe Clean', style: 'Regular' };
+            t.fontSize = 14;
+            t.characters = line;
+            t.textAutoResize = 'HEIGHT';
+            propsSlot.appendChild(t);
+            t.layoutSizingHorizontal = 'FILL';
+            if (cBody) bfv(t, cBody);
+          }
+          propsSlot.primaryAxisSizingMode = 'AUTO';
+        }
+
+        // ── All-variants grid + axis labels ────────────────────────────────
+        // Place one instance per variant at the set's own normalized grid
+        // positions, then label the axes: a property that's constant down every
+        // row is a "row" axis (labelled in the left gutter); the rest vary along
+        // the columns (headers anchored to the TOP row, which also keeps
+        // misaligned grids — variable-width IconButton/PromoCTA, variable-height
+        // RouterNavItem — readable since headers follow the row that defines x).
+        const gridSlot = find('@slot-all-variants') as FrameNode | null;
+        if (gridSlot && variants.length) {
+          clearBentoSlot(gridSlot);
+          gridSlot.strokes = []; gridSlot.dashPattern = []; gridSlot.fills = [];
+          gridSlot.layoutMode = 'NONE'; gridSlot.clipsContent = false;
+
+          const items = variants.map(v => ({
+            v, props: parseVariantProps(v.name),
+            nx: 0, ny: 0, w: Math.round(v.width), h: Math.round(v.height),
+            rx: Math.round(v.x), ry: Math.round(v.y),
+          }));
+          const minX = Math.min(...items.map(i => i.rx));
+          const minY = Math.min(...items.map(i => i.ry));
+          for (const it of items) { it.nx = it.rx - minX; it.ny = it.ry - minY; }
+
+          const propNames = Array.from(new Set(items.flatMap(i => Object.keys(i.props))));
+          const varying   = propNames.filter(p => new Set(items.map(i => i.props[p])).size > 1);
+          const yReps = clusterPositions(items.map(i => i.ny), 6);
+          const rowOf = (ny: number) => yReps.find(y => Math.abs(y - ny) <= 6) ?? ny;
+          const rowProps = varying.filter(p =>
+            yReps.every(y => new Set(items.filter(i => rowOf(i.ny) === y).map(i => i.props[p])).size === 1),
+          );
+          const colProps = varying.filter(p => !rowProps.includes(p));
+
+          const GUTTER_Y = 34;
+          // Create row labels first so we can measure the gutter width.
+          const rowLabels: { t: TextNode; y: number; h: number }[] = [];
+          for (const y of yReps) {
+            const rep = items.find(i => rowOf(i.ny) === y)!;
+            const txt = rowProps.map(p => rep.props[p]).filter(Boolean).join(' · ');
+            if (!txt) continue;
+            const t = mkAxisLabel(txt, 'Bold', 12, cLabel);
+            gridSlot.appendChild(t);
+            rowLabels.push({ t, y, h: rep.h });
+          }
+          const maxLW    = rowLabels.length ? Math.max(...rowLabels.map(r => r.t.width)) : 0;
+          const GUTTER_X = Math.max(56, Math.round(maxLW) + 24);
+
+          // Place the variant instances.
+          let maxRight = 0, maxBottom = 0;
+          for (const it of items) {
+            const inst = it.v.createInstance();
+            gridSlot.appendChild(inst);
+            inst.x = GUTTER_X + it.nx;
+            inst.y = GUTTER_Y + it.ny;
+            maxRight  = Math.max(maxRight,  inst.x + it.w);
+            maxBottom = Math.max(maxBottom, inst.y + it.h);
+          }
+          // Position row labels: right-aligned into the gutter, centered on the row.
+          for (const r of rowLabels) {
+            r.t.x = GUTTER_X - 16 - r.t.width;
+            r.t.y = GUTTER_Y + r.y + Math.round(r.h / 2) - Math.round(r.t.height / 2);
+          }
+          // Column headers anchored to the top row.
+          const topY   = Math.min(...yReps);
+          const topRow = items.filter(i => rowOf(i.ny) === topY).sort((a, b) => a.nx - b.nx);
+          for (const it of topRow) {
+            const txt = colProps.map(p => it.props[p]).filter(Boolean).join(' · ');
+            if (!txt) continue;
+            const t = mkAxisLabel(txt, 'Regular', 11, cCaption);
+            gridSlot.appendChild(t);
+            t.x = GUTTER_X + it.nx;
+            t.y = GUTTER_Y - 22;
+          }
+          gridSlot.resize(Math.max(maxRight + 24, gridSlot.width), maxBottom + 24);
+        }
+
+        // Slots row — hide unless the set actually uses native slots.
+        const slotsRow = doc.findOne(n => n.name === 'row: slots');
+        if (slotsRow) slotsRow.visible = setUsesNativeSlots(set);
+
+        // Dark-mode preview — clone the finished grid and pin the clone to Dark.
+        const darkSlot = find('@slot-dark-preview') as FrameNode | null;
+        if (darkSlot && gridSlot) {
+          clearBentoSlot(darkSlot);
+          darkSlot.strokes = []; darkSlot.dashPattern = []; darkSlot.fills = [];
+          darkSlot.layoutMode = 'NONE'; darkSlot.clipsContent = false;
+          const gclone = gridSlot.clone();
+          darkSlot.appendChild(gclone);
+          gclone.x = 0; gclone.y = 0;
+          if (themeColl && darkModeId) gclone.setExplicitVariableModeForCollection(themeColl, darkModeId);
+          darkSlot.resize(Math.max(darkSlot.width, gclone.width), gclone.height + 8);
+        }
+
+        // Reflow — re-hug row/doc heights after the slot resizes.
+        for (const child of doc.children) {
+          if (child.type === 'FRAME') {
+            const f = child as FrameNode;
+            if (f.layoutMode === 'VERTICAL') f.primaryAxisSizingMode = 'AUTO';
+            else if (f.layoutMode === 'HORIZONTAL') f.counterAxisSizingMode = 'AUTO';
+          }
+        }
+        doc.primaryAxisSizingMode = 'AUTO';
+
+        // Select + zoom to the new doc.
+        const page = pageOfNode(set);
+        if (page && page !== figma.currentPage) await figma.setCurrentPageAsync(page);
+        figma.currentPage.selection = [doc];
+        figma.viewport.scrollAndZoomIntoView([doc]);
+
+        figma.ui.postMessage({
+          type: 'bento:result',
+          nodeId: doc.id,
+          variantCount: variants.length,
+          warning: meta.hadFence ? undefined
+            : 'No s2a:meta fence in the set description — used placeholders for version / changelog / prose',
+        });
+      } catch (e: any) {
+        figma.ui.postMessage({ type: 'bento:result', error: e.message || String(e) });
+      }
+      break;
+    }
+
   }
 };

--- a/apps/s2a-toolkit/src/ui.css
+++ b/apps/s2a-toolkit/src/ui.css
@@ -346,47 +346,6 @@ body {
   line-height: 1.7;
 }
 
-/* ── Variables / Tokens ─────────────────────────────────────────────────── */
-
-.collection-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 8px 0;
-  border-bottom: 1px solid var(--border);
-  gap: 8px;
-}
-.collection-row:last-child { border-bottom: none; }
-.collection-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-1); font-size: 12px; }
-.collection-count {
-  font-size: 10px;
-  color: var(--text-3);
-  font-variant-numeric: tabular-nums;
-  flex-shrink: 0;
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 1px 6px;
-}
-
-.gen-btn {
-  flex-shrink: 0;
-  width: 22px;
-  height: 22px;
-  padding: 0;
-  font-size: 12px;
-  background: transparent;
-  color: var(--text-3);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: color 0.1s, border-color 0.1s;
-}
-.gen-btn:hover:not(:disabled) { color: var(--text-1); border-color: var(--border-md); }
-.gen-btn:disabled { opacity: 0.35; cursor: default; }
 
 /* ── Select ─────────────────────────────────────────────────────────────── */
 
@@ -449,10 +408,6 @@ body {
 
 /* ── Settings ───────────────────────────────────────────────────────────── */
 
-.settings-hint { font-size: 11px; color: var(--text-2); margin-bottom: 14px; line-height: 1.5; }
-.settings-hint a { color: var(--accent); text-decoration: none; }
-.settings-hint a:hover { text-decoration: underline; }
-.settings-hint code { font-family: 'Menlo', monospace; font-size: 10px; background: var(--bg); padding: 1px 4px; border-radius: 3px; border: 1px solid var(--border); }
 
 .form-field { margin-bottom: 10px; }
 .form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
@@ -472,6 +427,12 @@ body {
 }
 .form-input:focus { border-color: var(--accent); }
 .form-input::placeholder { color: var(--text-3); }
+.form-textarea {
+  min-height: 68px;
+  resize: vertical;
+  line-height: 1.45;
+}
+.llm-field { margin-top: 10px; margin-bottom: 0; }
 
 /* ── Section bar btn ─────────────────────────────────────────────────────── */
 
@@ -486,7 +447,6 @@ body {
 
 /* ── Settings gear active ───────────────────────────────────────────────── */
 
-#settingsBtn.active { color: var(--accent); background: var(--accent-bg); }
 
 .hidden { display: none !important; }
 
@@ -667,3 +627,4 @@ body {
   background: var(--border);
   margin: 16px -12px;
 }
+

--- a/apps/s2a-toolkit/src/ui.html
+++ b/apps/s2a-toolkit/src/ui.html
@@ -32,12 +32,6 @@
         <span class="bridge-dot" id="bridgeDot"></span>
         <span class="bridge-label" id="bridgePillLabel">Connect</span>
       </button>
-      <button class="icon-btn full-only" id="settingsBtn" title="Settings" aria-label="Settings">
-        <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
-          <circle cx="7" cy="7" r="2" stroke="currentColor" stroke-width="1.25"/>
-          <path d="M7 1.5v1.2M7 11.3v1.2M1.5 7h1.2M11.3 7h1.2M3.2 3.2l.85.85M9.95 9.95l.85.85M3.2 10.8l.85-.85M9.95 4.05l.85-.85" stroke="currentColor" stroke-width="1.25" stroke-linecap="round"/>
-        </svg>
-      </button>
       <button class="icon-btn" id="toggleMiniBtn" aria-label="Minimize plugin">
         <svg class="icon-collapse" width="13" height="13" viewBox="0 0 14 14" fill="none">
           <path d="M2 5h10M2 9h10" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
@@ -85,14 +79,6 @@
       </svg>
       <span class="tab-label">Home</span>
     </button>
-    <!-- Tokens -->
-    <button class="tab" data-panel="tokens" aria-label="Tokens">
-      <svg class="tab-icon" width="13" height="13" viewBox="0 0 14 14" fill="none">
-        <rect x="1.5" y="3" width="11" height="2.5" rx="1.25" stroke="currentColor" stroke-width="1.2"/>
-        <rect x="1.5" y="8" width="7.5" height="2.5" rx="1.25" stroke="currentColor" stroke-width="1.2"/>
-      </svg>
-      <span class="tab-label">Tokens</span>
-    </button>
     <!-- Tools -->
     <button class="tab" data-panel="tools" aria-label="Tools">
       <svg class="tab-icon" width="13" height="13" viewBox="0 0 14 14" fill="none">
@@ -120,24 +106,31 @@
       </div>
     </div>
 
-    <!-- Tokens (was Variables) -->
-    <div class="panel" id="tokensPanel">
-      <div class="section-label">Collections</div>
-      <div id="varCollections">
-        <div class="empty-state">Click Refresh to load collections</div>
-      </div>
-      <div class="section-label hidden" id="tokenGroupLabel" style="margin-top:14px;">Token groups</div>
-      <div id="tokenGroupList"></div>
-      <div class="btn-row">
-        <button class="btn btn-ghost" id="varRefreshBtn">Refresh</button>
-        <button class="btn btn-ghost" id="varExportLocalBtn" disabled>Local</button>
-        <button class="btn" id="varExportGithubBtn" disabled>↑ GitHub</button>
-      </div>
-      <div class="status" id="varStatus"></div>
-    </div>
-
     <!-- Tools — select + annotate + spec stacked -->
     <div class="panel" id="toolsPanel">
+
+      <!-- ── LLM capture ─────────────────────────────────────────────── -->
+      <div class="section-label">LLM capture</div>
+      <div class="sel-card">
+        <span class="sel-card-empty" id="llmCaptureSelectionEmpty">Select a frame or section</span>
+        <div class="sel-card-info" id="llmCaptureSelectionInfo" style="display:none;">
+          <span class="sel-icon">◈</span>
+          <div class="sel-meta">
+            <span class="sel-name" id="llmCaptureNodeName">—</span>
+            <span class="sel-type" id="llmCaptureNodeType">—</span>
+          </div>
+        </div>
+      </div>
+      <div class="form-field llm-field">
+        <label class="form-label" for="llmCapturePrompt">Prompt</label>
+        <textarea class="form-input form-textarea" id="llmCapturePrompt" rows="3" placeholder="Ask the LLM what to inspect or generate from this selection."></textarea>
+      </div>
+      <div class="btn-row">
+        <button class="btn" id="llmCaptureSendBtn" disabled style="flex:1;">Send Screenshot</button>
+      </div>
+      <div class="status" id="llmCaptureStatus"></div>
+
+      <div class="tools-divider"></div>
 
       <!-- ── Variant Filter ──────────────────────────────────────────── -->
       <div class="section-label">Variant filter</div>
@@ -185,62 +178,25 @@
 
       <div class="tools-divider"></div>
 
-      <!-- ── Spec sheet ──────────────────────────────────────────────── -->
-      <div class="section-label">Spec sheet</div>
+      <!-- ── Bento doc ───────────────────────────────────────────────── -->
+      <div class="section-label">Bento doc</div>
       <div class="sel-card">
-        <span class="sel-card-empty" id="specSelectionEmpty">Select a component or set</span>
-        <div class="sel-card-info" id="specSelectionInfo" style="display:none;">
-          <span class="sel-icon">◈</span>
+        <span class="sel-card-empty" id="bentoSelectionEmpty">Select a component set</span>
+        <div class="sel-card-info" id="bentoSelectionInfo" style="display:none;">
+          <span class="sel-icon">▤</span>
           <div class="sel-meta">
-            <span class="sel-name" id="specSetName">—</span>
-            <span class="sel-type" id="specSetCount">—</span>
+            <span class="sel-name" id="bentoSetName">—</span>
+            <span class="sel-type" id="bentoSetCount">—</span>
           </div>
         </div>
       </div>
-      <div class="chip-grid" id="specOpts" style="margin-top:10px;">
-        <button class="chip on" data-opt="variants">Variants</button>
-        <button class="chip on" data-opt="tokens">Tokens</button>
-        <button class="chip on" data-opt="children">Children</button>
-      </div>
       <div class="btn-row">
-        <button class="btn" id="specGenerateBtn" disabled style="flex:1;">Generate Spec</button>
+        <button class="btn" id="bentoGenerateBtn" disabled style="flex:1;">Generate bento doc</button>
       </div>
-      <div class="status" id="specStatus"></div>
+      <div class="status" id="bentoStatus"></div>
 
       <!-- bottom padding for scroll clearance -->
       <div style="height:16px;"></div>
-    </div>
-
-    <!-- Settings (gear icon only) -->
-    <div class="panel" id="settingsPanel">
-      <div class="section-label">GitHub Export</div>
-      <p class="settings-hint">Tokens commit directly to your repo. Needs a <a href="https://github.com/settings/tokens" target="_blank">Personal Access Token</a> with <code>repo</code> scope.</p>
-      <div class="form-field">
-        <label class="form-label" for="ghToken">Token</label>
-        <input class="form-input" type="password" id="ghToken" placeholder="ghp_…" autocomplete="off" />
-      </div>
-      <div class="form-row">
-        <div class="form-field">
-          <label class="form-label" for="ghOwner">Owner</label>
-          <input class="form-input" type="text" id="ghOwner" placeholder="adobecom" />
-        </div>
-        <div class="form-field">
-          <label class="form-label" for="ghRepo">Repo</label>
-          <input class="form-input" type="text" id="ghRepo" placeholder="consonant-2" />
-        </div>
-      </div>
-      <div class="form-field">
-        <label class="form-label" for="ghBranch">Branch</label>
-        <input class="form-input" type="text" id="ghBranch" placeholder="main" />
-      </div>
-      <div class="form-field">
-        <label class="form-label" for="ghFilePath">File path</label>
-        <input class="form-input" type="text" id="ghFilePath" placeholder="packages/toolkit-tokens/json/figma-export.json" />
-      </div>
-      <div class="btn-row">
-        <button class="btn" id="saveSettingsBtn">Save</button>
-      </div>
-      <div class="status" id="settingsStatus"></div>
     </div>
 
   </div>

--- a/apps/s2a-toolkit/src/ui.html
+++ b/apps/s2a-toolkit/src/ui.html
@@ -178,22 +178,22 @@
 
       <div class="tools-divider"></div>
 
-      <!-- ── Bento doc ───────────────────────────────────────────────── -->
-      <div class="section-label">Bento doc</div>
+      <!-- ── Component doc ───────────────────────────────────────────────── -->
+      <div class="section-label">Component doc</div>
       <div class="sel-card">
-        <span class="sel-card-empty" id="bentoSelectionEmpty">Select a component set</span>
-        <div class="sel-card-info" id="bentoSelectionInfo" style="display:none;">
+        <span class="sel-card-empty" id="docSelectionEmpty">Select a component set</span>
+        <div class="sel-card-info" id="docSelectionInfo" style="display:none;">
           <span class="sel-icon">▤</span>
           <div class="sel-meta">
-            <span class="sel-name" id="bentoSetName">—</span>
-            <span class="sel-type" id="bentoSetCount">—</span>
+            <span class="sel-name" id="docSetName">—</span>
+            <span class="sel-type" id="docSetCount">—</span>
           </div>
         </div>
       </div>
       <div class="btn-row">
-        <button class="btn" id="bentoGenerateBtn" disabled style="flex:1;">Generate bento doc</button>
+        <button class="btn" id="docGenerateBtn" disabled style="flex:1;">Generate component doc</button>
       </div>
-      <div class="status" id="bentoStatus"></div>
+      <div class="status" id="docStatus"></div>
 
       <!-- bottom padding for scroll clearance -->
       <div style="height:16px;"></div>

--- a/apps/s2a-toolkit/src/ui.ts
+++ b/apps/s2a-toolkit/src/ui.ts
@@ -66,7 +66,7 @@ function recentlyUsed(n = 5): Feature[] {
 let annotateNodeId: string | null = null;
 let llmCaptureNodeId: string | null = null;
 let selectSetId:    string | null = null;
-let bentoSetId:     string | null = null;
+let docSetId:     string | null = null;
 let bridgeConnected      = false;
 let bridgeWs: WebSocket | null = null;
 let bridgeWsPort: number | null = null;
@@ -171,9 +171,9 @@ const FEATURES: Feature[] = [
     },
   },
   {
-    id: 'tools:bento',
-    name: 'Generate bento doc',
-    description: 'Build a full bento documentation page for the selected component set',
+    id: 'tools:doc',
+    name: 'Generate component doc',
+    description: 'Build a full component documentation page for the selected component set',
     category: 'Tools',
     uiAction: () => switchPanel('tools'),
   },
@@ -200,7 +200,7 @@ const QUICK_ACTION_IDS = [
   'tools:copy-link',
   'tools:annotate',
   'tools:select-filter',
-  'tools:bento',
+  'tools:doc',
 ];
 
 // ── Fire a feature ────────────────────────────────────────────────────────────
@@ -808,22 +808,22 @@ document.getElementById('annotateClearBtn')?.addEventListener('click', () => {
   postToPlugin('annotate:clear', { nodeId: annotateNodeId });
 });
 
-// ── Tools — Bento ─────────────────────────────────────────────────────────────
+// ── Tools — Doc ─────────────────────────────────────────────────────────────
 
-function setBentoStatus(msg: string, type: '' | 'ok' | 'err' = '') {
-  const el = document.getElementById('bentoStatus') as HTMLElement;
+function setDocStatus(msg: string, type: '' | 'ok' | 'err' = '') {
+  const el = document.getElementById('docStatus') as HTMLElement;
   el.textContent = msg; el.className = 'status' + (type ? ' ' + type : '');
 }
 
-// Bento generation needs a full COMPONENT_SET (not a single COMPONENT).
-function updateBentoSelection(sel: { id: string; name: string; nodeType: string; variantCount?: number } | null) {
+// Doc generation needs a full COMPONENT_SET (not a single COMPONENT).
+function updateDocSelection(sel: { id: string; name: string; nodeType: string; variantCount?: number } | null) {
   const isSet = sel?.nodeType === 'COMPONENT_SET';
-  bentoSetId = isSet ? (sel?.id ?? null) : null;
-  const emptyEl = document.getElementById('bentoSelectionEmpty') as HTMLElement;
-  const infoEl  = document.getElementById('bentoSelectionInfo')  as HTMLElement;
-  const nameEl  = document.getElementById('bentoSetName')  as HTMLElement;
-  const countEl = document.getElementById('bentoSetCount') as HTMLElement;
-  const btn     = document.getElementById('bentoGenerateBtn') as HTMLButtonElement;
+  docSetId = isSet ? (sel?.id ?? null) : null;
+  const emptyEl = document.getElementById('docSelectionEmpty') as HTMLElement;
+  const infoEl  = document.getElementById('docSelectionInfo')  as HTMLElement;
+  const nameEl  = document.getElementById('docSetName')  as HTMLElement;
+  const countEl = document.getElementById('docSetCount') as HTMLElement;
+  const btn     = document.getElementById('docGenerateBtn') as HTMLButtonElement;
   if (isSet && sel) {
     emptyEl.style.display = 'none'; infoEl.style.display = 'flex';
     nameEl.textContent  = sel.name;
@@ -835,12 +835,12 @@ function updateBentoSelection(sel: { id: string; name: string; nodeType: string;
   }
 }
 
-document.getElementById('bentoGenerateBtn')?.addEventListener('click', () => {
-  if (!bentoSetId) return;
-  const btn = document.getElementById('bentoGenerateBtn') as HTMLButtonElement;
+document.getElementById('docGenerateBtn')?.addEventListener('click', () => {
+  if (!docSetId) return;
+  const btn = document.getElementById('docGenerateBtn') as HTMLButtonElement;
   btn.disabled = true; btn.textContent = 'Generating…';
-  setBentoStatus('');
-  postToPlugin('bento:generate', { setId: bentoSetId });
+  setDocStatus('');
+  postToPlugin('doc:generate', { setId: docSetId });
 });
 
 // ── Plugin messages ───────────────────────────────────────────────────────────
@@ -885,7 +885,7 @@ window.addEventListener('message', (event) => {
         };
         updateLlmCaptureSelection(sel);
         updateAnnotateSelection(sel);
-        updateBentoSelection(sel);
+        updateDocSelection(sel);
         updateCopyBtn(sel, msg.fileKey as string | null, msg.fileName as string | null, msg.allNodes as Array<{ id: string; name: string }> | undefined);
         updateSectionBar(
           !!(msg.isSection as boolean),
@@ -895,7 +895,7 @@ window.addEventListener('message', (event) => {
       } else {
         updateLlmCaptureSelection(null);
         updateAnnotateSelection(null);
-        updateBentoSelection(null);
+        updateDocSelection(null);
         updateCopyBtn(null, null);
         updateSectionBar(false, 0, '');
       }
@@ -970,14 +970,14 @@ window.addEventListener('message', (event) => {
       setAnnotateStatus(n > 0 ? `Cleared ${n} annotation${n !== 1 ? 's' : ''}` : 'Nothing to clear', 'ok');
       break;
     }
-    case 'bento:result': {
-      const btn = document.getElementById('bentoGenerateBtn') as HTMLButtonElement;
-      btn.disabled = !bentoSetId; btn.textContent = 'Generate bento doc';
-      if (msg.error) setBentoStatus('❌ ' + (msg.error as string), 'err');
+    case 'doc:result': {
+      const btn = document.getElementById('docGenerateBtn') as HTMLButtonElement;
+      btn.disabled = !docSetId; btn.textContent = 'Generate component doc';
+      if (msg.error) setDocStatus('❌ ' + (msg.error as string), 'err');
       else {
         const vars = msg.variantCount as number;
         const warn = msg.warning ? ' · ⚠ ' + (msg.warning as string) : '';
-        setBentoStatus(`✓ Bento doc generated · ${vars} variant${vars !== 1 ? 's' : ''}${warn}`, 'ok');
+        setDocStatus(`✓ Component doc generated · ${vars} variant${vars !== 1 ? 's' : ''}${warn}`, 'ok');
       }
       break;
     }

--- a/apps/s2a-toolkit/src/ui.ts
+++ b/apps/s2a-toolkit/src/ui.ts
@@ -64,10 +64,9 @@ function recentlyUsed(n = 5): Feature[] {
 // ── State vars (declared early so FEATURES closures can reference them) ───────
 
 let annotateNodeId: string | null = null;
+let llmCaptureNodeId: string | null = null;
 let selectSetId:    string | null = null;
-let specSetId:      string | null = null;
-let variablesCache: { variables: any[]; variableCollections: any[] } | null = null;
-let githubSettings: GitHubSettings | null = null;
+let bentoSetId:     string | null = null;
 let bridgeConnected      = false;
 let bridgeWs: WebSocket | null = null;
 let bridgeWsPort: number | null = null;
@@ -76,7 +75,6 @@ let bridgeReconnectTimer: ReturnType<typeof setTimeout>   | null = null;
 let bridgeReconnectAttempts = 0;
 let bridgeUserDisconnected  = false;
 let activePanel: Panel = 'home';
-let settingsOpen = false;
 let isMini = false;
 let popoverOpen = false;
 
@@ -89,20 +87,14 @@ let requestCounter = 0;
 
 // ── Panel switching ───────────────────────────────────────────────────────────
 
-type Panel = 'home' | 'tokens' | 'tools' | 'settings';
+type Panel = 'home' | 'tools';
 
 const panelEls: Record<Panel, HTMLElement> = {
   home:     document.getElementById('homePanel')     as HTMLElement,
-  tokens:   document.getElementById('tokensPanel')   as HTMLElement,
   tools:    document.getElementById('toolsPanel')    as HTMLElement,
-  settings: document.getElementById('settingsPanel') as HTMLElement,
 };
 
 function switchPanel(panel: Panel) {
-  if (panel !== 'settings') {
-    settingsOpen = false;
-    settingsBtn?.classList.remove('active');
-  }
   activePanel = panel;
   Object.entries(panelEls).forEach(([key, el]) => {
     el.classList.toggle('active', key === panel);
@@ -110,7 +102,6 @@ function switchPanel(panel: Panel) {
   document.querySelectorAll<HTMLButtonElement>('.tab[data-panel]').forEach(tab => {
     tab.classList.toggle('active', tab.dataset.panel === panel);
   });
-  if (panel === 'settings') postToPlugin('get-settings');
   if (panel === 'home') renderHomeView();
 }
 
@@ -119,19 +110,6 @@ document.querySelectorAll<HTMLButtonElement>('.tab[data-panel]').forEach(tab => 
     const p = tab.dataset.panel as Panel;
     if (p) switchPanel(p);
   });
-});
-
-const settingsBtn = document.getElementById('settingsBtn') as HTMLButtonElement;
-settingsBtn?.addEventListener('click', () => {
-  if (settingsOpen) {
-    settingsOpen = false;
-    settingsBtn.classList.remove('active');
-    switchPanel(activePanel === 'settings' ? 'home' : activePanel);
-  } else {
-    settingsOpen = true;
-    settingsBtn.classList.add('active');
-    switchPanel('settings');
-  }
 });
 
 // ── Feature registry ──────────────────────────────────────────────────────────
@@ -147,36 +125,6 @@ interface Feature {
 }
 
 const FEATURES: Feature[] = [
-  // Tokens
-  {
-    id: 'tokens:refresh',
-    name: 'Refresh variables',
-    description: 'Re-fetch all Figma variables from the current file',
-    category: 'Tokens',
-    uiAction: () => (document.getElementById('varRefreshBtn') as HTMLButtonElement)?.click(),
-  },
-  {
-    id: 'tokens:export-local',
-    name: 'Export tokens locally',
-    description: 'Push token JSON to local dev server on port 9300',
-    category: 'Tokens',
-    uiAction: () => (document.getElementById('varExportLocalBtn') as HTMLButtonElement)?.click(),
-  },
-  {
-    id: 'tokens:export-github',
-    name: 'Push tokens to GitHub',
-    description: 'Commit token JSON to your configured repo',
-    category: 'Tokens',
-    uiAction: () => (document.getElementById('varExportGithubBtn') as HTMLButtonElement)?.click(),
-  },
-  {
-    id: 'tokens:doc-gen',
-    name: 'Generate token docs',
-    description: 'Build a Figma doc sheet for a token group',
-    category: 'Tokens',
-    uiAction: () => switchPanel('tokens'),
-  },
-
   // Tools
   {
     id: 'tools:copy-link',
@@ -184,6 +132,13 @@ const FEATURES: Feature[] = [
     description: 'Copy a shareable link for the selected node(s)',
     category: 'Tools',
     uiAction: () => (document.getElementById('copyNodeBtn') as HTMLButtonElement)?.click(),
+  },
+  {
+    id: 'tools:llm-capture',
+    name: 'Send screenshot to LLM',
+    description: 'Capture the selected node and send image + metadata to the local LLM bridge',
+    category: 'Tools',
+    uiAction: () => switchPanel('tools'),
   },
   {
     id: 'tools:format-section',
@@ -216,9 +171,9 @@ const FEATURES: Feature[] = [
     },
   },
   {
-    id: 'tools:spec',
-    name: 'Generate spec sheet',
-    description: 'Scaffold a Figma spec doc for a component set',
+    id: 'tools:bento',
+    name: 'Generate bento doc',
+    description: 'Build a full bento documentation page for the selected component set',
     category: 'Tools',
     uiAction: () => switchPanel('tools'),
   },
@@ -241,12 +196,11 @@ const FEATURES: Feature[] = [
 ];
 
 const QUICK_ACTION_IDS = [
+  'tools:llm-capture',
   'tools:copy-link',
-  'tokens:refresh',
   'tools:annotate',
   'tools:select-filter',
-  'tokens:export-local',
-  'tools:spec',
+  'tools:bento',
 ];
 
 // ── Fire a feature ────────────────────────────────────────────────────────────
@@ -498,6 +452,55 @@ copyNodeBtn.addEventListener('click', () => {
   postToPlugin('notify', { message: msg });
 });
 
+// ── LLM capture ──────────────────────────────────────────────────────────────
+
+function setLlmCaptureStatus(msg: string, type: '' | 'ok' | 'err' = '') {
+  const el = document.getElementById('llmCaptureStatus') as HTMLElement;
+  el.textContent = msg;
+  el.className = 'status' + (type ? ' ' + type : '');
+}
+
+function updateLlmCaptureSelection(sel: { id: string; name: string; nodeType: string } | null) {
+  llmCaptureNodeId = sel?.id ?? null;
+  const emptyEl = document.getElementById('llmCaptureSelectionEmpty') as HTMLElement;
+  const infoEl  = document.getElementById('llmCaptureSelectionInfo')  as HTMLElement;
+  const nameEl  = document.getElementById('llmCaptureNodeName') as HTMLElement;
+  const typeEl  = document.getElementById('llmCaptureNodeType') as HTMLElement;
+  const sendBtn = document.getElementById('llmCaptureSendBtn') as HTMLButtonElement;
+  if (sel) {
+    emptyEl.style.display = 'none';
+    infoEl.style.display = 'flex';
+    nameEl.textContent = sel.name;
+    typeEl.textContent = sel.nodeType;
+    sendBtn.disabled = false;
+  } else {
+    emptyEl.style.display = 'block';
+    infoEl.style.display = 'none';
+    sendBtn.disabled = true;
+  }
+}
+
+async function pollLlmCaptureJob(jobId: string) {
+  for (;;) {
+    await new Promise(resolve => setTimeout(resolve, 1200));
+    const res = await fetch(`http://localhost:4002/jobs/${encodeURIComponent(jobId)}`);
+    if (!res.ok) throw new Error(`Job status failed (${res.status})`);
+    const job = await res.json();
+    if (job.phase) setLlmCaptureStatus(job.phase);
+    if (job.status === 'done') return job.result;
+    if (job.status === 'error') throw new Error(job.error || 'LLM job failed');
+  }
+}
+
+document.getElementById('llmCaptureSendBtn')?.addEventListener('click', () => {
+  if (!llmCaptureNodeId) return;
+  const btn = document.getElementById('llmCaptureSendBtn') as HTMLButtonElement;
+  btn.disabled = true;
+  btn.textContent = 'Capturing…';
+  setLlmCaptureStatus('Capturing selected node…');
+  postToPlugin('llm-capture:selection', { maxDimension: 2048 });
+});
+
 // ── Section bar ───────────────────────────────────────────────────────────────
 
 const sectionBar      = document.getElementById('sectionBar')      as HTMLElement;
@@ -605,9 +608,6 @@ function initBridgeConnection(ws: WebSocket) {
   sendBridgeCommand('REFRESH_VARIABLES', {}, 30000).then(result => {
     if (ws.readyState !== 1 || !result?.data) return;
     ws.send(JSON.stringify({ type: 'VARIABLES_DATA', data: result.data }));
-    renderVariables(result.data);
-    renderTokenGroups(result.data);
-    setVarMeta(result.data.variables.length + ' variables');
   }).catch(() => {});
 }
 
@@ -701,236 +701,6 @@ function bridgeDisconnect() {
   bridgeWs = null; bridgeWsPort = null; bridgeConnected = false; bridgeReconnectAttempts = 0;
   updateBridgeUi();
 }
-
-// ── Token group helpers ───────────────────────────────────────────────────────
-
-function getTokenGroup(name: string): string {
-  const parts = name.split('/').filter(p => p !== 's2a');
-  if (parts.length >= 4 && parts[1] === 'transparent') return parts[0] + ' / ' + parts[1] + ' / ' + parts[2];
-  if (parts.length >= 3) return parts[0] + ' / ' + parts[1];
-  return parts[0] ?? name;
-}
-
-// ── Variables / Tokens panel ──────────────────────────────────────────────────
-
-function setVarMeta(_text: string) {}
-
-function setVarStatus(msg: string, type: '' | 'ok' | 'err' = '') {
-  const el = document.getElementById('varStatus') as HTMLElement;
-  el.textContent = msg;
-  el.className = 'status' + (type ? ' ' + type : '');
-}
-
-function updateExportButtons() {
-  const localBtn  = document.getElementById('varExportLocalBtn')  as HTMLButtonElement;
-  const githubBtn = document.getElementById('varExportGithubBtn') as HTMLButtonElement;
-  const hasVars = !!variablesCache;
-  const hasGhSettings = !!(githubSettings?.token && githubSettings?.owner && githubSettings?.repo);
-  if (localBtn)  localBtn.disabled  = !hasVars;
-  if (githubBtn) githubBtn.disabled = !hasVars || !hasGhSettings;
-}
-
-function renderVariables(data: { variables: any[]; variableCollections: any[] }) {
-  variablesCache = data;
-  const el = document.getElementById('varCollections') as HTMLElement;
-  if (!el) return;
-
-  if (data.variableCollections.length === 0) {
-    el.innerHTML = '<div class="empty-state">No collections found</div>';
-    return;
-  }
-
-  const byCol: Record<string, number> = {};
-  for (const v of data.variables) byCol[v.variableCollectionId] = (byCol[v.variableCollectionId] || 0) + 1;
-
-  el.innerHTML = data.variableCollections.map((c: any) =>
-    `<div class="collection-row">
-      <span class="collection-name">${esc(c.name)}</span>
-      <span class="collection-count">${byCol[c.id] || 0}</span>
-    </div>`
-  ).join('');
-
-  updateExportButtons();
-}
-
-function renderTokenGroups(data: { variables: any[]; variableCollections: any[] }) {
-  const labelEl = document.getElementById('tokenGroupLabel') as HTMLElement;
-  const listEl  = document.getElementById('tokenGroupList')  as HTMLElement;
-  if (!listEl) return;
-
-  const semanticColls = data.variableCollections.filter(c =>
-    /Semantic|Responsive/.test(c.name) ||
-    (/Primitives/.test(c.name) && /Color/.test(c.name)) ||
-    (/Primitives/.test(c.name) && /Dimension/.test(c.name))
-  );
-  if (semanticColls.length === 0) {
-    listEl.innerHTML = '';
-    if (labelEl) labelEl.classList.add('hidden');
-    return;
-  }
-
-  const collIdToName = new Map<string, string>();
-  for (const c of data.variableCollections) collIdToName.set(c.id, c.name);
-
-  const collSet = new Set(semanticColls.map((c: any) => c.id));
-  const groups = new Map<string, { collectionId: string; collectionName: string; group: string; count: number }>();
-  for (const v of data.variables) {
-    if (!collSet.has(v.variableCollectionId)) continue;
-    const collName: string = collIdToName.get(v.variableCollectionId) || '';
-    const grp = getTokenGroup(v.name);
-    if (/Primitives/.test(collName) && /Dimension/.test(collName) && grp !== 'opacity') continue;
-    const key = v.variableCollectionId + '::' + grp;
-    if (!groups.has(key)) {
-      groups.set(key, { collectionId: v.variableCollectionId, collectionName: collName, group: grp, count: 0 });
-    }
-    groups.get(key)!.count++;
-  }
-
-  const sorted = [...groups.values()].sort((a, b) => {
-    if (a.collectionName !== b.collectionName) return a.collectionName.localeCompare(b.collectionName);
-    return a.group.localeCompare(b.group);
-  });
-
-  if (labelEl) labelEl.classList.remove('hidden');
-  listEl.innerHTML = sorted.map(g =>
-    `<div class="collection-row token-group-row" data-col="${esc(g.collectionId)}" data-group="${esc(g.group)}">
-      <span class="collection-name">${esc(g.group)}</span>
-      <span class="collection-count">${g.count}</span>
-      <button class="gen-btn" title="Generate docs for ${esc(g.group)}">→</button>
-    </div>`
-  ).join('');
-  listEl.insertAdjacentHTML('beforeend',
-    `<div class="collection-row token-group-row" style="margin-top:6px;padding-top:6px;border-top:1px solid rgba(255,255,255,0.08)" data-col="text-styles" data-group="text-styles">
-      <span class="collection-name">Text Styles</span>
-      <span class="collection-count">—</span>
-      <button class="gen-btn" title="Generate 4 breakpoint sections from native text styles">→</button>
-    </div>`
-  );
-}
-
-document.getElementById('tokenGroupList')?.addEventListener('click', (e) => {
-  const btn = (e.target as HTMLElement).closest<HTMLButtonElement>('.gen-btn');
-  if (!btn || btn.disabled) return;
-  const row = btn.closest<HTMLElement>('.token-group-row');
-  if (!row) return;
-  btn.disabled = true;
-  btn.textContent = '…';
-  setVarStatus('Generating ' + (row.dataset.group ?? '') + '…');
-  postToPlugin('token-docs:generate', { collectionId: row.dataset.col, group: row.dataset.group });
-});
-
-document.getElementById('varRefreshBtn')?.addEventListener('click', async () => {
-  const btn = document.getElementById('varRefreshBtn') as HTMLButtonElement;
-  btn.textContent = 'Refreshing…'; btn.disabled = true;
-  setVarStatus('Loading…');
-  try {
-    const result = await sendBridgeCommand('REFRESH_VARIABLES', {}, 30000);
-    if (result?.data) {
-      renderVariables(result.data);
-      renderTokenGroups(result.data);
-      setVarStatus(result.data.variables.length + ' variables loaded', 'ok');
-    } else {
-      setVarStatus('No data returned', 'err');
-    }
-  } catch (e: any) {
-    setVarStatus(e.message || 'Error', 'err');
-  } finally {
-    btn.textContent = 'Refresh'; btn.disabled = false;
-  }
-});
-
-document.getElementById('varExportLocalBtn')?.addEventListener('click', () => {
-  if (!variablesCache) { setVarStatus('No variables — hit Refresh first', 'err'); return; }
-  const btn = document.getElementById('varExportLocalBtn') as HTMLButtonElement;
-  btn.textContent = 'Exporting…'; btn.disabled = true;
-  setVarStatus('Sending to dev-server…');
-  fetch('http://localhost:9300/export', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(variablesCache),
-  })
-    .then(r => r.json())
-    .then((data: any) => {
-      if (data.ok) setVarStatus(`✓ ${data.variables} vars → dist/css/`, 'ok');
-      else setVarStatus('❌ ' + (data.error || 'Build failed'), 'err');
-    })
-    .catch(() => setVarStatus('❌ Dev server not running — run: npm run dev-server', 'err'))
-    .finally(() => { btn.textContent = 'Local'; updateExportButtons(); });
-});
-
-document.getElementById('varExportGithubBtn')?.addEventListener('click', async () => {
-  if (!variablesCache || !githubSettings?.token) return;
-  const btn = document.getElementById('varExportGithubBtn') as HTMLButtonElement;
-  btn.textContent = 'Pushing…'; btn.disabled = true;
-  setVarStatus('Pushing to GitHub…');
-  try {
-    await pushToGitHub(variablesCache, githubSettings);
-    setVarStatus('✓ Committed to ' + githubSettings.repo + ' / ' + githubSettings.branch, 'ok');
-  } catch (e: any) {
-    setVarStatus('❌ ' + (e.message || 'GitHub push failed'), 'err');
-  } finally {
-    btn.textContent = '↑ GitHub'; updateExportButtons();
-  }
-});
-
-// ── GitHub API ────────────────────────────────────────────────────────────────
-
-interface GitHubSettings {
-  token: string; owner: string; repo: string; branch: string; filePath: string;
-}
-
-async function pushToGitHub(data: any, settings: GitHubSettings): Promise<void> {
-  const { token, owner, repo, branch, filePath } = settings;
-  const apiBase = `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}`;
-  const headers = {
-    Authorization: `token ${token}`,
-    Accept: 'application/vnd.github.v3+json',
-    'Content-Type': 'application/json',
-  };
-  let sha: string | undefined;
-  const getRes = await fetch(`${apiBase}?ref=${branch}`, { headers });
-  if (getRes.ok) sha = (await getRes.json()).sha;
-  else if (getRes.status !== 404) throw new Error((await getRes.json()).message || `GitHub ${getRes.status}`);
-  const content = btoa(unescape(encodeURIComponent(JSON.stringify(data, null, 2))));
-  const body: Record<string, any> = { message: 'chore: sync tokens from Figma', content, branch };
-  if (sha) body.sha = sha;
-  const putRes = await fetch(apiBase, { method: 'PUT', headers, body: JSON.stringify(body) });
-  if (!putRes.ok) throw new Error((await putRes.json()).message || `GitHub ${putRes.status}`);
-}
-
-// ── Settings ──────────────────────────────────────────────────────────────────
-
-function setSettingsStatus(msg: string, type: '' | 'ok' | 'err' = '') {
-  const el = document.getElementById('settingsStatus') as HTMLElement;
-  el.textContent = msg;
-  el.className = 'status' + (type ? ' ' + type : '');
-}
-
-function applySettings(settings: GitHubSettings | null) {
-  githubSettings = settings;
-  if (!settings) return;
-  (document.getElementById('ghToken')    as HTMLInputElement).value = settings.token    || '';
-  (document.getElementById('ghOwner')    as HTMLInputElement).value = settings.owner    || '';
-  (document.getElementById('ghRepo')     as HTMLInputElement).value = settings.repo     || '';
-  (document.getElementById('ghBranch')   as HTMLInputElement).value = settings.branch   || 'main';
-  (document.getElementById('ghFilePath') as HTMLInputElement).value = settings.filePath || 'packages/toolkit-tokens/json/figma-export.json';
-  updateExportButtons();
-}
-
-document.getElementById('saveSettingsBtn')?.addEventListener('click', () => {
-  const settings: GitHubSettings = {
-    token:    (document.getElementById('ghToken')    as HTMLInputElement).value.trim(),
-    owner:    (document.getElementById('ghOwner')    as HTMLInputElement).value.trim(),
-    repo:     (document.getElementById('ghRepo')     as HTMLInputElement).value.trim(),
-    branch:   (document.getElementById('ghBranch')   as HTMLInputElement).value.trim() || 'main',
-    filePath: (document.getElementById('ghFilePath') as HTMLInputElement).value.trim() || 'packages/toolkit-tokens/json/figma-export.json',
-  };
-  if (!settings.token || !settings.owner || !settings.repo) {
-    setSettingsStatus('Token, owner, and repo are required', 'err');
-    return;
-  }
-  postToPlugin('save-settings', { settings });
-});
 
 // ── Tools — Select ────────────────────────────────────────────────────────────
 
@@ -1038,52 +808,39 @@ document.getElementById('annotateClearBtn')?.addEventListener('click', () => {
   postToPlugin('annotate:clear', { nodeId: annotateNodeId });
 });
 
-// ── Tools — Spec ──────────────────────────────────────────────────────────────
+// ── Tools — Bento ─────────────────────────────────────────────────────────────
 
-function setSpecStatus(msg: string, type: '' | 'ok' | 'err' = '') {
-  const el = document.getElementById('specStatus') as HTMLElement;
+function setBentoStatus(msg: string, type: '' | 'ok' | 'err' = '') {
+  const el = document.getElementById('bentoStatus') as HTMLElement;
   el.textContent = msg; el.className = 'status' + (type ? ' ' + type : '');
 }
 
-function updateSpecSelection(sel: { id: string; name: string; nodeType: string; variantCount?: number } | null) {
-  const isValid = sel?.nodeType === 'COMPONENT_SET' || sel?.nodeType === 'COMPONENT';
-  specSetId = isValid ? (sel?.id ?? null) : null;
-  const emptyEl  = document.getElementById('specSelectionEmpty') as HTMLElement;
-  const infoEl   = document.getElementById('specSelectionInfo')  as HTMLElement;
-  const nameEl   = document.getElementById('specSetName')   as HTMLElement;
-  const countEl  = document.getElementById('specSetCount')  as HTMLElement;
-  const genBtn   = document.getElementById('specGenerateBtn') as HTMLButtonElement;
-  if (isValid && sel) {
+// Bento generation needs a full COMPONENT_SET (not a single COMPONENT).
+function updateBentoSelection(sel: { id: string; name: string; nodeType: string; variantCount?: number } | null) {
+  const isSet = sel?.nodeType === 'COMPONENT_SET';
+  bentoSetId = isSet ? (sel?.id ?? null) : null;
+  const emptyEl = document.getElementById('bentoSelectionEmpty') as HTMLElement;
+  const infoEl  = document.getElementById('bentoSelectionInfo')  as HTMLElement;
+  const nameEl  = document.getElementById('bentoSetName')  as HTMLElement;
+  const countEl = document.getElementById('bentoSetCount') as HTMLElement;
+  const btn     = document.getElementById('bentoGenerateBtn') as HTMLButtonElement;
+  if (isSet && sel) {
     emptyEl.style.display = 'none'; infoEl.style.display = 'flex';
     nameEl.textContent  = sel.name;
-    countEl.textContent = sel.nodeType === 'COMPONENT_SET'
-      ? (sel.variantCount ?? 0) + ' variants'
-      : '1 variant';
-    genBtn.disabled = false;
+    countEl.textContent = (sel.variantCount ?? 0) + ' variants';
+    btn.disabled = false;
   } else {
     emptyEl.style.display = 'block'; infoEl.style.display = 'none';
-    genBtn.disabled = true;
+    btn.disabled = true;
   }
 }
 
-document.querySelectorAll<HTMLButtonElement>('#specOpts .chip').forEach(chip => {
-  chip.addEventListener('click', () => chip.classList.toggle('on'));
-});
-
-document.getElementById('specGenerateBtn')?.addEventListener('click', () => {
-  if (!specSetId) return;
-  const on = new Set(
-    Array.from(document.querySelectorAll<HTMLButtonElement>('#specOpts .chip.on'))
-      .map(c => c.dataset.opt!)
-  );
-  if (on.size === 0) { setSpecStatus('Select at least one section to include', 'err'); return; }
-  const btn = document.getElementById('specGenerateBtn') as HTMLButtonElement;
+document.getElementById('bentoGenerateBtn')?.addEventListener('click', () => {
+  if (!bentoSetId) return;
+  const btn = document.getElementById('bentoGenerateBtn') as HTMLButtonElement;
   btn.disabled = true; btn.textContent = 'Generating…';
-  setSpecStatus('');
-  postToPlugin('spec:generate', {
-    setId: specSetId,
-    options: { variants: on.has('variants'), tokens: on.has('tokens'), children: on.has('children') },
-  });
+  setBentoStatus('');
+  postToPlugin('bento:generate', { setId: bentoSetId });
 });
 
 // ── Plugin messages ───────────────────────────────────────────────────────────
@@ -1108,23 +865,6 @@ window.addEventListener('message', (event) => {
       }
       break;
     }
-    case 'settings-loaded': applySettings(msg.settings as GitHubSettings | null); break;
-    case 'settings-saved': {
-      if (msg.success) {
-        githubSettings = {
-          token:    (document.getElementById('ghToken')    as HTMLInputElement).value.trim(),
-          owner:    (document.getElementById('ghOwner')    as HTMLInputElement).value.trim(),
-          repo:     (document.getElementById('ghRepo')     as HTMLInputElement).value.trim(),
-          branch:   (document.getElementById('ghBranch')   as HTMLInputElement).value.trim() || 'main',
-          filePath: (document.getElementById('ghFilePath') as HTMLInputElement).value.trim() || 'packages/toolkit-tokens/json/figma-export.json',
-        };
-        setSettingsStatus('Saved', 'ok');
-        updateExportButtons();
-      } else {
-        setSettingsStatus('Save failed: ' + (msg.error as string), 'err');
-      }
-      break;
-    }
     case 'select:axes': {
       if (msg.setId) renderAxes(msg.setId as string, msg.setName as string, msg.axes as any[]);
       else clearSelect();
@@ -1143,8 +883,9 @@ window.addEventListener('message', (event) => {
           nodeType: msg.nodeType as string,
           variantCount: msg.variantCount as number | undefined,
         };
+        updateLlmCaptureSelection(sel);
         updateAnnotateSelection(sel);
-        updateSpecSelection(sel);
+        updateBentoSelection(sel);
         updateCopyBtn(sel, msg.fileKey as string | null, msg.fileName as string | null, msg.allNodes as Array<{ id: string; name: string }> | undefined);
         updateSectionBar(
           !!(msg.isSection as boolean),
@@ -1152,19 +893,59 @@ window.addEventListener('message', (event) => {
           (msg.sectionName as string)  ?? sel.name,
         );
       } else {
+        updateLlmCaptureSelection(null);
         updateAnnotateSelection(null);
-        updateSpecSelection(null);
+        updateBentoSelection(null);
         updateCopyBtn(null, null);
         updateSectionBar(false, 0, '');
       }
       break;
     }
-    case 'token-docs:result': {
-      document.querySelectorAll<HTMLButtonElement>('.gen-btn').forEach(b => {
-        b.disabled = false; b.textContent = '→';
-      });
-      if (msg.error) setVarStatus('❌ ' + (msg.error as string), 'err');
-      else setVarStatus('✓ ' + (msg.count as number) + ' tokens documented', 'ok');
+    case 'llm-capture:result': {
+      const btn = document.getElementById('llmCaptureSendBtn') as HTMLButtonElement;
+      const resetBtn = () => {
+        btn.disabled = !llmCaptureNodeId;
+        btn.textContent = 'Send Screenshot';
+      };
+      if (msg.error) {
+        resetBtn();
+        setLlmCaptureStatus('❌ ' + (msg.error as string), 'err');
+        break;
+      }
+      const capture = msg.capture as Record<string, any>;
+      const prompt = ((document.getElementById('llmCapturePrompt') as HTMLTextAreaElement)?.value || '').trim();
+      setLlmCaptureStatus('Sending image + metadata to local LLM bridge…');
+      btn.textContent = 'Sending…';
+      fetch('http://localhost:4002/llm/capture', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          capture,
+          prompt: prompt || 'Inspect this Figma selection and summarize the layout, visual system, tokens, and implementation notes.',
+        }),
+      })
+        .then(async res => {
+          const data = await res.json().catch(() => ({}));
+          if (!res.ok) throw new Error(data.error || `LLM bridge returned ${res.status}`);
+          if (data.jobId) return pollLlmCaptureJob(data.jobId as string);
+          return data;
+        })
+        .then((result: any) => {
+          const label = result?.fileName
+            ? `✓ Sent · ${result.fileName}`
+            : result?.title
+              ? `✓ Sent · ${result.title}`
+              : '✓ Sent to LLM';
+          setLlmCaptureStatus(label, 'ok');
+          resetBtn();
+        })
+        .catch((e: any) => {
+          const hint = /Failed to fetch|NetworkError|Load failed/i.test(e.message || '')
+            ? 'Local LLM bridge is not running. Run: npm run figma-story'
+            : (e.message || 'Capture failed');
+          setLlmCaptureStatus('❌ ' + hint, 'err');
+          resetBtn();
+        });
       break;
     }
     case 'format-section:done': {
@@ -1189,13 +970,14 @@ window.addEventListener('message', (event) => {
       setAnnotateStatus(n > 0 ? `Cleared ${n} annotation${n !== 1 ? 's' : ''}` : 'Nothing to clear', 'ok');
       break;
     }
-    case 'spec:result': {
-      const btn = document.getElementById('specGenerateBtn') as HTMLButtonElement;
-      btn.disabled = !specSetId; btn.textContent = 'Generate Spec';
-      if (msg.error) setSpecStatus('❌ ' + (msg.error as string), 'err');
+    case 'bento:result': {
+      const btn = document.getElementById('bentoGenerateBtn') as HTMLButtonElement;
+      btn.disabled = !bentoSetId; btn.textContent = 'Generate bento doc';
+      if (msg.error) setBentoStatus('❌ ' + (msg.error as string), 'err');
       else {
         const vars = msg.variantCount as number;
-        setSpecStatus(`✓ Spec generated · ${vars} variant${vars !== 1 ? 's' : ''}`, 'ok');
+        const warn = msg.warning ? ' · ⚠ ' + (msg.warning as string) : '';
+        setBentoStatus(`✓ Bento doc generated · ${vars} variant${vars !== 1 ? 's' : ''}${warn}`, 'ok');
       }
       break;
     }
@@ -1205,7 +987,6 @@ window.addEventListener('message', (event) => {
 // ── Init ──────────────────────────────────────────────────────────────────────
 
 postToPlugin('ui-ready');
-postToPlugin('get-settings');
 postToPlugin('resize-for-view', { width: 320, height: 460 });
 
 renderHomeView();


### PR DESCRIPTION
## What

Repurposes the **S2A Toolkit** Figma plugin around the tools the design-system team uses day to day, and retires the outdated doc-generation scaffolding.

**Added**
- **Tools → Generate bento doc** — select a component set → clones the `Bento Doc Template` and repopulates hero + versioning, the all-variants grid *with axis labels*, anatomy, properties, and a dark-mode preview from the set and its `s2a:meta` description fence. Spec: `apps/s2a-toolkit/BENTO-GENERATOR-SPEC.md`.
- `/llm/capture` endpoint on the story server (screenshot + metadata → LLM), plus the `localhost:4002` allow-list entry.

**Removed** (outdated — the docs have moved to the bento style)
- The entire **Tokens tab** (live doc-gen + token export to the experimental `toolkit-tokens` package).
- The old **Spec sheet** generator (dark-section component docs — superseded by the bento generator).
- The now-inert **Settings → GitHub Export** panel + gear.

**Preserved** — the figma-console **Bridge** (WS + `REFRESH_VARIABLES`/`serialize*`), header **Copy Figma link**, and the rest of **Tools** (LLM capture, Variant filter, Annotate, Format section).

## Why

The token doc-gen and spec-sheet emitted the old dark-section doc style the system has moved away from; the token export fed an experimental, non-shipping package. Cutting them leaves a leaner, teachable plugin focused on real workflows, and the bento generator replaces the spec sheet with current-style output.

## Result

- Tab bar is now **Home + Tools** (no gear).
- **+1,474 / −3,894** — mostly removal. `dist/` rebuilt (`npm run build` green).

## Testing

⚠️ Not runtime-tested in Figma (plugins can't run headless). To verify: Plugins → Development → Import from manifest → `apps/s2a-toolkit/manifest.json` → Tools → **Generate bento doc** on e.g. `IconButton — v2`; open the Bridge pill → Connect still works.

> The `Bento Doc Template` the generator clones lives in the Figma file (📐 Templates page), not in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
