### PR TITLE
ci(tokens): publish to GitHub Packages on release merge

### DIFF
--- a/.github/workflows/publish-tokens.yml
+++ b/.github/workflows/publish-tokens.yml
@@ -1,0 +1,78 @@
+name: Publish Tokens
+
+# Publishes @adobecom/s2a-tokens to GitHub Packages when a token release lands
+# on main. The release pipeline (token-release.yml) opens a PR that bumps the
+# version and commits the built dist/ + tarball; merging that PR trips this
+# workflow, which publishes the already-built, already-reviewed package.
+#
+# Publishing runs on GitHub's own GITHUB_TOKEN (packages: write) — no personal
+# token, nothing on anyone's machine. It is idempotent: a version already on the
+# registry is skipped, not re-published (registries are immutable per version).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/tokens/package.json" # version bump = a release merged
+  workflow_dispatch: # manual re-publish of the current version
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-tokens
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # The merge to main is already gated (CODEOWNERS review). This second gate
+    # makes the actual registry push — which is irreversible — require a
+    # reviewer's approval too. Remove this line to auto-publish on merge.
+    environment: token-release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Node (GitHub Packages)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@adobecom"
+
+      - name: Read package version
+        id: v
+        run: echo "version=$(node -p "require('./dist/packages/tokens/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Publish (skip if the version already exists)
+        id: publish
+        working-directory: dist/packages/tokens
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          OUT=$(npm publish 2>&1); CODE=$?
+          echo "$OUT"
+          if [ $CODE -eq 0 ]; then
+            echo "result=published" >> "$GITHUB_OUTPUT"
+          elif echo "$OUT" | grep -qiE "cannot publish over|already exists|E409|EPUBLISHCONFLICT|conflict"; then
+            echo "::notice::@adobecom/s2a-tokens@${{ steps.v.outputs.version }} is already on the registry — skipping."
+            echo "result=skipped" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Publish failed for a reason other than a version conflict."
+            exit $CODE
+          fi
+
+      - name: Summary
+        if: always()
+        run: |
+          V="${{ steps.v.outputs.version }}"
+          case "${{ steps.publish.outputs.result }}" in
+            published) echo "### 📦 Published @adobecom/s2a-tokens@$V to GitHub Packages" >> "$GITHUB_STEP_SUMMARY" ;;
+            skipped)   echo "### ⏭️ @adobecom/s2a-tokens@$V was already published — nothing to do" >> "$GITHUB_STEP_SUMMARY" ;;
+            *)         echo "### ⚠️ Publish did not complete for @adobecom/s2a-tokens@$V" >> "$GITHUB_STEP_SUMMARY" ;;
+          esac


### PR DESCRIPTION
Closes the release loop. Today the pipeline stops at a merged release PR; this publishes the package the moment that PR lands.

## Flow
`token-release.yml` opens a version-bump PR → a code owner reviews & merges it → **this workflow publishes** `dist/packages/tokens` (`@adobecom/s2a-tokens`) to GitHub Packages.

## How it works
- **Trigger:** push to `main` touching `packages/tokens/package.json` (a version bump = a release merged), plus `workflow_dispatch` for a manual re-publish.
- **Publishes the reviewed artifact** — the committed, already-built `dist/packages/tokens/`. No rebuild, no Figma access; it ships exactly what was in the merged PR.
- **Auth:** the workflow's own `GITHUB_TOKEN` with `packages: write`. No personal token, nothing on anyone's machine.
- **Idempotent:** a version already on the registry is skipped (registries are immutable per version); any *other* failure is a hard error.
- **Gated:** runs in the `token-release` environment, so the irreversible registry push needs a reviewer's approval on top of the merge. Remove that one line to auto-publish on merge instead.

## Before this can publish (repo settings)
- The `token-release` environment must exist with required reviewers (same one used by the release workflow).
- GitHub Packages publishing must be allowed for the repo's `GITHUB_TOKEN` (default on).

## Note
There's also a registry-free path already in place — `releases/latest.json` + the committed tarball that consumers can fetch by URL — so this npm publish is additive, for consumers who specifically want `npm install @adobecom/s2a-tokens`.

## Test plan
- [x] Workflow YAML validated
- [x] Confirmed the publishable artifact (`dist/packages/tokens/`, correct name + `publishConfig.registry`, built `tokens.min.css`) exists on main
- [ ] First real publish fires when the next release PR merges (or via `workflow_dispatch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtzFWxHSX7fvPdq17Sn125