### PR TITLE
feat(tokens): release manifest — stable consumption contract (no registry)

### DIFF
--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "nx build tokens",
     "package": "nx package tokens",
+    "manifest": "node scripts/build-release-manifest.js",
     "sync": "nx sync-figma tokens",
     "minify": "nx minify tokens",
     "clean": "nx clean tokens",

--- a/packages/tokens/scripts/build-release-manifest.js
+++ b/packages/tokens/scripts/build-release-manifest.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/**
+ * build-release-manifest.js
+ * -------------------------------------------------------------------------
+ * Emits the release "contract" that external consumers (e.g. Forge) fetch
+ * to always resolve the CURRENT S2A tokens release — no npm registry needed.
+ *
+ * Produces:
+ *   releases/<version>/manifest.json   — immutable, per-version
+ *   releases/latest.json               — pointer, overwritten every release
+ *
+ * A consumer fetches ONE stable URL:
+ *   https://raw.githubusercontent.com/<repo>/<branch>/releases/latest.json
+ * ...which always describes the newest release (version, artifact URLs,
+ * integrity, the token catalog, and the CSS var prefix to code against).
+ *
+ * Run AFTER the tarball has been produced into releases/:
+ *   node packages/tokens/scripts/build-release-manifest.js
+ * Optionally: RELEASE_REPO=adobecom/consonant RELEASE_BRANCH=main node ...
+ */
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const ROOT = path.resolve(__dirname, '../../..');
+const TOKENS = path.join(ROOT, 'packages', 'tokens');
+const RELEASES = path.join(ROOT, 'releases');
+const CSS_DEV = path.join(ROOT, 'dist', 'packages', 'tokens', 'css', 'dev');
+const JSON_DIR = path.join(TOKENS, 'json');
+
+const REPO = process.env.RELEASE_REPO || 'adobecom/consonant';
+const BRANCH = process.env.RELEASE_BRANCH || 'main';
+const RAW = `https://raw.githubusercontent.com/${REPO}/${BRANCH}`;
+const TREE = `https://github.com/${REPO}/tree/${BRANCH}`;
+const BLOB = `https://github.com/${REPO}/blob/${BRANCH}`;
+const SPEC = 'w3c-design-tokens'; // DTCG format
+
+const pkg = JSON.parse(fs.readFileSync(path.join(TOKENS, 'package.json'), 'utf8'));
+const version = pkg.version;
+
+// ── locate the tarball for this version (current naming, then legacy) ──
+const candidates = [
+  `adobecom-s2a-tokens-${version}.tgz`,
+  `s2a-tokens-${version}.tgz`,
+];
+const tarballName = candidates.find(n => fs.existsSync(path.join(RELEASES, n)));
+if (!tarballName) {
+  throw new Error(`No tarball for ${version} in releases/ (looked for ${candidates.join(', ')}). Package the release first.`);
+}
+const tarballPath = path.join(RELEASES, tarballName);
+const tarballBuf = fs.readFileSync(tarballPath);
+const sha256 = crypto.createHash('sha256').update(tarballBuf).digest('base64');
+
+// ── collections from metadata.json (grouped, with modes) ──
+function collections() {
+  const meta = JSON.parse(fs.readFileSync(path.join(JSON_DIR, 'metadata.json'), 'utf8'));
+  const map = new Map();
+  for (const f of meta.files || []) {
+    const c = f.collection || {};
+    if (!c.slug) continue;
+    if (!map.has(c.slug)) map.set(c.slug, { name: c.name, slug: c.slug, modes: new Set() });
+    if (f.mode?.slug) map.get(c.slug).modes.add(f.mode.slug);
+  }
+  return [...map.values()].map(c => ({ name: c.name, slug: c.slug, modes: [...c.modes] }));
+}
+
+// ── token count = unique --s2a-* custom properties in the shipped dev CSS ──
+function tokenCount() {
+  try {
+    const vars = new Set();
+    for (const f of fs.readdirSync(CSS_DEV).filter(n => n.endsWith('.css'))) {
+      const css = fs.readFileSync(path.join(CSS_DEV, f), 'utf8');
+      for (const m of css.matchAll(/(--s2a-[\w-]+)\s*:/g)) vars.add(m[1]);
+    }
+    return vars.size;
+  } catch {
+    return null; // dist not built — leave null rather than guess
+  }
+}
+
+// ── which CSS files the package ships (names inside the tarball's css/) ──
+function cssEntry() {
+  const pick = name => (fs.existsSync(path.join(CSS_DEV, name)) ? `css/${name}` : undefined);
+  return {
+    primitives: pick('tokens.primitives.css'),
+    semantic: pick('tokens.semantic.css'),
+    semanticLight: pick('tokens.semantic.light.css'),
+    semanticDark: pick('tokens.semantic.dark.css'),
+    responsive: ['xl', 'lg', 'md', 'sm']
+      .map(bp => pick(`tokens.responsive.${bp}.css`))
+      .filter(Boolean),
+  };
+}
+
+const manifest = {
+  $schema: `${RAW}/releases/manifest.schema.json`,
+  name: pkg.name,
+  version,
+  released: new Date().toISOString().slice(0, 10),
+  spec: SPEC,
+  semver: true,
+  cssVarPrefix: '--s2a-',
+  artifact: {
+    tarball: {
+      url: `${RAW}/releases/${tarballName}`,
+      integrity: `sha256-${sha256}`,
+      bytes: tarballBuf.length,
+    },
+    css: cssEntry(), // paths INSIDE the unpacked package
+  },
+  source: {
+    // the DTCG JSON source on the branch — always the current spec
+    spec: SPEC,
+    dir: `${TREE}/packages/tokens/json`,
+  },
+  collections: collections(),
+  tokenCount: tokenCount(),
+  changelog: `${BLOB}/packages/tokens/CHANGELOG.md`,
+  generatedBy: 'build-release-manifest.js',
+};
+
+// ── write per-version + latest pointer ──
+const versionDir = path.join(RELEASES, version);
+fs.mkdirSync(versionDir, { recursive: true });
+fs.writeFileSync(path.join(versionDir, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n');
+fs.writeFileSync(path.join(RELEASES, 'latest.json'), JSON.stringify(manifest, null, 2) + '\n');
+
+console.log(`✓ release manifest ${version}`);
+console.log(`  releases/${version}/manifest.json`);
+console.log(`  releases/latest.json  → consumers fetch ${RAW}/releases/latest.json`);
+console.log(`  tarball ${tarballName} (${(tarballBuf.length / 1024).toFixed(1)}KB) · ${manifest.tokenCount ?? '?'} tokens · ${manifest.collections.length} collections`);

--- a/releases/0.0.20/manifest.json
+++ b/releases/0.0.20/manifest.json
@@ -1,0 +1,165 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adobecom/consonant/main/releases/manifest.schema.json",
+  "name": "@adobecom/s2a-tokens",
+  "version": "0.0.20",
+  "released": "2026-08-13",
+  "spec": "w3c-design-tokens",
+  "semver": true,
+  "cssVarPrefix": "--s2a-",
+  "artifact": {
+    "tarball": {
+      "url": "https://raw.githubusercontent.com/adobecom/consonant/main/releases/adobecom-s2a-tokens-0.0.20.tgz",
+      "integrity": "sha256-YbMY1gjXYZ4VhnGGigHJEdeRceAYWxVSqBXl5M4qn9w=",
+      "bytes": 22472
+    },
+    "css": {
+      "primitives": "css/tokens.primitives.css",
+      "semantic": "css/tokens.semantic.css",
+      "semanticLight": "css/tokens.semantic.light.css",
+      "semanticDark": "css/tokens.semantic.dark.css",
+      "responsive": [
+        "css/tokens.responsive.xl.css",
+        "css/tokens.responsive.lg.css",
+        "css/tokens.responsive.md.css",
+        "css/tokens.responsive.sm.css"
+      ]
+    }
+  },
+  "source": {
+    "spec": "w3c-design-tokens",
+    "dir": "https://github.com/adobecom/consonant/tree/main/packages/tokens/json"
+  },
+  "collections": [
+    {
+      "name": "S2A / Responsive / Container / Grid",
+      "slug": "s2a-responsive-container-grid",
+      "modes": [
+        "xl",
+        "lg",
+        "md",
+        "sm"
+      ]
+    },
+    {
+      "name": "S2A / Design Guides",
+      "slug": "s2a-design-guides",
+      "modes": [
+        "hide-all",
+        "show-all",
+        "show-spacers",
+        "show-text",
+        "show-instance-swaps",
+        "show-layouts",
+        "show-corner-radius"
+      ]
+    },
+    {
+      "name": "S2A / Semantic / Dimension / Static",
+      "slug": "s2a-semantic-dimension-static",
+      "modes": [
+        "value",
+        "token"
+      ]
+    },
+    {
+      "name": "Primitives / Color / Theme",
+      "slug": "primitives-color-theme",
+      "modes": [
+        "light"
+      ]
+    },
+    {
+      "name": "S2A / Primitives / Color / Theme",
+      "slug": "s2a-primitives-color-theme",
+      "modes": [
+        "light"
+      ]
+    },
+    {
+      "name": "Semantic",
+      "slug": "semantic",
+      "modes": [
+        "mode-1"
+      ]
+    },
+    {
+      "name": "Primitives / Dimension / Static",
+      "slug": "primitives-dimension-static",
+      "modes": [
+        "mode-1"
+      ]
+    },
+    {
+      "name": "Semantic / Dimension / Static",
+      "slug": "semantic-dimension-static",
+      "modes": [
+        "mode-1"
+      ]
+    },
+    {
+      "name": "S2A / Semantic / Color / Theme",
+      "slug": "s2a-semantic-color-theme",
+      "modes": [
+        "light",
+        "dark"
+      ]
+    },
+    {
+      "name": "S2A / Primitives / Dimension / Static",
+      "slug": "s2a-primitives-dimension-static",
+      "modes": [
+        "mode-1"
+      ]
+    },
+    {
+      "name": "Typography",
+      "slug": "typography",
+      "modes": [
+        "modeless"
+      ]
+    },
+    {
+      "name": "S2A / Min-Max",
+      "slug": "s2a-min-max",
+      "modes": [
+        "min",
+        "max"
+      ]
+    },
+    {
+      "name": "S2A / Responsive / Grid / Typography",
+      "slug": "s2a-responsive-grid-typography",
+      "modes": [
+        "xl",
+        "lg",
+        "md",
+        "sm"
+      ]
+    },
+    {
+      "name": "•S Typography",
+      "slug": "s-typography",
+      "modes": [
+        "mode-1"
+      ]
+    },
+    {
+      "name": "Primitives (Core)",
+      "slug": "primitives-core",
+      "modes": [
+        "mode-1"
+      ]
+    },
+    {
+      "name": "Semantic / Color / Theme",
+      "slug": "semantic-color-theme",
+      "modes": [
+        "light",
+        "dark"
+      ]
+    }
+  ],
+  "tokenCount": 476,
+  "changelog": "https://github.com/adobecom/consonant/blob/main/packages/tokens/CHANGELOG.md",
+  "generatedBy": "build-release-manifest.js"
+}

--- a/releases/README.md
+++ b/releases/README.md
@@ -1,0 +1,54 @@
+# S2A Tokens — release contract
+
+Consume S2A design tokens **without an npm registry**. Every release is a semver'd
+tarball in this folder, and a single stable pointer always resolves to the newest one.
+
+## The one URL to fetch
+
+```
+https://raw.githubusercontent.com/adobecom/consonant/main/releases/latest.json
+```
+
+`latest.json` is overwritten on every release and always describes the **current**
+release. Per‑version manifests (`releases/<version>/manifest.json`) are **immutable**
+— pin to one if you need reproducibility.
+
+## What you get
+
+| Field | What it's for |
+|---|---|
+| `name`, `version`, `released` | Identity + semver. |
+| `spec` | `w3c-design-tokens` — the source JSON is DTCG format. |
+| `cssVarPrefix` | `--s2a-` — the prefix to code against. |
+| `artifact.tarball` | `url`, Subresource‑Integrity `integrity` (`sha256-…`), and `bytes`. The primary artifact. |
+| `artifact.css` | Paths **inside** the unpacked tarball to the built CSS custom properties (primitives, semantic, semantic light/dark, responsive xl/lg/md/sm). |
+| `source.dir` | Pointer to the DTCG **source** JSON on `main` (always the current spec) if you want the raw tokens rather than compiled CSS. |
+| `collections` | The token catalog: each collection + its modes (e.g. `s2a-semantic-color-theme` → `light`, `dark`). |
+| `tokenCount` | Count of shipped `--s2a-*` custom properties. |
+| `changelog` | Link to the CHANGELOG. |
+
+## How to consume
+
+1. `GET latest.json` → read `version` + `artifact.tarball.url`.
+2. Download the tarball, verify against `artifact.tarball.integrity`, unpack.
+3. Load the CSS files under `artifact.css.*`, or read the DTCG source under `source.dir`.
+4. Re‑poll `latest.json` to detect a newer `version`; it stays current automatically.
+
+## Guarantees
+
+- **Semver.** Breaking changes bump the major; check `version` before adopting.
+- **Non‑destructive naming.** Token/CSS‑var names follow the Figma source of truth and
+  are **deprecated, not silently removed** — so `--s2a-*` names you build against are stable.
+- **Currency.** `latest.json` reflects the newest *release* (stable), not the tip of `main`.
+
+## Producing a release manifest
+
+After packaging the tarball into `releases/`:
+
+```bash
+node packages/tokens/scripts/build-release-manifest.js
+# → releases/<version>/manifest.json  +  releases/latest.json
+# override target repo/branch: RELEASE_REPO=adobecom/consonant RELEASE_BRANCH=main node …
+```
+
+Wire it as the final step of the release flow (e.g. after `nx package tokens`).

--- a/releases/latest.json
+++ b/releases/latest.json
@@ -1,0 +1,165 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adobecom/consonant/main/releases/manifest.schema.json",
+  "name": "@adobecom/s2a-tokens",
+  "version": "0.0.20",
+  "released": "2026-08-13",
+  "spec": "w3c-design-tokens",
+  "semver": true,
+  "cssVarPrefix": "--s2a-",
+  "artifact": {
+    "tarball": {
+      "url": "https://raw.githubusercontent.com/adobecom/consonant/main/releases/adobecom-s2a-tokens-0.0.20.tgz",
+      "integrity": "sha256-YbMY1gjXYZ4VhnGGigHJEdeRceAYWxVSqBXl5M4qn9w=",
+      "bytes": 22472
+    },
+    "css": {
+      "primitives": "css/tokens.primitives.css",
+      "semantic": "css/tokens.semantic.css",
+      "semanticLight": "css/tokens.semantic.light.css",
+      "semanticDark": "css/tokens.semantic.dark.css",
+      "responsive": [
+        "css/tokens.responsive.xl.css",
+        "css/tokens.responsive.lg.css",
+        "css/tokens.responsive.md.css",
+        "css/tokens.responsive.sm.css"
+      ]
+    }
+  },
+  "source": {
+    "spec": "w3c-design-tokens",
+    "dir": "https://github.com/adobecom/consonant/tree/main/packages/tokens/json"
+  },
+  "collections": [
+    {
+      "name": "S2A / Responsive / Container / Grid",
+      "slug": "s2a-responsive-container-grid",
+      "modes": [
+        "xl",
+        "lg",
+        "md",
+        "sm"
+      ]
+    },
+    {
+      "name": "S2A / Design Guides",
+      "slug": "s2a-design-guides",
+      "modes": [
+        "hide-all",
+        "show-all",
+        "show-spacers",
+        "show-text",
+        "show-instance-swaps",
+        "show-layouts",
+        "show-corner-radius"
+      ]
+    },
+    {
+      "name": "S2A / Semantic / Dimension / Static",
+      "slug": "s2a-semantic-dimension-static",
+      "modes": [
+        "value",
+        "token"
+      ]
+    },
+    {
+      "name": "Primitives / Color / Theme",
+      "slug": "primitives-color-theme",
+      "modes": [
+        "light"
+      ]
+    },
+    {
+      "name": "S2A / Primitives / Color / Theme",
+      "slug": "s2a-primitives-color-theme",
+      "modes": [
+        "light"
+      ]
+    },
+    {
+      "name": "Semantic",
+      "slug": "semantic",
+      "modes": [
+        "mode-1"
+      ]
+    },
+    {
+      "name": "Primitives / Dimension / Static",
+      "slug": "primitives-dimension-static",
+      "modes": [
+        "mode-1"
+      ]
+    },
+    {
+      "name": "Semantic / Dimension / Static",
+      "slug": "semantic-dimension-static",
+      "modes": [
+        "mode-1"
+      ]
+    },
+    {
+      "name": "S2A / Semantic / Color / Theme",
+      "slug": "s2a-semantic-color-theme",
+      "modes": [
+        "light",
+        "dark"
+      ]
+    },
+    {
+      "name": "S2A / Primitives / Dimension / Static",
+      "slug": "s2a-primitives-dimension-static",
+      "modes": [
+        "mode-1"
+      ]
+    },
+    {
+      "name": "Typography",
+      "slug": "typography",
+      "modes": [
+        "modeless"
+      ]
+    },
+    {
+      "name": "S2A / Min-Max",
+      "slug": "s2a-min-max",
+      "modes": [
+        "min",
+        "max"
+      ]
+    },
+    {
+      "name": "S2A / Responsive / Grid / Typography",
+      "slug": "s2a-responsive-grid-typography",
+      "modes": [
+        "xl",
+        "lg",
+        "md",
+        "sm"
+      ]
+    },
+    {
+      "name": "•S Typography",
+      "slug": "s-typography",
+      "modes": [
+        "mode-1"
+      ]
+    },
+    {
+      "name": "Primitives (Core)",
+      "slug": "primitives-core",
+      "modes": [
+        "mode-1"
+      ]
+    },
+    {
+      "name": "Semantic / Color / Theme",
+      "slug": "semantic-color-theme",
+      "modes": [
+        "light",
+        "dark"
+      ]
+    }
+  ],
+  "tokenCount": 476,
+  "changelog": "https://github.com/adobecom/consonant/blob/main/packages/tokens/CHANGELOG.md",
+  "generatedBy": "build-release-manifest.js"
+}

--- a/releases/manifest.schema.json
+++ b/releases/manifest.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/adobecom/consonant/main/releases/manifest.schema.json",
+  "title": "S2A Tokens Release Manifest",
+  "description": "The consumption contract for an S2A design-tokens release. latest.json always describes the current release; releases/<version>/manifest.json is immutable.",
+  "type": "object",
+  "required": ["name", "version", "spec", "cssVarPrefix", "artifact", "collections"],
+  "additionalProperties": true,
+  "properties": {
+    "$schema": { "type": "string" },
+    "name": { "type": "string", "description": "Package name, e.g. @adobecom/s2a-tokens" },
+    "version": { "type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?$" },
+    "released": { "type": "string", "format": "date" },
+    "spec": { "type": "string", "enum": ["w3c-design-tokens"] },
+    "semver": { "type": "boolean" },
+    "cssVarPrefix": { "type": "string" },
+    "artifact": {
+      "type": "object",
+      "required": ["tarball"],
+      "properties": {
+        "tarball": {
+          "type": "object",
+          "required": ["url", "integrity"],
+          "properties": {
+            "url": { "type": "string", "format": "uri" },
+            "integrity": { "type": "string", "pattern": "^sha256-" },
+            "bytes": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "css": {
+          "type": "object",
+          "description": "Paths inside the unpacked package to the built CSS custom properties.",
+          "properties": {
+            "primitives": { "type": "string" },
+            "semantic": { "type": "string" },
+            "semanticLight": { "type": "string" },
+            "semanticDark": { "type": "string" },
+            "responsive": { "type": "array", "items": { "type": "string" } }
+          }
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "properties": {
+        "spec": { "type": "string" },
+        "dir": { "type": "string", "format": "uri" }
+      }
+    },
+    "collections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "slug"],
+        "properties": {
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "modes": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "tokenCount": { "type": ["integer", "null"], "minimum": 0 },
+    "changelog": { "type": "string" },
+    "generatedBy": { "type": "string" }
+  }
+}


### PR DESCRIPTION
## What

Adds a **release manifest** so consumers can always resolve the *current* S2A tokens release from **one stable URL**, without an npm registry.

Consumers fetch:
```
https://raw.githubusercontent.com/adobecom/consonant/main/releases/latest.json
```
It returns: `version`, tarball URL + `sha256` integrity, the built CSS entry paths, the collection catalog (each collection + modes), the `--s2a-` prefix, and a pointer to the DTCG source. `releases/<version>/manifest.json` is an immutable per-version copy.

## Why

Milo consumes tokens manually (tarball, no registry), and a new consumer (Forge / forge.adobe.io) asked to "establish a contract with the token catalog… long as it remains current." This is exactly that — a documented, semver'd, always-current contract — **without** requiring the npm-registry move (which needs separate signoff).

## Files
- `packages/tokens/scripts/build-release-manifest.js` — generator (`npm run manifest`): version, tarball URL + integrity + bytes, CSS entry paths, collections (from `metadata.json`), shipped `--s2a-*` count.
- `releases/latest.json` + `releases/0.0.20/manifest.json` — generated for the current release.
- `releases/README.md` — the consumer-facing contract.
- `releases/manifest.schema.json` — JSON Schema.
- `packages/tokens/package.json` — adds the `manifest` script.

## Run it (final step of a release)
```
nx package tokens                              # tarball → releases/
npm run manifest -w @adobecom/s2a-tokens       # emit releases/latest.json + per-version
```

## Notes
- `tokenCount` = shipped `--s2a-*` CSS custom properties (476 for 0.0.20) — precise, distinct from the ~744 total-variables figure.
- `collections` mirrors `metadata.json`, which still carries a few legacy/duplicate collection exports; a `metadata.json` hygiene pass would trim the catalog if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
