### PR TITLE
docs(tokens): how to install @adobecom/s2a-tokens

### DIFF
--- a/apps/storybook/stories/InstallingTokens.mdx
+++ b/apps/storybook/stories/InstallingTokens.mdx
@@ -32,9 +32,25 @@ on whether your project can authenticate to GitHub Packages.
 
 ## Option A — npm (GitHub Packages)
 
-**1. Create a token** — a classic PAT with the `read:packages` scope (for an org
-repo you may need to authorize it for `adobecom` via SSO). In GitHub Actions CI,
-the built-in `GITHUB_TOKEN` already has package read, so no PAT is needed there.
+**1. Create a token** — a classic PAT with the `read:packages` scope.
+
+> **Shortcut:** [this link](https://github.com/settings/tokens/new?scopes=read:packages&description=s2a-tokens)
+> opens the classic-token page with the scope pre-checked and the token pre-named.
+
+Click-by-click:
+
+1. GitHub → avatar → **Settings** → **Developer settings** (bottom of sidebar)
+2. **Personal access tokens → Tokens (classic)** → **Generate new token (classic)**
+3. **Note:** `s2a-tokens read`. **Expiration:** 90 days (`adobecom` caps lifetime at 366 days).
+4. **Scopes:** check **`read:packages`** only — that's the whole requirement.
+5. **Generate token**, then **copy it now** (shown once, starts with `ghp_`).
+6. **⚠️ Authorize SSO — the step people miss:** on the tokens list, click
+   **Configure SSO** next to your token and **Authorize** it for **`adobecom`**.
+   Skip this and the token returns **401** on an org package even with the right scope.
+
+A PAT is browser-only and shown once — you have to create it yourself; no agent can
+mint one. If that's a blocker, **Option B below needs no token at all**. In GitHub
+Actions CI, the built-in `GITHUB_TOKEN` already has package read, so no PAT is needed there.
 
 **2. Point the `@adobecom` scope at GitHub Packages** in your project's `.npmrc`:
 

--- a/apps/storybook/stories/InstallingTokens.mdx
+++ b/apps/storybook/stories/InstallingTokens.mdx
@@ -1,0 +1,97 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Getting Started/Installing Tokens" />
+
+# Installing S2A Tokens
+
+The S2A design tokens ship as CSS custom properties (prefix `--s2a-`) in the
+**`@adobecom/s2a-tokens`** package. There are two ways to consume them — pick based
+on whether your project can authenticate to GitHub Packages.
+
+## Do I need a token?
+
+<table>
+  <thead>
+    <tr><th align="left">Path</th><th align="left">Token required?</th><th align="left">Why</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>npm (GitHub Packages)</strong></td>
+      <td><strong>Yes</strong> — a <code>read:packages</code> token</td>
+      <td>GitHub's npm registry requires auth <strong>even for public packages</strong> — a documented GitHub limitation.</td>
+    </tr>
+    <tr>
+      <td><strong>Registry-free (fetch by URL)</strong></td>
+      <td><strong>No</strong></td>
+      <td><code>adobecom/consonant</code> is a public repo, so the release manifest and tarball are fetchable anonymously.</td>
+    </tr>
+  </tbody>
+</table>
+
+---
+
+## Option A — npm (GitHub Packages)
+
+**1. Create a token** — a classic PAT with the `read:packages` scope (for an org
+repo you may need to authorize it for `adobecom` via SSO). In GitHub Actions CI,
+the built-in `GITHUB_TOKEN` already has package read, so no PAT is needed there.
+
+**2. Point the `@adobecom` scope at GitHub Packages** in your project's `.npmrc`:
+
+```ini
+@adobecom:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+```
+
+**3. Install:**
+
+```bash
+npm install @adobecom/s2a-tokens
+```
+
+**4. Import the CSS** — the consolidated bundle, or just the layers you need:
+
+```js
+import '@adobecom/s2a-tokens';                          // all layers, minified
+// …or individually:
+import '@adobecom/s2a-tokens/css/tokens.primitives.css';
+import '@adobecom/s2a-tokens/css/tokens.semantic.css';
+import '@adobecom/s2a-tokens/css/tokens.semantic.light.css';
+import '@adobecom/s2a-tokens/css/tokens.semantic.dark.css';
+import '@adobecom/s2a-tokens/css/tokens.responsive.xl.css'; // + .lg / .md / .sm
+```
+
+**5. Use the tokens:**
+
+```css
+.card {
+  background: var(--s2a-color-background-default);
+  color: var(--s2a-color-content-default);
+  padding: var(--s2a-spacing-md);
+  border-radius: var(--s2a-border-radius-sm);
+}
+```
+
+Light/dark is a variable mode — set `data-theme="light"` or `data-theme="dark"` on a
+root element and the semantic tokens re-resolve (no separate stylesheet swap).
+
+---
+
+## Option B — Registry-free (no token)
+
+For consumers that can't authenticate, or that load assets at runtime with no build
+step, consume the release **manifest** and **tarball** directly — no `.npmrc`, no
+registry config, no token.
+
+The manifest always points at the latest release:
+
+```
+https://raw.githubusercontent.com/adobecom/consonant/main/releases/latest.json
+```
+
+It contains the version, the tarball URL, a `sha256` integrity hash, the CSS file
+list, and the `--s2a-` prefix. To pin a specific version, use
+`releases/<version>/manifest.json` instead of `latest.json`.
+
+Both paths serve the exact same tokens from the same release — Option B just skips
+the registry.

--- a/docs/how-tos/install-s2a-tokens.md
+++ b/docs/how-tos/install-s2a-tokens.md
@@ -19,8 +19,35 @@ Current published version: **0.0.21** (486 tokens).
 
 **1. Create a token.** A classic PAT with the `read:packages` scope is the
 reliable choice. (Fine-grained tokens can work too, but classic `read:packages`
-is the best-supported path for the npm registry.) For an org repo you may need to
-authorize the token for `adobecom` (SSO).
+is the best-supported path for the npm registry.)
+
+> **Shortcut:** this link opens the classic-token page with the right scope
+> already checked and the token pre-named:
+> <https://github.com/settings/tokens/new?scopes=read:packages&description=s2a-tokens>
+
+Click-by-click, if you'd rather do it by hand:
+
+1. GitHub → your avatar (top-right) → **Settings**
+2. Bottom of the left sidebar → **Developer settings**
+3. **Personal access tokens → Tokens (classic)**
+4. **Generate new token → Generate new token (classic)** (you may be asked to
+   re-enter your password)
+5. **Note:** name it something like `s2a-tokens read`
+6. **Expiration:** 90 days is fine. The `adobecom` org caps token lifetime at
+   **366 days** — anything longer is rejected.
+7. **Scopes:** check **`read:packages`** only. That is the entire requirement to
+   install; leave everything else unchecked.
+8. **Generate token**, then **copy it immediately** — it starts with `ghp_` and
+   is shown exactly once.
+9. **⚠️ Authorize SSO — this is the step people miss.** Back on the tokens list,
+   find your new token, click **Configure SSO**, and **Authorize** it for
+   **`adobecom`**. Without this the token returns **401** on an org package even
+   though the scope is correct.
+
+> **Note:** a PAT is a browser-only, log-in-required, shown-once secret — no
+> agent or script can mint one for you; you have to create it yourself. If that's
+> a blocker, **[Option B](#option-b--registry-free--no-token) needs no token at
+> all.**
 
 **2. Point the `@adobecom` scope at GitHub Packages.** In the consuming project's
 `.npmrc`:

--- a/docs/how-tos/install-s2a-tokens.md
+++ b/docs/how-tos/install-s2a-tokens.md
@@ -1,0 +1,111 @@
+# Installing `@adobecom/s2a-tokens`
+
+The S2A design tokens ship as CSS custom properties (prefix `--s2a-`). There are
+**two ways to consume them** — pick based on whether your project can authenticate
+to GitHub Packages.
+
+## Do I need a token?
+
+| Path | Token required? | Why |
+|---|---|---|
+| **A — `npm install` from GitHub Packages** | **Yes** — a `read:packages` token | GitHub's npm registry requires auth **even for public packages** (a documented GitHub limitation, not something we can turn off). |
+| **B — Registry-free (fetch CSS/tarball by URL)** | **No** | `adobecom/consonant` is a public repo, so the release manifest and tarball are fetchable anonymously. |
+
+Current published version: **0.0.21** (486 tokens).
+
+---
+
+## Option A — npm (GitHub Packages) · needs a token
+
+**1. Create a token.** A classic PAT with the `read:packages` scope is the
+reliable choice. (Fine-grained tokens can work too, but classic `read:packages`
+is the best-supported path for the npm registry.) For an org repo you may need to
+authorize the token for `adobecom` (SSO).
+
+**2. Point the `@adobecom` scope at GitHub Packages.** In the consuming project's
+`.npmrc`:
+
+```ini
+@adobecom:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+```
+
+Set `GITHUB_TOKEN` in your environment (don't commit a raw token). In CI on
+GitHub Actions, the built-in `GITHUB_TOKEN` already has package read — no PAT
+needed there.
+
+**3. Install:**
+
+```bash
+npm install @adobecom/s2a-tokens
+```
+
+**4. Use the tokens.** The package ships CSS. Import the consolidated bundle, or
+just the layers you need:
+
+```js
+import '@adobecom/s2a-tokens';                              // minified bundle (all layers)
+
+// …or import layers individually:
+import '@adobecom/s2a-tokens/css/tokens.primitives.css';
+import '@adobecom/s2a-tokens/css/tokens.semantic.css';
+import '@adobecom/s2a-tokens/css/tokens.semantic.light.css';
+import '@adobecom/s2a-tokens/css/tokens.semantic.dark.css';
+import '@adobecom/s2a-tokens/css/tokens.responsive.xl.css'; // + .lg / .md / .sm
+```
+
+Then reference the custom properties in your CSS:
+
+```css
+.card {
+  background: var(--s2a-color-background-default);
+  color: var(--s2a-color-content-default);
+  padding: var(--s2a-spacing-md);
+  border-radius: var(--s2a-border-radius-sm);
+}
+```
+
+Light/dark is driven by a variable mode: set `data-theme="light"` or
+`data-theme="dark"` on a root element and the semantic tokens re-resolve.
+
+---
+
+## Option B — Registry-free · no token
+
+For consumers that can't (or don't want to) authenticate — or that load assets at
+runtime with no build step (e.g. Milo-style) — consume the release **manifest**
+and **tarball** directly. No `.npmrc`, no registry config, no token.
+
+**The manifest always points at the latest release:**
+
+```
+https://raw.githubusercontent.com/adobecom/consonant/main/releases/latest.json
+```
+
+It contains the version, the tarball URL, a `sha256` integrity hash, the CSS file
+list, and the `--s2a-` var prefix. Fetch it, then pull what you need:
+
+```bash
+# 1. read the manifest
+curl -s https://raw.githubusercontent.com/adobecom/consonant/main/releases/latest.json
+
+# 2. download the tarball it points to (verify against manifest.artifact.tarball.integrity)
+curl -sLO https://raw.githubusercontent.com/adobecom/consonant/main/releases/adobecom-s2a-tokens-0.0.21.tgz
+
+# 3. extract the CSS you want
+tar -xzf adobecom-s2a-tokens-0.0.21.tgz package/css/min/tokens.min.css
+```
+
+To **pin a specific version** instead of "latest," use the per-version manifest:
+`https://raw.githubusercontent.com/adobecom/consonant/main/releases/<version>/manifest.json`.
+
+---
+
+## Which should I use?
+
+- **App with a normal npm/build toolchain and a place to store a token** (env var,
+  CI secret) → **Option A**.
+- **No build step, runtime-loaded, or you want zero tokens** → **Option B** (manifest).
+
+Both serve the exact same tokens from the same release — Option B just skips the
+registry.

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -4,8 +4,57 @@ This package is the **source of truth** for every design token that ships in S2A
 It outputs **CSS only** (no JS runtime required).
 All CSS is generated from our internal Figma Variables → JSON export (`json/`), but these raw JSON files are **not** included in the published package.
 
-**Package name:** `s2a-tokens`  
-**Current version:** `0.0.4`
+**Package name:** `@adobecom/s2a-tokens` · published to GitHub Packages
+
+---
+
+# Installation
+
+The tokens ship as CSS custom properties (prefix `--s2a-`). Two ways to consume them:
+
+### npm (GitHub Packages) — needs a `read:packages` token
+
+GitHub's npm registry requires an auth token **even though this package is public**.
+
+`.npmrc` in your project:
+
+```ini
+@adobecom:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+```
+
+```bash
+npm install @adobecom/s2a-tokens
+```
+
+```js
+import '@adobecom/s2a-tokens';                          // all layers, minified
+// …or import layers individually:
+import '@adobecom/s2a-tokens/css/tokens.semantic.css';
+import '@adobecom/s2a-tokens/css/tokens.semantic.light.css';
+import '@adobecom/s2a-tokens/css/tokens.semantic.dark.css';
+```
+
+```css
+.card {
+  color: var(--s2a-color-content-default);
+  padding: var(--s2a-spacing-md);
+}
+```
+
+### Registry-free — no token
+
+Because `adobecom/consonant` is public, fetch the release manifest and tarball
+directly — no `.npmrc`, no token. Ideal for runtime-loaded / no-build consumers:
+
+```
+https://raw.githubusercontent.com/adobecom/consonant/main/releases/latest.json
+```
+
+The manifest points at the current tarball with a `sha256` integrity hash and the
+list of CSS files.
+
+> Full guide (both paths, CI notes, version pinning): `docs/how-tos/install-s2a-tokens.md`.
 
 ---
 


### PR DESCRIPTION
Now that `@adobecom/s2a-tokens` publishes to GitHub Packages, this adds install instructions in the three places a consumer would look.

## What's added
- **`packages/tokens/README.md`** — a condensed **Installation** section (this is what shows on the GitHub Packages listing page and ships inside the tarball). Also fixes the stale package name (`s2a-tokens` → `@adobecom/s2a-tokens`).
- **`docs/how-tos/install-s2a-tokens.md`** — the full guide: both consumption paths, CI notes, version pinning.
- **`apps/storybook/stories/InstallingTokens.mdx`** — a "Getting Started / Installing Tokens" doc page in Storybook.

## Both paths, and the token question
- **npm (GitHub Packages)** — needs a `read:packages` token. GitHub's npm registry requires auth **even for public packages** (verified against the live package: unauthenticated `GET` → 401). Includes the `.npmrc` scope config and CI notes.
- **Registry-free** — **no token**. Because `adobecom/consonant` is public, the `releases/latest.json` manifest + tarball are fetchable anonymously (verified: unauthenticated `GET` → 200). For runtime-loaded / no-build consumers.

## Test plan
- [x] Storybook builds green; the MDX page compiles and registers as `Getting Started/Installing Tokens`
- [x] Fixed a real MDX rendering bug found while building — Storybook's MDX doesn't enable GFM markdown tables, so the comparison table is authored as HTML (renders reliably)
- [x] Token-required claims verified empirically against the live package, not asserted

_Note: sidebar pinning of the "Getting Started" section to the top is a one-line `storySort` change that lives with the sidebar reorg on the components branch (#119), kept out of this PR to avoid a `preview.js` conflict — the doc appears regardless._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtzFWxHSX7fvPdq17Sn125