### PR TITLE
chore(s2a-toolkit): set published Figma plugin id

### DIFF
--- a/apps/s2a-toolkit/manifest.json
+++ b/apps/s2a-toolkit/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "S2A Toolkit",
-  "id": "s2a-toolkit-internal-2",
+  "id": "1672001342733547591",
   "api": "1.0.0",
   "editorType": ["figma"],
   "main": "dist/code.js",


### PR DESCRIPTION
Replaces the dev placeholder `id` in the plugin manifest with the real id Figma assigned when the S2A Toolkit was published to Adobe Enterprise (private), so builds from source carry the published id (`1672001342733547591`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)