### PR TITLE
feat(mcp): usage telemetry POC (opt-out, local sink by default)

### DIFF
--- a/apps/s2a-ds-mcp/README.md
+++ b/apps/s2a-ds-mcp/README.md
@@ -113,3 +113,32 @@ The bundled `data/` is regenerated from the live monorepo sources at publish tim
 (`prepack` → `copy-data.mjs`) and, for the hosted HTTP deployment, at each Vercel
 deploy. A CI check (`mcp-data-freshness`) verifies the snapshot is a complete,
 byte-faithful mirror of the live sources before it ships.
+
+---
+
+## Usage telemetry (proof of concept)
+
+The server can record **which tools get used** — to understand adoption, not to
+watch anyone. It captures only: the tool name, a timestamp, ok/error, and how
+long the call took. It never records arguments, results, token values, or file
+contents.
+
+**Privacy posture:**
+
+- **Nothing leaves your machine by default.** With no endpoint configured, events
+  are appended to a local file (`~/.s2a-ds-mcp/usage.jsonl`) you can inspect.
+- The only identifier is a **one-way hash of hostname+username** (truncated) —
+  stable per machine, not reversible to a person.
+- Every telemetry path is fail-silent and non-blocking; it can never change a
+  tool's result.
+
+**Environment variables:**
+
+| Var | Effect |
+|---|---|
+| `S2A_TELEMETRY=0` (or `DO_NOT_TRACK=1`) | Disable telemetry entirely. |
+| `S2A_TELEMETRY_ENDPOINT=<url>` | POST each event to a collector (fire-and-forget) instead of the local file. |
+| `S2A_TELEMETRY_DEBUG=1` | Also print each event to stderr. |
+
+The server prints its telemetry state on startup. This is a POC: the client-side
+event emission is done; the collector the endpoint points at is a separate piece.

--- a/apps/s2a-ds-mcp/src/local.ts
+++ b/apps/s2a-ds-mcp/src/local.ts
@@ -40,6 +40,7 @@ import { registerComponentTools } from "./tools/components.js";
 import { registerValidateTools } from "./tools/validate.js";
 import { registerSpecTools } from "./tools/spec.js";
 import { registerAuditTools } from "./tools/audit.js";
+import { instrument, telemetryEnabled } from "./telemetry.js";
 
 // ── Resolve DS_ROOT ───────────────────────────────────────────────────────
 const __filename = fileURLToPath(import.meta.url);
@@ -84,6 +85,10 @@ const server = new McpServer({
   version: "0.1.0",
 });
 
+// Usage telemetry (opt-out via S2A_TELEMETRY=0 / DO_NOT_TRACK). Must run BEFORE
+// tools are registered so it can wrap each handler. No-op when opted out.
+instrument(server);
+
 // Register all tool groups
 registerTokenTools(server, DS_ROOT);
 registerComponentTools(server, DS_ROOT);
@@ -94,4 +99,8 @@ registerAuditTools(server, DS_ROOT);
 // ── Start ─────────────────────────────────────────────────────────────────
 const transport = new StdioServerTransport();
 await server.connect(transport);
-process.stderr.write("[s2a-ds-mcp] Ready.\n");
+process.stderr.write(
+  `[s2a-ds-mcp] Ready. Usage telemetry: ${telemetryEnabled() ? "on" : "off"}` +
+    (telemetryEnabled() ? " (anonymous; set S2A_TELEMETRY=0 to disable)" : "") +
+    ".\n"
+);

--- a/apps/s2a-ds-mcp/src/telemetry.ts
+++ b/apps/s2a-ds-mcp/src/telemetry.ts
@@ -1,0 +1,141 @@
+// src/telemetry.ts — usage telemetry (proof of concept)
+//
+// Goal: see which tools get used, how often, and roughly by how many distinct
+// users — WITHOUT collecting anything sensitive. No arguments, no results, no
+// token values, no file contents. Just: which tool, when, ok/error, how long.
+//
+// Privacy posture (POC defaults):
+//   • Nothing leaves the machine by default. With no S2A_TELEMETRY_ENDPOINT set,
+//     events are appended to a local JSONL file so you can inspect them.
+//   • Set S2A_TELEMETRY_ENDPOINT to POST events to a collector (fire-and-forget).
+//   • Opt out entirely with S2A_TELEMETRY=0 or the standard DO_NOT_TRACK=1.
+//   • The only identifier is a one-way hash of hostname+username, truncated —
+//     stable per machine, not reversible to a person.
+//
+// Telemetry must never change behavior: every path here is fail-silent and
+// non-blocking, and the wrapper always returns the tool's real result.
+
+import { createHash } from "node:crypto";
+import { hostname, userInfo, homedir } from "node:os";
+import { appendFile, mkdir } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+let VERSION = "0.0.0";
+try {
+  VERSION = require("../package.json").version;
+} catch {
+  /* keep default */
+}
+
+const OPT_OUT = process.env.S2A_TELEMETRY === "0" || process.env.DO_NOT_TRACK === "1";
+const ENDPOINT = process.env.S2A_TELEMETRY_ENDPOINT?.trim() || "";
+const DEBUG = process.env.S2A_TELEMETRY_DEBUG === "1";
+const LOCAL_LOG = join(homedir(), ".s2a-ds-mcp", "usage.jsonl");
+
+let _anonId: string | null = null;
+/** Stable, anonymous machine id: truncated one-way hash of hostname+username. */
+function anonId(): string {
+  if (_anonId) return _anonId;
+  let seed = "unknown";
+  try {
+    seed = `${hostname()}::${userInfo().username}`;
+  } catch {
+    /* keep default */
+  }
+  _anonId = createHash("sha256").update(seed).digest("hex").slice(0, 16);
+  return _anonId;
+}
+
+export interface UsageEvent {
+  tool: string;
+  status: "ok" | "error";
+  durationMs: number;
+  ts: string;
+  anonId: string;
+  version: string;
+  server: "s2a-ds-mcp";
+}
+
+export function telemetryEnabled(): boolean {
+  return !OPT_OUT;
+}
+
+/** Fire-and-forget. Never throws, never blocks a tool result. */
+function emit(partial: Pick<UsageEvent, "tool" | "status" | "durationMs">): void {
+  if (OPT_OUT) return;
+  const ev: UsageEvent = {
+    ...partial,
+    ts: new Date().toISOString(),
+    anonId: anonId(),
+    version: VERSION,
+    server: "s2a-ds-mcp",
+  };
+  const line = JSON.stringify(ev);
+  if (DEBUG) process.stderr.write(`[s2a-ds-mcp:telemetry] ${line}\n`);
+
+  if (ENDPOINT) {
+    // Non-blocking POST; swallow every failure — telemetry is best-effort.
+    void (async () => {
+      try {
+        await fetch(ENDPOINT, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: line,
+        });
+      } catch {
+        /* best-effort */
+      }
+    })();
+  } else {
+    // Local POC sink so events are visible without any collector.
+    void (async () => {
+      try {
+        await mkdir(dirname(LOCAL_LOG), { recursive: true });
+        await appendFile(LOCAL_LOG, line + "\n");
+      } catch {
+        /* best-effort */
+      }
+    })();
+  }
+}
+
+type ToolHandler = (...args: unknown[]) => unknown | Promise<unknown>;
+
+// Structural type for "something with a .tool registrar". `any` here is
+// deliberate: McpServer.tool is heavily overloaded, and this wrapper is
+// signature-agnostic (it only cares that the handler is the last argument).
+type ToolRegistrar = { tool: (...args: any[]) => any };
+
+/**
+ * Instrument an McpServer so every registered tool emits a usage event on call.
+ * One line to wire up — no per-tool changes. Wraps `server.tool`, intercepting
+ * the handler (always the last argument across the SDK's overloads).
+ */
+export function instrument(server: ToolRegistrar): void {
+  if (OPT_OUT) {
+    if (DEBUG) process.stderr.write("[s2a-ds-mcp:telemetry] disabled (opt-out)\n");
+    return;
+  }
+  const original = server.tool.bind(server);
+  server.tool = (...args: any[]) => {
+    const name = typeof args[0] === "string" ? (args[0] as string) : "unknown";
+    const handler = args[args.length - 1];
+    if (typeof handler === "function") {
+      const orig = handler as ToolHandler;
+      args[args.length - 1] = async (...hArgs: unknown[]) => {
+        const start = Date.now();
+        try {
+          const res = (await orig(...hArgs)) as { isError?: boolean } | undefined;
+          emit({ tool: name, status: res?.isError ? "error" : "ok", durationMs: Date.now() - start });
+          return res;
+        } catch (err) {
+          emit({ tool: name, status: "error", durationMs: Date.now() - start });
+          throw err;
+        }
+      };
+    }
+    return original(...args);
+  };
+}


### PR DESCRIPTION
## What
A proof-of-concept for seeing **which s2a-ds-mcp tools get used** — adoption signal, not surveillance.

Each tool call emits an anonymized event: `{ tool, status, durationMs, ts, anonId, version }`. It **never** captures arguments, results, token values, or file contents.

## How
- **`src/telemetry.ts`** — `instrument(server)` wraps `server.tool` once, so every registered tool auto-emits on call (no per-tool edits). The only identifier is a **truncated one-way hash of hostname+username** (stable per machine, not reversible).
- **`local.ts`** — one line: `instrument(server)` before tool registration; startup line discloses telemetry state.

## Privacy posture
- **Nothing leaves the machine by default** — with no endpoint set, events append to `~/.s2a-ds-mcp/usage.jsonl` so you can inspect them.
- `S2A_TELEMETRY_ENDPOINT=<url>` → POST to a collector (fire-and-forget).
- `S2A_TELEMETRY=0` / `DO_NOT_TRACK=1` → fully disabled (no-op).
- Every path is fail-silent and non-blocking — telemetry can never change a tool's result.

## Verified
Events written for both ok and error calls; opt-out fully no-ops; `tsc` build green.

## Scope
Client-side emission only. The **collector** the endpoint points at is the next piece (endpoint-agnostic by design — Worker/Durable Object/internal Adobe telemetry all fit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)