### PR TITLE
feat(s2a-toolkit): wire plugin telemetry to live collector + track direct buttons

### DIFF
--- a/apps/s2a-toolkit/dist/ui-bundle.js
+++ b/apps/s2a-toolkit/dist/ui-bundle.js
@@ -28,7 +28,7 @@
     parent.postMessage({ pluginMessage: __spreadValues({ type }, payload) }, "https://www.figma.com");
   }
   var PLUGIN_VERSION = "0.1.0";
-  var TELEMETRY_ENDPOINT = "";
+  var TELEMETRY_ENDPOINT = "https://s2a-telemetry-collector.mmhuntsberry.workers.dev";
   var telemetryAnonId = "";
   var telemetryOptOut = false;
   function sendTelemetry(action, status = "ok") {
@@ -411,6 +411,7 @@
   var _copyResetTimer = null;
   copyNodeBtn.addEventListener("click", () => {
     if (!_copyFileKey || _copyAllNodes.length === 0) return;
+    sendTelemetry("action:copy-link");
     const slug = (_copyFileName || "file").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
     const urls = _copyAllNodes.map((n) => {
       const nid = n.id.replace(":", "-");
@@ -436,6 +437,7 @@
     }
   }
   formatSectionBtn.addEventListener("click", () => {
+    sendTelemetry("action:format-section");
     formatSectionBtn.disabled = true;
     formatSectionBtn.textContent = "\u2026";
     postToPlugin("format-section");
@@ -713,6 +715,7 @@
   var _a2;
   (_a2 = document.getElementById("selectApplyBtn")) == null ? void 0 : _a2.addEventListener("click", () => {
     if (!selectSetId) return;
+    sendTelemetry("action:apply-filter");
     const filter = {};
     document.querySelectorAll(".chip.on[data-axis]").forEach((chip) => {
       const axis = chip.dataset.axis;
@@ -760,6 +763,7 @@
   var _a5;
   (_a5 = document.getElementById("annotateApplyBtn")) == null ? void 0 : _a5.addEventListener("click", () => {
     if (!annotateNodeId) return;
+    sendTelemetry("action:annotate");
     const categories = Array.from(
       document.querySelectorAll("#annotateCats .chip.on")
     ).map((c) => c.dataset.cat);
@@ -776,6 +780,7 @@
   var _a6;
   (_a6 = document.getElementById("annotateClearBtn")) == null ? void 0 : _a6.addEventListener("click", () => {
     if (!annotateNodeId) return;
+    sendTelemetry("action:annotate-clear");
     const btn = document.getElementById("annotateClearBtn");
     btn.disabled = true;
     setAnnotateStatus("Clearing\u2026");
@@ -810,6 +815,7 @@
   var _a7;
   (_a7 = document.getElementById("docGenerateBtn")) == null ? void 0 : _a7.addEventListener("click", () => {
     if (!docSetId) return;
+    sendTelemetry("action:doc-generate");
     const btn = document.getElementById("docGenerateBtn");
     btn.disabled = true;
     btn.textContent = "Generating\u2026";
@@ -979,6 +985,7 @@
   (_a10 = document.getElementById("tokenReleaseBtn")) == null ? void 0 : _a10.addEventListener("click", async () => {
     var _a11;
     if (!ghToken) return;
+    sendTelemetry("action:token-release");
     const btn = document.getElementById("tokenReleaseBtn");
     btn.disabled = true;
     btn.textContent = "Releasing\u2026";

--- a/apps/s2a-toolkit/dist/ui.html
+++ b/apps/s2a-toolkit/dist/ui.html
@@ -920,7 +920,7 @@ body {
     parent.postMessage({ pluginMessage: __spreadValues({ type }, payload) }, "https://www.figma.com");
   }
   var PLUGIN_VERSION = "0.1.0";
-  var TELEMETRY_ENDPOINT = "";
+  var TELEMETRY_ENDPOINT = "https://s2a-telemetry-collector.mmhuntsberry.workers.dev";
   var telemetryAnonId = "";
   var telemetryOptOut = false;
   function sendTelemetry(action, status = "ok") {
@@ -1303,6 +1303,7 @@ body {
   var _copyResetTimer = null;
   copyNodeBtn.addEventListener("click", () => {
     if (!_copyFileKey || _copyAllNodes.length === 0) return;
+    sendTelemetry("action:copy-link");
     const slug = (_copyFileName || "file").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
     const urls = _copyAllNodes.map((n) => {
       const nid = n.id.replace(":", "-");
@@ -1328,6 +1329,7 @@ body {
     }
   }
   formatSectionBtn.addEventListener("click", () => {
+    sendTelemetry("action:format-section");
     formatSectionBtn.disabled = true;
     formatSectionBtn.textContent = "\u2026";
     postToPlugin("format-section");
@@ -1605,6 +1607,7 @@ body {
   var _a2;
   (_a2 = document.getElementById("selectApplyBtn")) == null ? void 0 : _a2.addEventListener("click", () => {
     if (!selectSetId) return;
+    sendTelemetry("action:apply-filter");
     const filter = {};
     document.querySelectorAll(".chip.on[data-axis]").forEach((chip) => {
       const axis = chip.dataset.axis;
@@ -1652,6 +1655,7 @@ body {
   var _a5;
   (_a5 = document.getElementById("annotateApplyBtn")) == null ? void 0 : _a5.addEventListener("click", () => {
     if (!annotateNodeId) return;
+    sendTelemetry("action:annotate");
     const categories = Array.from(
       document.querySelectorAll("#annotateCats .chip.on")
     ).map((c) => c.dataset.cat);
@@ -1668,6 +1672,7 @@ body {
   var _a6;
   (_a6 = document.getElementById("annotateClearBtn")) == null ? void 0 : _a6.addEventListener("click", () => {
     if (!annotateNodeId) return;
+    sendTelemetry("action:annotate-clear");
     const btn = document.getElementById("annotateClearBtn");
     btn.disabled = true;
     setAnnotateStatus("Clearing\u2026");
@@ -1702,6 +1707,7 @@ body {
   var _a7;
   (_a7 = document.getElementById("docGenerateBtn")) == null ? void 0 : _a7.addEventListener("click", () => {
     if (!docSetId) return;
+    sendTelemetry("action:doc-generate");
     const btn = document.getElementById("docGenerateBtn");
     btn.disabled = true;
     btn.textContent = "Generating\u2026";
@@ -1871,6 +1877,7 @@ body {
   (_a10 = document.getElementById("tokenReleaseBtn")) == null ? void 0 : _a10.addEventListener("click", async () => {
     var _a11;
     if (!ghToken) return;
+    sendTelemetry("action:token-release");
     const btn = document.getElementById("tokenReleaseBtn");
     btn.disabled = true;
     btn.textContent = "Releasing\u2026";

--- a/apps/s2a-toolkit/manifest.json
+++ b/apps/s2a-toolkit/manifest.json
@@ -15,6 +15,7 @@
       "http://localhost:9300",
       "http://localhost:9400",
       "http://localhost:8787",
+      "https://s2a-telemetry-collector.mmhuntsberry.workers.dev",
       "https://api.github.com",
       "ws://localhost:9220",
       "ws://localhost:9221",

--- a/apps/s2a-toolkit/src/ui.ts
+++ b/apps/s2a-toolkit/src/ui.ts
@@ -17,7 +17,7 @@ const PLUGIN_VERSION = '0.1.0';
 // Set to your collector to enable, e.g. 'http://localhost:8787' (dev) or the
 // deployed Worker URL. Empty string = telemetry disabled. The chosen host must
 // also be listed in manifest.json → networkAccess.allowedDomains.
-const TELEMETRY_ENDPOINT = '';
+const TELEMETRY_ENDPOINT = 'https://s2a-telemetry-collector.mmhuntsberry.workers.dev';
 let telemetryAnonId = '';
 let telemetryOptOut = false;
 
@@ -494,6 +494,7 @@ let _copyResetTimer: ReturnType<typeof setTimeout> | null = null;
 
 copyNodeBtn.addEventListener('click', () => {
   if (!_copyFileKey || _copyAllNodes.length === 0) return;
+  sendTelemetry('action:copy-link');
   const slug = (_copyFileName || 'file')
     .toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
   const urls = _copyAllNodes.map(n => {
@@ -528,6 +529,7 @@ function updateSectionBar(hasSection: boolean, sectionCount: number, firstName: 
 }
 
 formatSectionBtn.addEventListener('click', () => {
+  sendTelemetry('action:format-section');
   formatSectionBtn.disabled = true;
   formatSectionBtn.textContent = '…';
   postToPlugin('format-section');
@@ -758,6 +760,7 @@ function clearSelect() {
 
 document.getElementById('selectApplyBtn')?.addEventListener('click', () => {
   if (!selectSetId) return;
+  sendTelemetry('action:apply-filter');
   const filter: Record<string, string[]> = {};
   document.querySelectorAll<HTMLButtonElement>('.chip.on[data-axis]').forEach(chip => {
     const axis = chip.dataset.axis!;
@@ -804,6 +807,7 @@ document.querySelectorAll<HTMLButtonElement>('#annotateCats .chip').forEach(chip
 
 document.getElementById('annotateApplyBtn')?.addEventListener('click', () => {
   if (!annotateNodeId) return;
+  sendTelemetry('action:annotate');
   const categories = Array.from(
     document.querySelectorAll<HTMLButtonElement>('#annotateCats .chip.on')
   ).map(c => c.dataset.cat!);
@@ -816,6 +820,7 @@ document.getElementById('annotateApplyBtn')?.addEventListener('click', () => {
 
 document.getElementById('annotateClearBtn')?.addEventListener('click', () => {
   if (!annotateNodeId) return;
+  sendTelemetry('action:annotate-clear');
   const btn = document.getElementById('annotateClearBtn') as HTMLButtonElement;
   btn.disabled = true; setAnnotateStatus('Clearing…');
   postToPlugin('annotate:clear', { nodeId: annotateNodeId });
@@ -850,6 +855,7 @@ function updateDocSelection(sel: { id: string; name: string; nodeType: string; v
 
 document.getElementById('docGenerateBtn')?.addEventListener('click', () => {
   if (!docSetId) return;
+  sendTelemetry('action:doc-generate');
   const btn = document.getElementById('docGenerateBtn') as HTMLButtonElement;
   btn.disabled = true; btn.textContent = 'Generating…';
   setDocStatus('');
@@ -1028,6 +1034,7 @@ async function ghJson(path: string) {
 
 document.getElementById('tokenReleaseBtn')?.addEventListener('click', async () => {
   if (!ghToken) return;
+  sendTelemetry('action:token-release');
   const btn = document.getElementById('tokenReleaseBtn') as HTMLButtonElement;
   btn.disabled = true;
   btn.textContent = 'Releasing…';


### PR DESCRIPTION
## What
Turns plugin telemetry **on** and expands it to the actions that matter.

1. **Endpoint wired** — `TELEMETRY_ENDPOINT` now points at the live collector (`s2a-telemetry-collector.mmhuntsberry.workers.dev`), and the manifest's `networkAccess.allowedDomains` allows it (Figma blocks undeclared hosts).
2. **Direct buttons tracked** — `sendTelemetry('action:*')` on the completion buttons that previously weren't tracked at all: **token-release** (flagship), doc-generate, annotate, annotate-clear, apply-filter, format-section, copy-link.

## Event model
- `tools:*` (via `logEvent`) = **opened / invoked a tool** (palette + home)
- `action:*` (new) = **completed the action**

Distinct id prefixes, so "opened the doc tool" and "actually generated a doc" are separate signals — no double-counting, and you get a rough open→complete funnel.

## Verified
esbuild build green; endpoint + all 7 `action:*` ids compiled into `dist/ui.html`; manifest domain present.

## To see it live
**Re-import the plugin in Figma** (the currently-loaded build predates all of this), then click e.g. **Release Tokens** → it shows up on the collector dashboard.

## Caveat
The endpoint is a **personal** `workers.dev` account (POC). Moving to an Adobe-owned collector later is a one-line re-point + rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)