### PR TITLE
feat(toolkit-bridge): usage telemetry — session start + duration (v0.1.1)

### DIFF
--- a/apps/s2a-toolkit-bridge/README.md
+++ b/apps/s2a-toolkit-bridge/README.md
@@ -75,3 +75,17 @@ drive your Figma file.
 - Version pinning is deliberate: this package tracks a `figma-console-mcp` build
   verified against the current toolkit plugin. Bumping it is how the team ships a
   new validated Bridge.
+
+## Usage telemetry (proof of concept)
+
+The launcher can record that the Bridge was used — a **session start** and its
+**duration** — so you can see adoption. Nothing sensitive: just the event, a
+timestamp, an anonymous machine id (a one-way hash of hostname+username), and the
+version.
+
+- **Off by default** — set `S2A_TELEMETRY_ENDPOINT=<collector-url>` to enable.
+- Opt out with `S2A_TELEMETRY=0` or `DO_NOT_TRACK=1`.
+- Fail-silent and time-bounded; never delays startup or shutdown.
+
+Same event schema and env vars as `@adobecom/s2a-ds-mcp`, so both report into one
+collector/dashboard.

--- a/apps/s2a-toolkit-bridge/bin/s2a-toolkit-bridge.mjs
+++ b/apps/s2a-toolkit-bridge/bin/s2a-toolkit-bridge.mjs
@@ -17,6 +17,8 @@
 import { createRequire } from "node:module";
 import { spawn } from "node:child_process";
 import { dirname, resolve } from "node:path";
+import { createHash } from "node:crypto";
+import { hostname, userInfo } from "node:os";
 
 const require = createRequire(import.meta.url);
 
@@ -50,15 +52,73 @@ if (!env.FIGMA_ACCESS_TOKEN) {
   );
 }
 
+// ── Usage telemetry (POC) ─────────────────────────────────────────────────────
+// Records that the Bridge was used — a session start and its duration. Nothing
+// sensitive: just the event, a timestamp, an anonymous machine id, and version.
+// OFF unless S2A_TELEMETRY_ENDPOINT is set; opt out with S2A_TELEMETRY=0 /
+// DO_NOT_TRACK. Every path is fail-silent.
+const TEL_ENDPOINT = process.env.S2A_TELEMETRY_ENDPOINT?.trim() || "";
+const TEL_OPTOUT = process.env.S2A_TELEMETRY === "0" || process.env.DO_NOT_TRACK === "1";
+let TEL_VERSION = "0.0.0";
+try {
+  TEL_VERSION = require("../package.json").version;
+} catch {
+  /* keep default */
+}
+let _anonId;
+function anonId() {
+  if (_anonId) return _anonId;
+  let seed = "unknown";
+  try {
+    seed = `${hostname()}::${userInfo().username}`;
+  } catch {
+    /* keep default */
+  }
+  _anonId = createHash("sha256").update(seed).digest("hex").slice(0, 16);
+  return _anonId;
+}
+async function emit(tool, durationMs) {
+  if (!TEL_ENDPOINT || TEL_OPTOUT) return;
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 800);
+    await fetch(TEL_ENDPOINT, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        tool,
+        status: "ok",
+        durationMs,
+        ts: new Date().toISOString(),
+        anonId: anonId(),
+        version: TEL_VERSION,
+        server: "s2a-toolkit-bridge",
+      }),
+      signal: ctrl.signal,
+    }).catch(() => {});
+    clearTimeout(timer);
+  } catch {
+    /* best-effort */
+  }
+}
+
+const startedAt = Date.now();
+emit("bridge:start", 0); // fire-and-forget; the process keeps running
+
 // Hand off transparently: the child speaks MCP over inherited stdio.
 const child = spawn(process.execPath, [entry, ...process.argv.slice(2)], {
   stdio: "inherit",
   env,
 });
 
-child.on("exit", (code, signal) => {
+async function shutdown(code, signal) {
+  // Best-effort session-duration event, bounded by emit()'s 800ms timeout.
+  await emit("bridge:stop", Date.now() - startedAt);
   if (signal) process.kill(process.pid, signal);
   else process.exit(code ?? 0);
+}
+child.on("exit", (code, signal) => {
+  void shutdown(code, signal);
 });
 process.on("SIGINT", () => child.kill("SIGINT"));
 process.on("SIGTERM", () => child.kill("SIGTERM"));

--- a/apps/s2a-toolkit-bridge/package.json
+++ b/apps/s2a-toolkit-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobecom/s2a-toolkit-bridge",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Blessed launcher for the S2A Toolkit Bridge — runs a pinned figma-console-mcp so teammates connect Claude Code to Figma with one command.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What
Instruments `@adobecom/s2a-toolkit-bridge` — the last un-instrumented tool. It's a thin launcher, so the meaningful signals are **session start** (adoption) and **session duration** (engagement).

- `bridge:start` on launch (fire-and-forget)
- `bridge:stop` with `durationMs` on exit (awaited, bounded by an 800ms timeout so shutdown isn't delayed)

## Consistent with the rest
Same **event schema**, **env vars**, and **opt-out** as `s2a-ds-mcp` — anonymous machine id (one-way hash of hostname+username), `server: "s2a-toolkit-bridge"`. OFF unless `S2A_TELEMETRY_ENDPOINT` is set; `S2A_TELEMETRY=0` / `DO_NOT_TRACK` opt out. Every path is fail-silent.

## Version bump
`0.1.0 → 0.1.1` so merging republishes the telemetry-enabled launcher (the publish workflow triggers on the version bump).

## Verified end-to-end
Ran the real launcher against a local sink:
```
{"tool":"bridge:start","durationMs":0,...,"version":"0.1.1","server":"s2a-toolkit-bridge"}
{"tool":"bridge:stop","durationMs":1960,...,"version":"0.1.1","server":"s2a-toolkit-bridge"}
```
`node --check` clean; the awaited shutdown emit survives SIGTERM.

## The set is complete
**#128** MCP · **#129** collector · **#130** plugin · this = bridge. All four report into one dashboard, off-by-default, opt-out everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)