### PR TITLE
chore(deps): bump vitest 4.0.3 → 4.1.0 + @vitest/* companions (verified)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "@storybook/addon-vitest": "10.2.0",
     "@storybook/react": "10.2.0",
     "@storybook/web-components-vite": "10.2.0",
-    "@vitest/browser-playwright": "^4.0.3",
-    "@vitest/coverage-v8": "^4.0.3",
+    "@vitest/browser-playwright": "^4.1.0",
+    "@vitest/coverage-v8": "^4.1.0",
     "chromatic": "^15.2.0",
     "clean-css": "^5.3.3",
     "concurrently": "^10.0.4",
@@ -57,7 +57,7 @@
     "react-dom": "^19.2.4",
     "storybook": "10.2.0",
     "style-dictionary": "^4.4.0",
-    "vitest": "^4.0.3"
+    "vitest": "^4.1.0"
   },
   "optionalDependencies": {
     "@rollup/rollup-darwin-arm64": "^4.52.5",


### PR DESCRIPTION
Supersedes Dependabot **#63**. The bare vitest bump ERESOLVEs — `@vitest/browser` moves to 4.1.0 while `@vitest/coverage-v8` stays 4.0.3. The `@vitest/*` family must move together; this bumps vitest + coverage-v8 + browser-playwright in lockstep. Verified: install resolves clean, no ERESOLVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)