### PR TITLE
chore(mcp): make @adobecom/s2a-ds-mcp an installable npm package

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,83 @@
+name: Publish MCP
+
+# Publishes @adobecom/s2a-ds-mcp to GitHub Packages when its version bumps on
+# main. Mirrors publish-tokens.yml: the merge is gated by CODEOWNERS review, and
+# the actual registry push additionally requires an environment reviewer.
+#
+# Publishing runs on GitHub's own GITHUB_TOKEN (packages: write) — no personal
+# token, nothing on anyone's machine. It is idempotent: a version already on the
+# registry is skipped (registries are immutable per version).
+#
+# The published tarball is built by the package's `prepack` (copy-data + tsc), so
+# it always ships a fresh data/ snapshot bundled alongside the compiled dist/.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/s2a-ds-mcp/package.json" # version bump = a release
+  workflow_dispatch: # manual re-publish of the current version
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-mcp
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: token-release
+    defaults:
+      run:
+        working-directory: apps/s2a-ds-mcp
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Node (GitHub Packages)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@adobecom"
+
+      # Dev deps (typescript) are needed because `prepack` compiles dist/.
+      - name: Install
+        run: npm ci
+
+      - name: Read package version
+        id: v
+        run: echo "version=$(npm pkg get version | tr -d '\"')" >> "$GITHUB_OUTPUT"
+
+      - name: Publish (skip if the version already exists)
+        id: publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          OUT=$(npm publish 2>&1); CODE=$?
+          echo "$OUT"
+          if [ $CODE -eq 0 ]; then
+            echo "result=published" >> "$GITHUB_OUTPUT"
+          elif echo "$OUT" | grep -qiE "cannot publish over|already exists|E409|EPUBLISHCONFLICT|conflict"; then
+            echo "::notice::@adobecom/s2a-ds-mcp@${{ steps.v.outputs.version }} is already on the registry — skipping."
+            echo "result=skipped" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Publish failed for a reason other than a version conflict."
+            exit $CODE
+          fi
+
+      - name: Summary
+        if: always()
+        run: |
+          V="${{ steps.v.outputs.version }}"
+          case "${{ steps.publish.outputs.result }}" in
+            published) echo "### 📦 Published @adobecom/s2a-ds-mcp@$V to GitHub Packages" >> "$GITHUB_STEP_SUMMARY" ;;
+            skipped)   echo "### ⏭️ @adobecom/s2a-ds-mcp@$V was already published — nothing to do" >> "$GITHUB_STEP_SUMMARY" ;;
+            *)         echo "### ⚠️ Publish did not complete for @adobecom/s2a-ds-mcp@$V" >> "$GITHUB_STEP_SUMMARY" ;;
+          esac

--- a/apps/s2a-ds-mcp/README.md
+++ b/apps/s2a-ds-mcp/README.md
@@ -1,0 +1,115 @@
+# `@adobecom/s2a-ds-mcp`
+
+The **S2A Design System MCP** — lets an AI agent (Claude Code, Cursor, any MCP
+client) query the S2A design system as **structured data** instead of guessing at
+token names or component APIs. It bundles a snapshot of the tokens and component
+specs and exposes them as tools, so an agent can resolve real values and
+**validate its own output** against the system before shipping it.
+
+The published package is **self-contained** — the token/component data ships
+inside it, so there's nothing to point at and no repo checkout required.
+
+---
+
+## Install
+
+This package is published to **GitHub Packages**, which requires auth even for
+reads — so consuming it needs a token, one time.
+
+### 1. Create a `read:packages` token
+
+A classic PAT with the **`read:packages`** scope. Shortcut that pre-selects it:
+<https://github.com/settings/tokens/new?scopes=read:packages&description=s2a-ds-mcp>
+
+Then **authorize it for the `adobecom` org** (on the tokens list → **Configure
+SSO** → Authorize). Without this the token returns **401** even with the right
+scope.
+
+### 2. Point the `@adobecom` scope at GitHub Packages
+
+In your `~/.npmrc` (or the project's):
+
+```ini
+@adobecom:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+```
+
+Set `GITHUB_TOKEN` in your environment — don't commit a raw token.
+
+---
+
+## Use it in your MCP client
+
+Once the `.npmrc` above is in place, wire it up with `npx` — no install, no config,
+the data is bundled:
+
+```json
+{
+  "mcpServers": {
+    "s2a-ds": {
+      "command": "npx",
+      "args": ["-y", "@adobecom/s2a-ds-mcp"]
+    }
+  }
+}
+```
+
+- **Claude Code** — add to `.mcp.json` (project) or your user MCP config.
+- **Cursor** — add to `.cursor/mcp.json`.
+
+That's it. The server starts on stdio and serves the bundled snapshot.
+
+---
+
+## Tools
+
+**Tokens**
+- `resolve_token` — path or CSS var → resolved values across all modes (light/dark, breakpoints)
+- `search_tokens` — find tokens by keyword
+- `get_token_collection` · `list_token_collections` — full token maps
+- `check_token_exists` · `get_token_aliases` — existence + alias chains
+
+**Components**
+- `get_component` · `list_components` · `get_component_tokens`
+- `find_component_for_use_case` — describe a need → suggested component + confidence
+
+**Specs**
+- `get_component_spec` · `validate_spec` (spec-vs-reality drift) · `list_spec_coverage`
+
+**Validation**
+- `validate_css` — flags primitive tokens and hardcoded hex/rgb/px
+- `check_token_in_css` · `validate_component_usage`
+
+**Audit**
+- `audit_css` — whole-file token-violation sweep
+
+---
+
+## Pointing at live sources (maintainers)
+
+By default the server reads the **bundled** snapshot. If you're working on the
+design system itself and want it to read *live* tokens/components from a repo
+checkout, set `DS_ROOT` to the repo's absolute path:
+
+```json
+{
+  "mcpServers": {
+    "s2a-ds": {
+      "command": "npx",
+      "args": ["-y", "@adobecom/s2a-ds-mcp"],
+      "env": { "DS_ROOT": "/absolute/path/to/consonant" }
+    }
+  }
+}
+```
+
+Resolution order: `DS_ROOT` → bundled `data/` → repo root (when run from source).
+
+---
+
+## How the data stays current
+
+The bundled `data/` is regenerated from the live monorepo sources at publish time
+(`prepack` → `copy-data.mjs`) and, for the hosted HTTP deployment, at each Vercel
+deploy. A CI check (`mcp-data-freshness`) verifies the snapshot is a complete,
+byte-faithful mirror of the live sources before it ships.

--- a/apps/s2a-ds-mcp/package.json
+++ b/apps/s2a-ds-mcp/package.json
@@ -7,14 +7,23 @@
   "bin": {
     "s2a-ds-mcp": "./dist/local.js"
   },
-  "files": ["dist", "README.md"],
+  "files": ["dist", "data", "README.md"],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adobecom/consonant.git",
+    "directory": "apps/s2a-ds-mcp"
+  },
   "scripts": {
     "dev": "tsx src/local.ts",
     "build": "tsc -p tsconfig.local.json",
     "type-check": "tsc --noEmit",
     "copy-data": "node scripts/copy-data.mjs",
     "check-data": "node scripts/check-data-fresh.mjs",
-    "build:vercel": "node scripts/copy-data.mjs"
+    "build:vercel": "node scripts/copy-data.mjs",
+    "prepack": "node scripts/copy-data.mjs && tsc -p tsconfig.local.json"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/apps/s2a-ds-mcp/src/local.ts
+++ b/apps/s2a-ds-mcp/src/local.ts
@@ -4,23 +4,29 @@
  *
  * Runs as a local MCP server via Claude Code / Cursor / any stdio MCP client.
  *
- * Requirements:
- *   DS_ROOT env var — absolute path to the consonant-2 repo root.
- *   Defaults to the directory two levels above this file (apps/s2a-ds-mcp → repo root).
+ * Data root resolution (no config needed for the published package):
+ *   1. DS_ROOT env var — absolute path to a consonant repo checkout (for DS
+ *      maintainers who want the server to read *live* tokens/components).
+ *   2. The data/ snapshot bundled next to dist/ in the published package.
+ *   3. The repo root, when running from source inside the monorepo.
  *
- * Usage (Claude Code .claude/settings.json):
+ * Usage — installed from GitHub Packages (bundled data, zero config):
+ *   {
+ *     "mcpServers": {
+ *       "s2a-ds": { "command": "npx", "args": ["-y", "@adobecom/s2a-ds-mcp"] }
+ *     }
+ *   }
+ *
+ * Usage — from a repo checkout against live sources:
  *   {
  *     "mcpServers": {
  *       "s2a-ds": {
  *         "command": "node",
  *         "args": ["apps/s2a-ds-mcp/dist/local.js"],
- *         "env": { "DS_ROOT": "/absolute/path/to/consonant-2" }
+ *         "env": { "DS_ROOT": "/absolute/path/to/consonant" }
  *       }
  *     }
  *   }
- *
- * Or via NPX after publish:
- *   { "command": "npx", "args": ["-y", "@adobecom/s2a-ds-mcp"], "env": { "DS_ROOT": "." } }
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -39,19 +45,33 @@ import { registerAuditTools } from "./tools/audit.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-// Default: dist/local.js is at apps/s2a-ds-mcp/dist/local.js → ../../.. = repo root
-const DEFAULT_ROOT = resolve(__dirname, "../../..");
+// A directory is a valid data root if it contains the token metadata index.
+const hasData = (root: string): boolean =>
+  existsSync(resolve(root, "packages/tokens/json/metadata.json"));
 
-const DS_ROOT = process.env.DS_ROOT
-  ? resolve(process.env.DS_ROOT)
-  : DEFAULT_ROOT;
+function resolveRoot(): string | null {
+  // 1. Explicit override — a live repo checkout.
+  if (process.env.DS_ROOT) {
+    const r = resolve(process.env.DS_ROOT);
+    return hasData(r) ? r : null;
+  }
+  // 2. Bundled snapshot: dist/local.js → ../data (published package layout).
+  const bundled = resolve(__dirname, "..", "data");
+  if (hasData(bundled)) return bundled;
+  // 3. Running from source inside the monorepo: dist/local.js → ../../.. = repo root.
+  const repoRoot = resolve(__dirname, "../../..");
+  if (hasData(repoRoot)) return repoRoot;
+  return null;
+}
 
-// Sanity check
-if (!existsSync(resolve(DS_ROOT, "packages/tokens/json/metadata.json"))) {
+const DS_ROOT = resolveRoot();
+
+if (!DS_ROOT) {
+  const attempted = process.env.DS_ROOT ? resolve(process.env.DS_ROOT) : "(none)";
   process.stderr.write(
-    `[s2a-ds-mcp] ERROR: DS_ROOT "${DS_ROOT}" does not look like the consonant-2 repo root.\n` +
-    `  Expected to find packages/tokens/json/metadata.json.\n` +
-    `  Set the DS_ROOT environment variable to the absolute path of the repo.\n`
+    `[s2a-ds-mcp] ERROR: could not locate the design-system data.\n` +
+    `  Looked for packages/tokens/json/metadata.json in: the bundled data/ snapshot, the repo root, and DS_ROOT=${attempted}.\n` +
+    `  If you installed the package this should not happen — please report it. To point at a live repo, set DS_ROOT to its absolute path.\n`
   );
   process.exit(1);
 }


### PR DESCRIPTION
## Goal
Release the S2A Design System MCP as an installable package on **GitHub Packages** (consistent with `@adobecom/s2a-tokens`), so anyone can wire it into Claude Code / Cursor.

## The blocker this fixes
The server read a **gitignored `data/` snapshot resolved from the repo root** and hard-exited if it wasn't found — so an `npm install`'d copy had no data and refused to start.

## Changes
- **`src/local.ts`** — resolve the data root as `DS_ROOT` env → **bundled `data/`** (next to `dist/`) → repo root, mirroring the fallback `api/mcp.ts` already uses. Installed copies boot off the bundled snapshot with **zero config**.
- **`package.json`** — bundle `data/` in `files`; `prepack` runs `copy-data` + `tsc` so every tarball ships a **fresh** snapshot + compiled `dist/`; add `publishConfig` (GitHub Packages) + `repository` metadata.
- **`README.md`** — what it is, GitHub Packages install (`read:packages` token + `adobecom` SSO), the `npx` MCP-client config, the 17-tool list, and the `DS_ROOT` override for maintainers who want live data.
- **`.github/workflows/publish-mcp.yml`** — publishes on a version bump to `apps/s2a-ds-mcp/package.json` on `main`; idempotent (skips a version already on the registry), `environment: token-release` gated. Mirrors `publish-tokens.yml`.

## Verified locally
- `npm pack --dry-run` bundles `dist/` + `data/` (157 files incl `metadata.json`) + `README.md`.
- The built server **boots clean and prefers the bundled snapshot** over a reachable repo root.

## To ship
Merging this (a version-bearing change to `apps/s2a-ds-mcp/package.json`) trips `publish-mcp.yml` → first publish of `@adobecom/s2a-ds-mcp@0.1.0`, which auto-links the package to this repo. Publishing runs on the built-in `GITHUB_TOKEN` — no personal token, nothing on anyone's machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)