### PR TITLE
feat(validators): authoritative shared token/spec validator lib

### DIFF
--- a/packages/validators/README.md
+++ b/packages/validators/README.md
@@ -1,0 +1,66 @@
+# `@adobecom/s2a-validators`
+
+**One authoritative home** for S2A token/spec validation — the same logic the
+`s2a-ds` MCP, CI, and the eval scorers should all call. One definition of "what's
+a violation," everywhere. (See `docs/evals/eval-discipline.md`.)
+
+## Use
+
+```ts
+import { loadTokenIndex, validateCss, validateSpec } from "@adobecom/s2a-validators";
+
+const index = loadTokenIndex(repoRoot);          // built once from the shipped token CSS
+const { ok, score, violations } = validateCss(css, index);
+```
+
+CLI (for CI):
+
+```bash
+npm run validate:css -- packages/components/src/button/button.css
+# or, once built:  s2a-validate-css [--strict] <file.css ...>
+```
+
+Demo (no deps beyond tsx): `npx tsx packages/validators/demo.ts`
+
+## Why it's authoritative (and the JSON approach isn't)
+
+The primitive/semantic split is read from the **built token CSS**, not the source
+JSON:
+
+- Anything **defined** in `tokens.primitives*.css` is a design-only primitive.
+- Anything in `tokens.semantic*/responsive*.css` is a shippable semantic token.
+
+We tried the obvious source-JSON signal — `figma.hiddenFromPublishing` — and it's
+**wrong**: semantic tokens like `--s2a-spacing-md` carry that flag too, so it
+over-reports. The built CSS separates the two cleanly by file.
+
+`validateCss` also learns the custom properties a file **defines itself**
+(component context aliases like `--s2a-color-button-background-solid-default`) so
+those aren't mistaken for unknowns.
+
+## Codes
+
+| Code | Severity | Meaning |
+|---|---|---|
+| `HARDCODED_HEX` / `HARDCODED_RGB` | hard (fails) | Raw color — use a semantic color token |
+| `PRIMITIVE_TOKEN` | hard (fails) | A design-only primitive used in component CSS |
+| `HARDCODED_PX` | hard (`--strict` only) | Raw px — likely a spacing/radius token |
+| `UNKNOWN_TOKEN` | **warning** | `var()` the shipped registry doesn't know |
+
+`UNKNOWN_TOKEN` is intentionally a **warning**, not a failure: component tokens are
+currently *filtered out of the shipped token CSS*, so a component may legitimately
+reference `--s2a-color-<component>-*` vars that aren't in the global registry. It
+informs; it doesn't gate. (Running this on the real `button.css` surfaces exactly
+that — 28 such references — which is a genuine finding about the component-token
+pipeline, worth fixing at the source.)
+
+## Wiring it up (the "shared" in shared lib)
+
+- **CI** — the `cli` is a ready consumer.
+- **Evals** — `evals/scorers/token-compliance.ts` should import `validateCss`
+  instead of its naming heuristic.
+- **MCP** — `s2a-ds`'s `validate_css` should delegate here so the tool and the
+  evals never diverge.
+
+The last two are follow-ups (the MCP change touches the published bundle; the eval
+scorer lives on a separate branch). This package is the destination both migrate to.

--- a/packages/validators/demo.ts
+++ b/packages/validators/demo.ts
@@ -1,0 +1,34 @@
+// demo.ts — proves the authoritative token check. Run: npx tsx packages/validators/demo.ts
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadTokenIndex, validateCss } from "./src/index.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..", "..");
+
+const index = loadTokenIndex(ROOT);
+console.log(`token index: ${index.known.size} known cssVars, ${index.primitive.size} primitive (designOnly)\n`);
+
+function report(label: string, css: string) {
+  const { ok, score, violations } = validateCss(css, index);
+  const tally = violations.reduce<Record<string, number>>((a, v) => ((a[v.code] = (a[v.code] || 0) + 1), a), {});
+  const codes = Object.entries(tally).map(([c, n]) => `${c}${n > 1 ? `×${n}` : ""}`).join(", ") || "none";
+  console.log(`${ok ? "PASS" : "FAIL"}  ${score}/5  [${label}]  codes: ${codes}`);
+  return violations;
+}
+
+console.log("=== authoritative check on the REAL button.css ===");
+const btn = readFileSync(join(ROOT, "packages/components/src/button/button.css"), "utf-8");
+const v = report("button.css", btn);
+// The heuristic scorer flagged --s2a-spacing-2/3 as SUSPECTED. The metadata decides:
+for (const name of ["--s2a-spacing-2", "--s2a-spacing-3"]) {
+  const verdict = index.primitive.has(name) ? "PRIMITIVE (designOnly)" : index.known.has(name) ? "semantic (OK)" : "UNKNOWN (not a token)";
+  console.log(`    ${name} → ${verdict}`);
+}
+console.log();
+
+console.log("=== synthetic ===");
+report("good.css", `.c{ color:var(--s2a-color-content-default); padding:var(--s2a-spacing-md); }`);
+report("bad.css", `.c{ color:#1473e6; padding:var(--s2a-spacing-16); border:1px solid var(--s2a-not-a-real-token); }`);
+console.log("\nOne authoritative validateCss — the MCP, CI, and evals all call this.");

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@adobecom/s2a-validators",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Authoritative S2A token/spec validators — one source of truth for the MCP, CI, and evals.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": { "s2a-validate-css": "./dist/cli.js" },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "demo": "tsx demo.ts",
+    "validate:css": "tsx src/cli.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/packages/validators/src/cli.ts
+++ b/packages/validators/src/cli.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// cli.ts — CI consumer. Validate CSS files against the authoritative token index.
+//
+//   s2a-validate-css [--strict] <file.css> [more.css ...]
+//
+// Exits non-zero if any file has violations, printing them as stable codes so a
+// CI log (or a diff of two runs) reads clearly. Reuses the SAME validateCss the
+// MCP and evals use — one definition of "violation."
+
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadTokenIndex } from "./token-index.js";
+import { validateCss } from "./validate-css.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// packages/validators/src -> repo root
+const REPO_ROOT = resolve(__dirname, "..", "..", "..");
+
+const args = process.argv.slice(2);
+const strict = args.includes("--strict");
+const files = args.filter((a) => a !== "--strict");
+
+if (files.length === 0) {
+  console.error("usage: s2a-validate-css [--strict] <file.css> [...]");
+  process.exit(2);
+}
+
+const index = loadTokenIndex(process.env.DS_ROOT ? resolve(process.env.DS_ROOT) : REPO_ROOT);
+console.error(`[s2a-validate-css] token index: ${index.known.size} known, ${index.primitive.size} primitive\n`);
+
+let totalHard = 0;
+for (const file of files) {
+  let css: string;
+  try {
+    css = readFileSync(resolve(file), "utf-8");
+  } catch {
+    console.error(`✗ ${file}: cannot read`);
+    totalHard++;
+    continue;
+  }
+  const { ok, score, violations } = validateCss(css, index, { strict });
+  totalHard += violations.length;
+  if (ok) {
+    console.log(`✓ ${file} — clean (score ${score}/5)`);
+  } else {
+    console.log(`✗ ${file} — ${violations.length} violation(s), score ${score}/5`);
+    for (const v of violations) {
+      console.log(`    ${v.code}${v.line ? ` (line ${v.line})` : ""}: ${v.value ?? ""}`);
+    }
+  }
+}
+
+process.exit(totalHard > 0 ? 1 : 0);

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -1,0 +1,5 @@
+// @adobecom/s2a-validators — one authoritative home for token/spec validation.
+export { loadTokenIndex, type TokenIndex } from "./token-index.js";
+export { validateCss, type ValidateCssOptions } from "./validate-css.js";
+export { validateSpec, type ComponentSpec, type GeneratedSummary } from "./validate-spec.js";
+export type { Violation, ValidationResult } from "./types.js";

--- a/packages/validators/src/token-index.ts
+++ b/packages/validators/src/token-index.ts
@@ -1,0 +1,51 @@
+// token-index.ts — build the AUTHORITATIVE token index from the BUILT CSS.
+//
+// Why the built CSS and not the source JSON:
+//   - The primitive/semantic split is clean by file: anything DEFINED in
+//     tokens.primitives*.css is a design-only primitive; anything in
+//     tokens.semantic*/responsive*.css is a shippable semantic token. (The source
+//     JSON's `hiddenFromPublishing` flag over-flags semantic tokens, so it's the
+//     wrong signal.)
+//   - The built CSS is what actually ships, so it's the true registry of valid
+//     --s2a-* custom properties.
+//
+// Note: component tokens are often defined *locally* inside a component's own CSS
+// (context aliases), so validateCss also learns definitions from the file under
+// test — see validate-css.ts.
+
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+export interface TokenIndex {
+  /** cssProp names defined in the primitives CSS (design-only). */
+  primitive: Set<string>;
+  /** every cssProp name defined in the shipped token CSS. */
+  known: Set<string>;
+}
+
+/** Matches a custom-property DEFINITION: `--s2a-foo: value`. */
+const DEF_RE = /(--s2a-[a-z0-9-]+)\s*:/g;
+
+/** Load the token index from the built token CSS under a repo root. */
+export function loadTokenIndex(dsRoot: string): TokenIndex {
+  const dir = resolve(dsRoot, "dist/packages/tokens/css/dev");
+  const primitive = new Set<string>();
+  const known = new Set<string>();
+
+  if (!existsSync(dir)) {
+    throw new Error(`[s2a-validators] built token CSS not found at ${dir}. Run the token build first.`);
+  }
+
+  for (const fileName of readdirSync(dir)) {
+    if (!fileName.endsWith(".css")) continue;
+    const isPrimitiveFile = fileName.startsWith("tokens.primitives");
+    const css = readFileSync(join(dir, fileName), "utf-8");
+    for (const m of css.matchAll(DEF_RE)) {
+      const name = m[1];
+      known.add(name);
+      if (isPrimitiveFile) primitive.add(name);
+    }
+  }
+
+  return { primitive, known };
+}

--- a/packages/validators/src/types.ts
+++ b/packages/validators/src/types.ts
@@ -1,0 +1,15 @@
+// types.ts — shared validation types.
+
+export interface Violation {
+  /** Stable, diffable code — e.g. PRIMITIVE_TOKEN, HARDCODED_HEX, UNKNOWN_TOKEN. */
+  code: string;
+  message: string;
+  value?: string;
+  line?: number;
+}
+
+export interface ValidationResult {
+  ok: boolean; // no hard violations
+  score: 1 | 2 | 3 | 4 | 5;
+  violations: Violation[];
+}

--- a/packages/validators/src/validate-css.ts
+++ b/packages/validators/src/validate-css.ts
@@ -1,0 +1,76 @@
+// validate-css.ts — the ONE authoritative CSS token validator.
+//
+// Consumed by: the s2a-ds MCP (validate_css tool), CI (the cli), and the eval
+// scorers. Because it resolves every --s2a-* usage against the token index's
+// `designOnly` flag, PRIMITIVE_TOKEN is a fact, not a naming guess.
+
+import type { TokenIndex } from "./token-index.js";
+import type { ValidationResult, Violation } from "./types.js";
+
+const HEX_RE = /#[0-9a-fA-F]{3,8}\b/g;
+const RGB_RE = /\brgba?\([^)]*\)/g;
+const VAR_RE = /var\(\s*(--s2a-[a-z0-9-]+)\s*[,)]/g;
+// A local custom-property DEFINITION in the file under test (component alias).
+const LOCAL_DEF_RE = /(--s2a-[a-z0-9-]+)\s*:/g;
+// Raw px in a value, excluding 0/1px (borders) and anything inside var().
+const RAW_PX_RE = /(?<!var\([^)]*)\b([2-9]\d*|1\d+)px\b/g;
+
+export interface ValidateCssOptions {
+  /** Also flag raw px values (off by default — noisy around media queries). */
+  strict?: boolean;
+}
+
+function scoreFrom(hard: number): 1 | 2 | 3 | 4 | 5 {
+  if (hard === 0) return 5;
+  if (hard <= 1) return 3;
+  if (hard <= 3) return 2;
+  return 1;
+}
+
+export function validateCss(
+  css: string,
+  index: TokenIndex,
+  opts: ValidateCssOptions = {},
+): ValidationResult {
+  const violations: Violation[] = [];
+
+  // Custom properties this file defines itself (component context aliases) are
+  // legitimate targets for var() — treat them as known.
+  const localDefs = new Set<string>();
+  for (const m of css.matchAll(LOCAL_DEF_RE)) localDefs.add(m[1]);
+
+  css.split("\n").forEach((line, i) => {
+    const ln = i + 1;
+
+    for (const m of line.matchAll(HEX_RE)) {
+      violations.push({ code: "HARDCODED_HEX", message: "Hardcoded hex color — use a semantic color token.", value: m[0], line: ln });
+    }
+    for (const m of line.matchAll(RGB_RE)) {
+      violations.push({ code: "HARDCODED_RGB", message: "Hardcoded rgb()/rgba() — use a semantic color token.", value: m[0], line: ln });
+    }
+
+    // Authoritative token resolution.
+    for (const m of line.matchAll(VAR_RE)) {
+      const name = m[1];
+      if (index.primitive.has(name)) {
+        violations.push({ code: "PRIMITIVE_TOKEN", message: `${name} is a design-only primitive — use its semantic alias.`, value: name, line: ln });
+      } else if (!index.known.has(name) && !localDefs.has(name)) {
+        violations.push({ code: "UNKNOWN_TOKEN", message: `${name} is not a known S2A token and is not defined locally.`, value: name, line: ln });
+      }
+    }
+
+    if (opts.strict) {
+      for (const m of line.matchAll(RAW_PX_RE)) {
+        violations.push({ code: "HARDCODED_PX", message: "Raw px — likely maps to a spacing/radius token.", value: m[0], line: ln });
+      }
+    }
+  });
+
+  // HARDCODED_* and PRIMITIVE_TOKEN are hard failures (unambiguous, actionable).
+  // UNKNOWN_TOKEN is a WARNING: component tokens are currently filtered out of the
+  // shipped token CSS, so a var() the global registry doesn't know may still be a
+  // legitimate component token provided at runtime. It informs; it doesn't fail.
+  const HARD = new Set(["HARDCODED_HEX", "HARDCODED_RGB", "HARDCODED_PX", "PRIMITIVE_TOKEN"]);
+  const hard = violations.filter((v) => HARD.has(v.code)).length;
+  return { ok: hard === 0, score: scoreFrom(hard), violations };
+}

--- a/packages/validators/src/validate-spec.ts
+++ b/packages/validators/src/validate-spec.ts
@@ -1,0 +1,60 @@
+// validate-spec.ts — does a generated artifact cover the spec.json contract?
+
+import type { ValidationResult, Violation } from "./types.js";
+
+export interface ComponentSpec {
+  name: string;
+  variants?: Record<string, string[]>;
+  props?: Array<{ name: string }>;
+  a11y?: { wcag?: string[] };
+}
+
+export interface GeneratedSummary {
+  variants?: Record<string, string[]>;
+  props?: string[];
+  wcag?: string[];
+}
+
+export function validateSpec(generated: GeneratedSummary, spec: ComponentSpec): ValidationResult {
+  const violations: Violation[] = [];
+  const specVariants = spec.variants ?? {};
+  const genVariants = generated.variants ?? {};
+  let required = 0;
+  let covered = 0;
+
+  for (const [axis, values] of Object.entries(specVariants)) {
+    if (!(axis in genVariants)) {
+      violations.push({ code: "MISSING_VARIANT_AXIS", message: `Missing variant axis "${axis}".`, value: axis });
+      required += values.length;
+      continue;
+    }
+    for (const v of values) {
+      required++;
+      if (genVariants[axis].includes(v)) covered++;
+      else violations.push({ code: "MISSING_VARIANT_VALUE", message: `Missing "${axis}" value "${v}".`, value: `${axis}=${v}` });
+    }
+  }
+
+  const specProps = (spec.props ?? []).map((p) => p.name);
+  const genProps = new Set(generated.props ?? []);
+  let coveredProps = 0;
+  for (const p of specProps) {
+    if (genProps.has(p)) coveredProps++;
+    else violations.push({ code: "MISSING_PROP", message: `Missing prop "${p}".`, value: p });
+  }
+
+  const specScs = spec.a11y?.wcag ?? [];
+  const genScs = new Set(generated.wcag ?? []);
+  let coveredScs = 0;
+  for (const sc of specScs) {
+    if (genScs.has(sc)) coveredScs++;
+    else violations.push({ code: "MISSING_A11Y_SC", message: `Spec requires WCAG ${sc} — not addressed.`, value: sc });
+  }
+
+  const total = required + specProps.length + specScs.length || 1;
+  const hit = covered + coveredProps + coveredScs;
+  const ratio = hit / total;
+  const score: 1 | 2 | 3 | 4 | 5 = ratio >= 1 ? 5 : ratio >= 0.9 ? 4 : ratio >= 0.7 ? 3 : ratio >= 0.4 ? 2 : 1;
+
+  return { ok: violations.length === 0, score, violations };
+}

--- a/packages/validators/tsconfig.json
+++ b/packages/validators/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
One canonical `@adobecom/s2a-validators` — the keystone the MCP, CI, and eval scorers all call, so 'what's a violation' is defined once.

**Correctness finding (the whole point):** the obvious source-JSON signal `figma.hiddenFromPublishing` is **wrong** — semantic tokens like `--s2a-spacing-md` carry it too. The authoritative signal is the **built CSS**: defined in `tokens.primitives*.css` = primitive; in `tokens.semantic*/responsive*.css` = semantic. `validateCss` also learns a file's own local custom-property definitions so component context aliases aren't flagged unknown.

**Codes:** `HARDCODED_HEX/RGB`, `PRIMITIVE_TOKEN` (hard); `HARDCODED_PX` (strict); `UNKNOWN_TOKEN` (**warning** — component tokens are filtered out of the shipped CSS, so a component may legitimately reference vars not in the registry).

**Verified:** synthetic good.css → 5/5; bad.css → fails on real codes; real `button.css` surfaces genuine findings (primitive usages + 28 component-token references not in the shipped CSS — a real pipeline gap, flagged as warnings).

Wiring the MCP + eval scorer to import this is the follow-up (MCP touches the published bundle; the eval scorer is on another branch). This package is where both migrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)