### PR TITLE
feat(s2a-toolkit): usage telemetry to the collector (opt-out, off by default)

### DIFF
--- a/apps/s2a-toolkit/dist/code.js
+++ b/apps/s2a-toolkit/dist/code.js
@@ -372,12 +372,27 @@ figma.on("currentpagechange", () => {
   });
 });
 figma.showUI(__html__, { width: 320, height: 480, themeColors: true });
+function genAnonId() {
+  const rnd = () => Math.floor(Math.random() * 4294967295).toString(16).padStart(8, "0");
+  return (rnd() + rnd()).slice(0, 16);
+}
 figma.ui.onmessage = async (msg) => {
   var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x;
   switch (msg.type) {
     case "ui-ready":
       notifySelection();
       break;
+    // Provision the anonymous telemetry id (and opt-out flag) for the UI.
+    case "telemetry:init": {
+      let anonId = await figma.clientStorage.getAsync("telemetry-anon-id");
+      if (!anonId) {
+        anonId = genAnonId();
+        await figma.clientStorage.setAsync("telemetry-anon-id", anonId);
+      }
+      const optOut = await figma.clientStorage.getAsync("telemetry-opt-out") === true;
+      figma.ui.postMessage({ type: "telemetry:config", anonId, optOut });
+      break;
+    }
     // GitHub PAT for the Token Release feature — persisted in clientStorage
     // (local to this user's Figma install; never written into the document).
     case "gh-token:get": {

--- a/apps/s2a-toolkit/dist/ui-bundle.js
+++ b/apps/s2a-toolkit/dist/ui-bundle.js
@@ -27,6 +27,31 @@
   function postToPlugin(type, payload) {
     parent.postMessage({ pluginMessage: __spreadValues({ type }, payload) }, "https://www.figma.com");
   }
+  var PLUGIN_VERSION = "0.1.0";
+  var TELEMETRY_ENDPOINT = "";
+  var telemetryAnonId = "";
+  var telemetryOptOut = false;
+  function sendTelemetry(action, status = "ok") {
+    if (!TELEMETRY_ENDPOINT || telemetryOptOut) return;
+    try {
+      fetch(TELEMETRY_ENDPOINT, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          tool: action,
+          status,
+          durationMs: 0,
+          ts: (/* @__PURE__ */ new Date()).toISOString(),
+          anonId: telemetryAnonId || "unknown",
+          version: PLUGIN_VERSION,
+          server: "s2a-toolkit"
+        }),
+        keepalive: true
+      }).catch(() => {
+      });
+    } catch (e) {
+    }
+  }
   var USAGE_KEY = "s2a:usage";
   function loadUsage() {
     try {
@@ -53,6 +78,7 @@
     store.totals[featureId] = (store.totals[featureId] || 0) + 1;
     store.lastUsed[featureId] = Date.now();
     saveUsage(store);
+    sendTelemetry(featureId);
   }
   function heatOf(featureId) {
     const { events } = loadUsage();
@@ -795,6 +821,11 @@
     const msg = event.data.pluginMessage;
     if (!msg) return;
     switch (msg.type) {
+      case "telemetry:config": {
+        telemetryAnonId = msg.anonId || "";
+        telemetryOptOut = msg.optOut === true;
+        break;
+      }
       case "bridge:command-result": {
         const p = pendingRequests.get(msg.requestId);
         if (p) {
@@ -1019,4 +1050,5 @@
       bridgeConnect();
     }
   }, 45e3);
+  postToPlugin("telemetry:init");
 })();

--- a/apps/s2a-toolkit/dist/ui.html
+++ b/apps/s2a-toolkit/dist/ui.html
@@ -919,6 +919,31 @@ body {
   function postToPlugin(type, payload) {
     parent.postMessage({ pluginMessage: __spreadValues({ type }, payload) }, "https://www.figma.com");
   }
+  var PLUGIN_VERSION = "0.1.0";
+  var TELEMETRY_ENDPOINT = "";
+  var telemetryAnonId = "";
+  var telemetryOptOut = false;
+  function sendTelemetry(action, status = "ok") {
+    if (!TELEMETRY_ENDPOINT || telemetryOptOut) return;
+    try {
+      fetch(TELEMETRY_ENDPOINT, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          tool: action,
+          status,
+          durationMs: 0,
+          ts: (/* @__PURE__ */ new Date()).toISOString(),
+          anonId: telemetryAnonId || "unknown",
+          version: PLUGIN_VERSION,
+          server: "s2a-toolkit"
+        }),
+        keepalive: true
+      }).catch(() => {
+      });
+    } catch (e) {
+    }
+  }
   var USAGE_KEY = "s2a:usage";
   function loadUsage() {
     try {
@@ -945,6 +970,7 @@ body {
     store.totals[featureId] = (store.totals[featureId] || 0) + 1;
     store.lastUsed[featureId] = Date.now();
     saveUsage(store);
+    sendTelemetry(featureId);
   }
   function heatOf(featureId) {
     const { events } = loadUsage();
@@ -1687,6 +1713,11 @@ body {
     const msg = event.data.pluginMessage;
     if (!msg) return;
     switch (msg.type) {
+      case "telemetry:config": {
+        telemetryAnonId = msg.anonId || "";
+        telemetryOptOut = msg.optOut === true;
+        break;
+      }
       case "bridge:command-result": {
         const p = pendingRequests.get(msg.requestId);
         if (p) {
@@ -1911,6 +1942,7 @@ body {
       bridgeConnect();
     }
   }, 45e3);
+  postToPlugin("telemetry:init");
 })();
 </script>
 </body>

--- a/apps/s2a-toolkit/manifest.json
+++ b/apps/s2a-toolkit/manifest.json
@@ -14,6 +14,7 @@
       "http://localhost:4002",
       "http://localhost:9300",
       "http://localhost:9400",
+      "http://localhost:8787",
       "https://api.github.com",
       "ws://localhost:9220",
       "ws://localhost:9221",

--- a/apps/s2a-toolkit/src/code.ts
+++ b/apps/s2a-toolkit/src/code.ts
@@ -382,11 +382,32 @@ figma.on('currentpagechange', () => {
 
 figma.showUI(__html__, { width: 320, height: 480, themeColors: true });
 
+// Anonymous, random per-install id for usage telemetry. Not tied to identity —
+// generated once and persisted in this user's clientStorage.
+function genAnonId(): string {
+  const rnd = () => Math.floor(Math.random() * 0xffffffff).toString(16).padStart(8, '0');
+  return (rnd() + rnd()).slice(0, 16);
+}
+
 figma.ui.onmessage = async (msg: { type: string; [key: string]: unknown }) => {
   switch (msg.type) {
     case 'ui-ready':
       notifySelection();
       break;
+
+    // Provision the anonymous telemetry id (and opt-out flag) for the UI.
+    case 'telemetry:init': {
+      let anonId = (await figma.clientStorage.getAsync('telemetry-anon-id')) as
+        | string
+        | undefined;
+      if (!anonId) {
+        anonId = genAnonId();
+        await figma.clientStorage.setAsync('telemetry-anon-id', anonId);
+      }
+      const optOut = (await figma.clientStorage.getAsync('telemetry-opt-out')) === true;
+      figma.ui.postMessage({ type: 'telemetry:config', anonId, optOut });
+      break;
+    }
 
     // GitHub PAT for the Token Release feature — persisted in clientStorage
     // (local to this user's Figma install; never written into the document).

--- a/apps/s2a-toolkit/src/ui.ts
+++ b/apps/s2a-toolkit/src/ui.ts
@@ -8,6 +8,41 @@ function postToPlugin(type: string, payload?: Record<string, unknown>) {
   parent.postMessage({ pluginMessage: { type, ...payload } }, 'https://www.figma.com');
 }
 
+// ── Usage telemetry (network) — POC ───────────────────────────────────────────
+// Emits one anonymized event per action to a collector. OFF unless an endpoint is
+// set below. Nothing sensitive is sent — just the action id, timestamp, ok/error,
+// an anonymous per-install id (from clientStorage, provisioned by code.ts), and
+// the plugin version. Every path is fail-silent and never blocks the UI.
+const PLUGIN_VERSION = '0.1.0';
+// Set to your collector to enable, e.g. 'http://localhost:8787' (dev) or the
+// deployed Worker URL. Empty string = telemetry disabled. The chosen host must
+// also be listed in manifest.json → networkAccess.allowedDomains.
+const TELEMETRY_ENDPOINT = '';
+let telemetryAnonId = '';
+let telemetryOptOut = false;
+
+function sendTelemetry(action: string, status: 'ok' | 'error' = 'ok') {
+  if (!TELEMETRY_ENDPOINT || telemetryOptOut) return;
+  try {
+    fetch(TELEMETRY_ENDPOINT, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        tool: action,
+        status,
+        durationMs: 0,
+        ts: new Date().toISOString(),
+        anonId: telemetryAnonId || 'unknown',
+        version: PLUGIN_VERSION,
+        server: 's2a-toolkit',
+      }),
+      keepalive: true,
+    }).catch(() => {});
+  } catch {
+    /* best-effort */
+  }
+}
+
 // ── Telemetry — UsageStore in localStorage ────────────────────────────────────
 
 const USAGE_KEY = 's2a:usage';
@@ -40,6 +75,7 @@ function logEvent(featureId: string) {
   store.totals[featureId]   = (store.totals[featureId]   || 0) + 1;
   store.lastUsed[featureId] = Date.now();
   saveUsage(store);
+  sendTelemetry(featureId); // network emit alongside the local UsageStore
 }
 
 function heatOf(featureId: string): 'hot' | 'warm' | 'cold' {
@@ -827,6 +863,11 @@ window.addEventListener('message', (event) => {
   if (!msg) return;
 
   switch (msg.type) {
+    case 'telemetry:config': {
+      telemetryAnonId = (msg.anonId as string) || '';
+      telemetryOptOut = msg.optOut === true;
+      break;
+    }
     case 'bridge:command-result': {
       const p = pendingRequests.get(msg.requestId as string);
       if (p) {
@@ -1068,3 +1109,6 @@ setInterval(() => {
     bridgeConnect();
   }
 }, 45000);
+
+// Ask code.ts for the anonymous telemetry id (provisioned in clientStorage).
+postToPlugin('telemetry:init');


### PR DESCRIPTION
## What
Extends the telemetry POC to the **S2A Toolkit plugin**, using the same event schema the collector (#129) already accepts — so plugin actions and MCP tool calls land in one dashboard.

## How (Figma-specific wrinkles handled)
- **`ui.ts`** — network is only available from the UI iframe, so `sendTelemetry()` lives here and POSTs one anonymized event per action. Hooked into the existing **`logEvent()`** choke point (the plugin already tracks local usage for heat badges), so every tracked action also reports. `server: "s2a-toolkit"`.
- **`code.ts`** — the UI iframe can't read a stable machine id, so `code.ts` provisions a **random, anonymous per-install id** in `clientStorage` (plus an opt-out flag) and hands it to the UI on `telemetry:init`. Mirrors the existing `gh-token` clientStorage pattern.
- **`manifest.json`** — added `http://localhost:8787` to `networkAccess.allowedDomains` (Figma requires declared domains). Add the deployed collector domain here when you deploy.

## Privacy
Off unless `TELEMETRY_ENDPOINT` is set. No arguments, no node/document contents, no identity — just which action, when, ok/error, an anonymous id, and the plugin version. Fail-silent; never blocks the UI.

## Verified
- **esbuild build green**; telemetry compiled into `dist/code.js` + `dist/ui-bundle.js` + `dist/ui.html`.
- No real new type errors — the +4 `tsc` deltas are the pre-existing "figma global not recognized by tsc" noise (tsc isn't the plugin's build tool), now also hitting my `figma.clientStorage` calls.
- Event schema is identical to what the collector already validated end-to-end in the MCP loop.

**In-Figma check (can't run headlessly):** set `TELEMETRY_ENDPOINT` to a running collector, rebuild, load the plugin, invoke an action → it shows on the dashboard.

Completes the trio: **#128** MCP · **#129** collector · this = plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)