### PR TITLE
feat(toolkit): Request tab — file triage-ready intake from inside Figma

### DIFF
--- a/apps/s2a-toolkit/dist/code.js
+++ b/apps/s2a-toolkit/dist/code.js
@@ -377,7 +377,7 @@ function genAnonId() {
   return (rnd() + rnd()).slice(0, 16);
 }
 figma.ui.onmessage = async (msg) => {
-  var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x;
+  var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _A, _B, _C, _D;
   switch (msg.type) {
     case "ui-ready":
       notifySelection();
@@ -404,6 +404,44 @@ figma.ui.onmessage = async (msg) => {
       const token = msg.token || "";
       if (token) await figma.clientStorage.setAsync("gh-token", token);
       else await figma.clientStorage.deleteAsync("gh-token");
+      break;
+    }
+    // Gather the Figma context the Request tab attaches to an intake issue:
+    // the requester, the selected node, the file/page, and the first S2A token
+    // bound to that node (if any). Sent on demand — the UI asks when the Request
+    // tab opens and again on each selection change while it's active.
+    case "request:capture": {
+      const sel = (_b = figma.currentPage.selection[0]) != null ? _b : null;
+      let tokenName = "";
+      if (sel) {
+        const bv = (_c = sel.boundVariables) != null ? _c : {};
+        let firstId = "";
+        for (const k of Object.keys(bv)) {
+          const val = bv[k];
+          if (!val) continue;
+          const id = Array.isArray(val) ? ((_d = val.find((v) => v == null ? void 0 : v.id)) != null ? _d : {}).id : val == null ? void 0 : val.id;
+          if (id) {
+            firstId = id;
+            break;
+          }
+        }
+        if (firstId) {
+          try {
+            const v = await figma.variables.getVariableByIdAsync(firstId);
+            if (v) tokenName = v.name;
+          } catch (e) {
+          }
+        }
+      }
+      figma.ui.postMessage({
+        type: "request:context",
+        user: (_f = (_e = figma.currentUser) == null ? void 0 : _e.name) != null ? _f : null,
+        node: sel ? { id: sel.id, name: sel.name, type: sel.type } : null,
+        fileKey: (_g = figma.fileKey) != null ? _g : null,
+        fileName: figma.root.name,
+        page: figma.currentPage.name,
+        tokenName
+      });
       break;
     }
     case "select:apply-filter": {
@@ -481,7 +519,7 @@ figma.ui.onmessage = async (msg) => {
         return id ? (_b2 = varNames.get(id)) != null ? _b2 : "" : "";
       };
       var bvLabel = bvLabel2;
-      const categories = new Set((_b = msg.categories) != null ? _b : []);
+      const categories = new Set((_h = msg.categories) != null ? _h : []);
       const selection = figma.currentPage.selection;
       if (!selection.length) {
         figma.ui.postMessage({ type: "annotate:result", error: "No selection" });
@@ -495,7 +533,7 @@ figma.ui.onmessage = async (msg) => {
       }
       const varIdSet = /* @__PURE__ */ new Set();
       for (const n of allNodes) {
-        const bv = (_c = n.boundVariables) != null ? _c : {};
+        const bv = (_i = n.boundVariables) != null ? _i : {};
         for (const key of Object.keys(bv)) {
           const val = bv[key];
           if (!val) continue;
@@ -515,19 +553,19 @@ figma.ui.onmessage = async (msg) => {
       }));
       let annotated = 0;
       for (const n of allNodes) {
-        const bv = (_d = n.boundVariables) != null ? _d : {};
+        const bv = (_j = n.boundVariables) != null ? _j : {};
         const anns = [];
-        const pdVar = (_f = (_e = n.getPluginData) == null ? void 0 : _e.call(n, "s2aTokenVar")) != null ? _f : "";
-        const pdProp = (_h = (_g = n.getPluginData) == null ? void 0 : _g.call(n, "s2aTokenProp")) != null ? _h : "";
+        const pdVar = (_l = (_k = n.getPluginData) == null ? void 0 : _k.call(n, "s2aTokenVar")) != null ? _l : "";
+        const pdProp = (_n = (_m = n.getPluginData) == null ? void 0 : _m.call(n, "s2aTokenProp")) != null ? _n : "";
         if (categories.has("color-fg") && n.type === "TEXT") {
-          if (((_j = (_i = bv.fills) == null ? void 0 : _i.length) != null ? _j : 0) > 0) {
+          if (((_p = (_o = bv.fills) == null ? void 0 : _o.length) != null ? _p : 0) > 0) {
             anns.push({ label: bvLabel2(bv, "fills") || "color-fg", properties: [{ type: "fills" }] });
           } else if (pdVar && pdProp === "fills") {
             anns.push({ label: pdVar, properties: [{ type: "fills" }] });
           }
         }
         if (categories.has("color-bg") && n.type !== "TEXT") {
-          if (((_l = (_k = bv.fills) == null ? void 0 : _k.length) != null ? _l : 0) > 0) {
+          if (((_r = (_q = bv.fills) == null ? void 0 : _q.length) != null ? _r : 0) > 0) {
             anns.push({ label: bvLabel2(bv, "fills") || "color-bg", properties: [{ type: "fills" }] });
           } else if (pdVar && pdProp === "fills") {
             anns.push({ label: pdVar, properties: [{ type: "fills" }] });
@@ -563,15 +601,15 @@ figma.ui.onmessage = async (msg) => {
         }
         if (categories.has("typography") && n.type === "TEXT") {
           const tp = [];
-          if (((_n = (_m = bv.fontFamily) == null ? void 0 : _m.length) != null ? _n : 0) > 0) tp.push({ type: "fontFamily" });
-          if (((_p = (_o = bv.fontSize) == null ? void 0 : _o.length) != null ? _p : 0) > 0) tp.push({ type: "fontSize" });
-          if (((_r = (_q = bv.lineHeight) == null ? void 0 : _q.length) != null ? _r : 0) > 0) tp.push({ type: "lineHeight" });
-          if (((_t = (_s = bv.letterSpacing) == null ? void 0 : _s.length) != null ? _t : 0) > 0) tp.push({ type: "letterSpacing" });
+          if (((_t = (_s = bv.fontFamily) == null ? void 0 : _s.length) != null ? _t : 0) > 0) tp.push({ type: "fontFamily" });
+          if (((_v = (_u = bv.fontSize) == null ? void 0 : _u.length) != null ? _v : 0) > 0) tp.push({ type: "fontSize" });
+          if (((_x = (_w = bv.lineHeight) == null ? void 0 : _w.length) != null ? _x : 0) > 0) tp.push({ type: "lineHeight" });
+          if (((_z = (_y = bv.letterSpacing) == null ? void 0 : _y.length) != null ? _z : 0) > 0) tp.push({ type: "letterSpacing" });
           if (tp.length) {
             const lbl = bvLabel2(bv, "fontSize") || bvLabel2(bv, "fontFamily") || "typography";
             anns.push({ label: lbl, properties: tp });
           }
-          if (((_v = (_u = bv.fontStyle) == null ? void 0 : _u.length) != null ? _v : 0) > 0) {
+          if (((_B = (_A = bv.fontStyle) == null ? void 0 : _A.length) != null ? _B : 0) > 0) {
             const lbl = bvLabel2(bv, "fontStyle");
             anns.push({ label: lbl || "font-weight", properties: [{ type: "fontWeight" }] });
           }
@@ -611,7 +649,7 @@ figma.ui.onmessage = async (msg) => {
       let cleared = 0;
       for (const n of all) {
         try {
-          if (((_w = n.annotations) == null ? void 0 : _w.length) > 0) {
+          if (((_C = n.annotations) == null ? void 0 : _C.length) > 0) {
             n.annotations = [];
             cleared++;
           }
@@ -656,7 +694,7 @@ figma.ui.onmessage = async (msg) => {
         }
         const bColls = await figma.variables.getLocalVariableCollectionsAsync();
         const themeColl = bColls.find((c) => c.id === "VariableCollectionId:6:17");
-        const darkModeId = (_x = themeColl == null ? void 0 : themeColl.modes.find((m) => m.name === "Dark")) == null ? void 0 : _x.modeId;
+        const darkModeId = (_D = themeColl == null ? void 0 : themeColl.modes.find((m) => m.name === "Dark")) == null ? void 0 : _D.modeId;
         const [cLabel, cCaption, cBody] = await Promise.all([
           figma.variables.getVariableByIdAsync("VariableID:2483:41392"),
           // content/label

--- a/apps/s2a-toolkit/dist/code.js
+++ b/apps/s2a-toolkit/dist/code.js
@@ -411,35 +411,55 @@ figma.ui.onmessage = async (msg) => {
     // bound to that node (if any). Sent on demand — the UI asks when the Request
     // tab opens and again on each selection change while it's active.
     case "request:capture": {
-      const sel = (_b = figma.currentPage.selection[0]) != null ? _b : null;
+      let user = null;
+      try {
+        user = (_c = (_b = figma.currentUser) == null ? void 0 : _b.name) != null ? _c : null;
+      } catch (e) {
+      }
+      const sel = (_d = figma.currentPage.selection[0]) != null ? _d : null;
       let tokenName = "";
       if (sel) {
-        const bv = (_c = sel.boundVariables) != null ? _c : {};
-        let firstId = "";
-        for (const k of Object.keys(bv)) {
-          const val = bv[k];
-          if (!val) continue;
-          const id = Array.isArray(val) ? ((_d = val.find((v) => v == null ? void 0 : v.id)) != null ? _d : {}).id : val == null ? void 0 : val.id;
-          if (id) {
-            firstId = id;
-            break;
+        try {
+          const bv = (_e = sel.boundVariables) != null ? _e : {};
+          let firstId = "";
+          for (const k of Object.keys(bv)) {
+            const val = bv[k];
+            if (!val) continue;
+            const id = Array.isArray(val) ? ((_f = val.find((v) => v == null ? void 0 : v.id)) != null ? _f : {}).id : val == null ? void 0 : val.id;
+            if (id) {
+              firstId = id;
+              break;
+            }
           }
-        }
-        if (firstId) {
-          try {
+          if (firstId) {
             const v = await figma.variables.getVariableByIdAsync(firstId);
             if (v) tokenName = v.name;
-          } catch (e) {
           }
+        } catch (e) {
         }
+      }
+      let fileName = "";
+      let fileKey = null;
+      let page = "";
+      try {
+        fileName = figma.root.name;
+      } catch (e) {
+      }
+      try {
+        fileKey = (_g = figma.fileKey) != null ? _g : null;
+      } catch (e) {
+      }
+      try {
+        page = figma.currentPage.name;
+      } catch (e) {
       }
       figma.ui.postMessage({
         type: "request:context",
-        user: (_f = (_e = figma.currentUser) == null ? void 0 : _e.name) != null ? _f : null,
+        user,
         node: sel ? { id: sel.id, name: sel.name, type: sel.type } : null,
-        fileKey: (_g = figma.fileKey) != null ? _g : null,
-        fileName: figma.root.name,
-        page: figma.currentPage.name,
+        fileKey,
+        fileName,
+        page,
         tokenName
       });
       break;

--- a/apps/s2a-toolkit/dist/ui-bundle.js
+++ b/apps/s2a-toolkit/dist/ui-bundle.js
@@ -138,8 +138,8 @@
       description: "Copy a shareable link for the selected node(s)",
       category: "Tools",
       uiAction: () => {
-        var _a12;
-        return (_a12 = document.getElementById("copyNodeBtn")) == null ? void 0 : _a12.click();
+        var _a14;
+        return (_a14 = document.getElementById("copyNodeBtn")) == null ? void 0 : _a14.click();
       }
     },
     {
@@ -210,13 +210,13 @@
     "tools:request"
   ];
   function fireFeature(feat) {
-    var _a12;
+    var _a14;
     logEvent(feat.id);
     closePalette();
     if (feat.uiAction) {
       feat.uiAction();
     } else if (feat.pluginAction) {
-      postToPlugin(feat.pluginAction, (_a12 = feat.pluginPayload) != null ? _a12 : {});
+      postToPlugin(feat.pluginAction, (_a14 = feat.pluginPayload) != null ? _a14 : {});
     }
     if (activePanel === "home") renderHomeView();
   }
@@ -308,12 +308,12 @@
   }
   paletteInput.addEventListener("input", () => filterPalette(paletteInput.value));
   paletteInput.addEventListener("keydown", (e) => {
-    var _a12, _b;
+    var _a14, _b;
     if (e.key === "ArrowDown") {
       e.preventDefault();
       paletteSelected = Math.min(paletteSelected + 1, paletteFiltered.length - 1);
       renderPalette();
-      (_a12 = paletteList.querySelector(`[data-selected="true"]`)) == null ? void 0 : _a12.scrollIntoView({ block: "nearest" });
+      (_a14 = paletteList.querySelector(`[data-selected="true"]`)) == null ? void 0 : _a14.scrollIntoView({ block: "nearest" });
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       paletteSelected = Math.max(paletteSelected - 1, 0);
@@ -378,7 +378,7 @@
   var _copyFileName = null;
   var _copyAllNodes = [];
   function copyToClipboard(text) {
-    var _a12;
+    var _a14;
     const ta = document.createElement("textarea");
     ta.value = text;
     ta.style.cssText = "position:fixed;left:-9999px;top:-9999px;opacity:0";
@@ -391,7 +391,7 @@
     }
     document.body.removeChild(ta);
     try {
-      (_a12 = navigator.clipboard) == null ? void 0 : _a12.writeText(text).catch(() => {
+      (_a14 = navigator.clipboard) == null ? void 0 : _a14.writeText(text).catch(() => {
       });
     } catch (e) {
     }
@@ -748,8 +748,8 @@
     el.className = "status" + (type ? " " + type : "");
   }
   function updateAnnotateSelection(sel) {
-    var _a12;
-    annotateNodeId = (_a12 = sel == null ? void 0 : sel.id) != null ? _a12 : null;
+    var _a14;
+    annotateNodeId = (_a14 = sel == null ? void 0 : sel.id) != null ? _a14 : null;
     const emptyEl = document.getElementById("annotateSelectionEmpty");
     const infoEl = document.getElementById("annotateSelectionInfo");
     const nameEl = document.getElementById("annotateNodeName");
@@ -802,9 +802,9 @@
     el.className = "status" + (type ? " " + type : "");
   }
   function updateDocSelection(sel) {
-    var _a12, _b;
+    var _a14, _b;
     const isSet = (sel == null ? void 0 : sel.nodeType) === "COMPONENT_SET";
-    docSetId = isSet ? (_a12 = sel == null ? void 0 : sel.id) != null ? _a12 : null : null;
+    docSetId = isSet ? (_a14 = sel == null ? void 0 : sel.id) != null ? _a14 : null : null;
     const emptyEl = document.getElementById("docSelectionEmpty");
     const infoEl = document.getElementById("docSelectionInfo");
     const nameEl = document.getElementById("docSetName");
@@ -833,7 +833,7 @@
     postToPlugin("doc:generate", { setId: docSetId });
   });
   window.addEventListener("message", (event) => {
-    var _a12, _b, _c, _d, _e, _f, _g, _h;
+    var _a14, _b, _c, _d, _e, _f, _g, _h;
     const msg = event.data.pluginMessage;
     if (!msg) return;
     switch (msg.type) {
@@ -884,7 +884,7 @@
           updateCopyBtn(sel, msg.fileKey, msg.fileName, msg.allNodes);
           updateSectionBar(
             !!msg.isSection,
-            (_a12 = msg.sectionCount) != null ? _a12 : 0,
+            (_a14 = msg.sectionCount) != null ? _a14 : 0,
             (_b = msg.sectionName) != null ? _b : sel.name
           );
         } else {
@@ -1011,7 +1011,7 @@
   }
   var _a10;
   (_a10 = document.getElementById("tokenReleaseBtn")) == null ? void 0 : _a10.addEventListener("click", async () => {
-    var _a12;
+    var _a14;
     if (!ghToken) return;
     sendTelemetry("action:token-release");
     const btn = document.getElementById("tokenReleaseBtn");
@@ -1034,9 +1034,9 @@
       for (let i = 0; i < 15 && !run; i++) {
         await new Promise((r) => setTimeout(r, 2e3));
         const data = await ghJson(`/actions/workflows/${GH_WORKFLOW}/runs?per_page=5`);
-        run = (_a12 = (data.workflow_runs || []).find(
+        run = (_a14 = (data.workflow_runs || []).find(
           (r) => new Date(r.created_at).getTime() >= dispatchedAt - 5e3
-        )) != null ? _a12 : null;
+        )) != null ? _a14 : null;
       }
       if (!run) throw new Error("Dispatched, but no run appeared within 30s \u2014 check the Actions tab.");
       const runLink = `<a href="${run.html_url}" target="_blank">Actions run \u2192</a>`;
@@ -1136,9 +1136,52 @@
   bindReqChips("reqPriority", "priority", (v) => {
     reqPriority = v;
   });
+  var reqImages = [];
+  var MAX_IMAGES = 4;
+  var MAX_IMAGE_BYTES = 4 * 1024 * 1024;
+  function renderReqImages() {
+    const wrap = document.getElementById("reqImages");
+    wrap.innerHTML = reqImages.map(
+      (img, i) => `<div class="req-thumb"><img src="${img.dataUrl}" alt="${esc(img.name)}"><button class="req-thumb-rm" data-i="${i}" title="Remove image" type="button">\xD7</button></div>`
+    ).join("");
+    wrap.querySelectorAll(".req-thumb-rm").forEach((b) => {
+      b.addEventListener("click", () => {
+        reqImages.splice(Number(b.dataset.i), 1);
+        renderReqImages();
+      });
+    });
+    const addBtn = document.getElementById("reqAddImageBtn");
+    if (addBtn) addBtn.style.display = reqImages.length >= MAX_IMAGES ? "none" : "";
+  }
   var _a11;
-  (_a11 = document.getElementById("reqSubmitBtn")) == null ? void 0 : _a11.addEventListener("click", async () => {
-    var _a12;
+  (_a11 = document.getElementById("reqAddImageBtn")) == null ? void 0 : _a11.addEventListener("click", () => {
+    document.getElementById("reqImageInput").click();
+  });
+  var _a12;
+  (_a12 = document.getElementById("reqImageInput")) == null ? void 0 : _a12.addEventListener("change", (e) => {
+    const input = e.target;
+    const files = Array.from(input.files || []);
+    input.value = "";
+    for (const file of files) {
+      if (reqImages.length >= MAX_IMAGES) {
+        setReqStatus(`Up to ${MAX_IMAGES} images.`, "err");
+        break;
+      }
+      if (file.size > MAX_IMAGE_BYTES) {
+        setReqStatus(`"${file.name}" is over 4MB \u2014 skipped.`, "err");
+        continue;
+      }
+      const reader = new FileReader();
+      reader.onload = () => {
+        reqImages.push({ name: file.name, type: file.type, dataUrl: String(reader.result), size: file.size });
+        renderReqImages();
+      };
+      reader.readAsDataURL(file);
+    }
+  });
+  var _a13;
+  (_a13 = document.getElementById("reqSubmitBtn")) == null ? void 0 : _a13.addEventListener("click", async () => {
+    var _a14;
     const summaryEl = document.getElementById("reqSummary");
     const useCaseEl = document.getElementById("reqUseCase");
     const summary = summaryEl.value.trim();
@@ -1193,9 +1236,10 @@
             figmaUrl,
             fileName: ctx == null ? void 0 : ctx.fileName,
             page: ctx == null ? void 0 : ctx.page,
-            nodeName: (_a12 = ctx == null ? void 0 : ctx.node) == null ? void 0 : _a12.name,
+            nodeName: (_a14 = ctx == null ? void 0 : ctx.node) == null ? void 0 : _a14.name,
             tokenName: ctx == null ? void 0 : ctx.tokenName,
-            requester: ctx == null ? void 0 : ctx.user
+            requester: ctx == null ? void 0 : ctx.user,
+            images: reqImages.map((i) => ({ name: i.name, type: i.type, dataUrl: i.dataUrl }))
           })
         });
         if (!res.ok) throw new Error(`Intake endpoint returned ${res.status}.`);
@@ -1218,9 +1262,12 @@
       } else {
         throw new Error("No intake endpoint set and no GitHub token saved. Save a PAT in Tools \u2192 Token release (add Issues: read/write), or configure the intake Worker.");
       }
-      setReqStatus(`\u2713 Filed as <a href="${issueUrl}" target="_blank">#${issueNumber} \u2192</a> \u2014 triage will pick it up.`, "ok");
+      const imgNote = !REQUEST_ENDPOINT && reqImages.length ? ` \xB7 \u26A0 ${reqImages.length} image${reqImages.length !== 1 ? "s" : ""} not attached (needs the intake Worker)` : "";
+      setReqStatus(`\u2713 Filed as <a href="${issueUrl}" target="_blank">#${issueNumber} \u2192</a> \u2014 triage will pick it up.${imgNote}`, "ok");
       summaryEl.value = "";
       useCaseEl.value = "";
+      reqImages = [];
+      renderReqImages();
     } catch (err) {
       setReqStatus("\u274C " + (err instanceof Error ? err.message : String(err)), "err");
     } finally {

--- a/apps/s2a-toolkit/dist/ui-bundle.js
+++ b/apps/s2a-toolkit/dist/ui-bundle.js
@@ -934,6 +934,11 @@
           tokenName: (_h = msg.tokenName) != null ? _h : ""
         };
         renderRequestCtx(requestCtx);
+        if (_reqCtxResolve) {
+          const r = _reqCtxResolve;
+          _reqCtxResolve = null;
+          r(requestCtx);
+        }
         break;
       }
       case "doc:result": {
@@ -1068,6 +1073,19 @@
   var requestCtx = null;
   var reqKind = "New token";
   var reqPriority = "Nice to have";
+  var _reqCtxResolve = null;
+  function captureContext(timeoutMs = 1500) {
+    return new Promise((resolve) => {
+      _reqCtxResolve = resolve;
+      postToPlugin("request:capture");
+      setTimeout(() => {
+        if (_reqCtxResolve === resolve) {
+          _reqCtxResolve = null;
+          resolve(requestCtx);
+        }
+      }, timeoutMs);
+    });
+  }
   function renderRequestCtx(ctx) {
     const nodeEl = document.getElementById("reqCtxNode");
     const tokenEl = document.getElementById("reqCtxToken");
@@ -1140,7 +1158,7 @@
     btn.disabled = true;
     btn.textContent = "Submitting\u2026";
     setReqStatus("");
-    const ctx = requestCtx;
+    const ctx = await captureContext();
     const figmaUrl = ctx ? figmaNodeUrl(ctx) : "";
     const bodyLines = [
       `**Requested by:** ${(ctx == null ? void 0 : ctx.user) || "(unknown)"}`,

--- a/apps/s2a-toolkit/dist/ui-bundle.js
+++ b/apps/s2a-toolkit/dist/ui-bundle.js
@@ -27,7 +27,7 @@
   function postToPlugin(type, payload) {
     parent.postMessage({ pluginMessage: __spreadValues({ type }, payload) }, "https://www.figma.com");
   }
-  var PLUGIN_VERSION = "0.1.0";
+  var PLUGIN_VERSION = "0.2.0";
   var TELEMETRY_ENDPOINT = "https://s2a-telemetry-collector.mmhuntsberry.workers.dev";
   var telemetryAnonId = "";
   var telemetryOptOut = false;
@@ -110,7 +110,8 @@
   var requestCounter = 0;
   var panelEls = {
     home: document.getElementById("homePanel"),
-    tools: document.getElementById("toolsPanel")
+    tools: document.getElementById("toolsPanel"),
+    request: document.getElementById("requestPanel")
   };
   function switchPanel(panel) {
     activePanel = panel;
@@ -121,6 +122,7 @@
       tab.classList.toggle("active", tab.dataset.panel === panel);
     });
     if (panel === "home") renderHomeView();
+    if (panel === "request") postToPlugin("request:capture");
   }
   document.querySelectorAll(".tab[data-panel]").forEach((tab) => {
     tab.addEventListener("click", () => {
@@ -136,8 +138,8 @@
       description: "Copy a shareable link for the selected node(s)",
       category: "Tools",
       uiAction: () => {
-        var _a11;
-        return (_a11 = document.getElementById("copyNodeBtn")) == null ? void 0 : _a11.click();
+        var _a12;
+        return (_a12 = document.getElementById("copyNodeBtn")) == null ? void 0 : _a12.click();
       }
     },
     {
@@ -177,6 +179,13 @@
       category: "Tools",
       uiAction: () => switchPanel("tools")
     },
+    {
+      id: "tools:request",
+      name: "Request a change",
+      description: "File a token/component/change request as a triage-ready GitHub issue",
+      category: "Tools",
+      uiAction: () => switchPanel("request")
+    },
     // Bridge
     {
       id: "bridge:connect",
@@ -197,16 +206,17 @@
     "tools:copy-link",
     "tools:annotate",
     "tools:select-filter",
-    "tools:doc"
+    "tools:doc",
+    "tools:request"
   ];
   function fireFeature(feat) {
-    var _a11;
+    var _a12;
     logEvent(feat.id);
     closePalette();
     if (feat.uiAction) {
       feat.uiAction();
     } else if (feat.pluginAction) {
-      postToPlugin(feat.pluginAction, (_a11 = feat.pluginPayload) != null ? _a11 : {});
+      postToPlugin(feat.pluginAction, (_a12 = feat.pluginPayload) != null ? _a12 : {});
     }
     if (activePanel === "home") renderHomeView();
   }
@@ -298,12 +308,12 @@
   }
   paletteInput.addEventListener("input", () => filterPalette(paletteInput.value));
   paletteInput.addEventListener("keydown", (e) => {
-    var _a11, _b;
+    var _a12, _b;
     if (e.key === "ArrowDown") {
       e.preventDefault();
       paletteSelected = Math.min(paletteSelected + 1, paletteFiltered.length - 1);
       renderPalette();
-      (_a11 = paletteList.querySelector(`[data-selected="true"]`)) == null ? void 0 : _a11.scrollIntoView({ block: "nearest" });
+      (_a12 = paletteList.querySelector(`[data-selected="true"]`)) == null ? void 0 : _a12.scrollIntoView({ block: "nearest" });
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       paletteSelected = Math.max(paletteSelected - 1, 0);
@@ -368,7 +378,7 @@
   var _copyFileName = null;
   var _copyAllNodes = [];
   function copyToClipboard(text) {
-    var _a11;
+    var _a12;
     const ta = document.createElement("textarea");
     ta.value = text;
     ta.style.cssText = "position:fixed;left:-9999px;top:-9999px;opacity:0";
@@ -381,7 +391,7 @@
     }
     document.body.removeChild(ta);
     try {
-      (_a11 = navigator.clipboard) == null ? void 0 : _a11.writeText(text).catch(() => {
+      (_a12 = navigator.clipboard) == null ? void 0 : _a12.writeText(text).catch(() => {
       });
     } catch (e) {
     }
@@ -738,8 +748,8 @@
     el.className = "status" + (type ? " " + type : "");
   }
   function updateAnnotateSelection(sel) {
-    var _a11;
-    annotateNodeId = (_a11 = sel == null ? void 0 : sel.id) != null ? _a11 : null;
+    var _a12;
+    annotateNodeId = (_a12 = sel == null ? void 0 : sel.id) != null ? _a12 : null;
     const emptyEl = document.getElementById("annotateSelectionEmpty");
     const infoEl = document.getElementById("annotateSelectionInfo");
     const nameEl = document.getElementById("annotateNodeName");
@@ -792,9 +802,9 @@
     el.className = "status" + (type ? " " + type : "");
   }
   function updateDocSelection(sel) {
-    var _a11, _b;
+    var _a12, _b;
     const isSet = (sel == null ? void 0 : sel.nodeType) === "COMPONENT_SET";
-    docSetId = isSet ? (_a11 = sel == null ? void 0 : sel.id) != null ? _a11 : null : null;
+    docSetId = isSet ? (_a12 = sel == null ? void 0 : sel.id) != null ? _a12 : null : null;
     const emptyEl = document.getElementById("docSelectionEmpty");
     const infoEl = document.getElementById("docSelectionInfo");
     const nameEl = document.getElementById("docSetName");
@@ -823,7 +833,7 @@
     postToPlugin("doc:generate", { setId: docSetId });
   });
   window.addEventListener("message", (event) => {
-    var _a11, _b;
+    var _a12, _b, _c, _d, _e, _f, _g, _h;
     const msg = event.data.pluginMessage;
     if (!msg) return;
     switch (msg.type) {
@@ -874,7 +884,7 @@
           updateCopyBtn(sel, msg.fileKey, msg.fileName, msg.allNodes);
           updateSectionBar(
             !!msg.isSection,
-            (_a11 = msg.sectionCount) != null ? _a11 : 0,
+            (_a12 = msg.sectionCount) != null ? _a12 : 0,
             (_b = msg.sectionName) != null ? _b : sel.name
           );
         } else {
@@ -883,6 +893,7 @@
           updateCopyBtn(null, null);
           updateSectionBar(false, 0, "");
         }
+        if (activePanel === "request") postToPlugin("request:capture");
         break;
       }
       case "format-section:done": {
@@ -911,6 +922,18 @@
       case "gh-token:value": {
         ghToken = msg.token || null;
         syncTokenReleaseAuthUi();
+        break;
+      }
+      case "request:context": {
+        requestCtx = {
+          user: (_c = msg.user) != null ? _c : null,
+          node: (_d = msg.node) != null ? _d : null,
+          fileKey: (_e = msg.fileKey) != null ? _e : null,
+          fileName: (_f = msg.fileName) != null ? _f : "",
+          page: (_g = msg.page) != null ? _g : "",
+          tokenName: (_h = msg.tokenName) != null ? _h : ""
+        };
+        renderRequestCtx(requestCtx);
         break;
       }
       case "doc:result": {
@@ -983,7 +1006,7 @@
   }
   var _a10;
   (_a10 = document.getElementById("tokenReleaseBtn")) == null ? void 0 : _a10.addEventListener("click", async () => {
-    var _a11;
+    var _a12;
     if (!ghToken) return;
     sendTelemetry("action:token-release");
     const btn = document.getElementById("tokenReleaseBtn");
@@ -1006,9 +1029,9 @@
       for (let i = 0; i < 15 && !run; i++) {
         await new Promise((r) => setTimeout(r, 2e3));
         const data = await ghJson(`/actions/workflows/${GH_WORKFLOW}/runs?per_page=5`);
-        run = (_a11 = (data.workflow_runs || []).find(
+        run = (_a12 = (data.workflow_runs || []).find(
           (r) => new Date(r.created_at).getTime() >= dispatchedAt - 5e3
-        )) != null ? _a11 : null;
+        )) != null ? _a12 : null;
       }
       if (!run) throw new Error("Dispatched, but no run appeared within 30s \u2014 check the Actions tab.");
       const runLink = `<a href="${run.html_url}" target="_blank">Actions run \u2192</a>`;
@@ -1039,6 +1062,152 @@
     } finally {
       btn.disabled = false;
       btn.textContent = "Release Tokens";
+    }
+  });
+  var REQUEST_ENDPOINT = "";
+  var requestCtx = null;
+  var reqKind = "New token";
+  var reqPriority = "Nice to have";
+  function renderRequestCtx(ctx) {
+    const nodeEl = document.getElementById("reqCtxNode");
+    const tokenEl = document.getElementById("reqCtxToken");
+    const fileEl = document.getElementById("reqCtxFile");
+    const userEl = document.getElementById("reqCtxUser");
+    if (!ctx) return;
+    if (ctx.node) {
+      nodeEl.textContent = `${ctx.node.name} \xB7 ${ctx.node.type.toLowerCase().replace(/_/g, " ")}`;
+      nodeEl.classList.remove("muted");
+    } else {
+      nodeEl.textContent = "\u2014 none selected (file & page still captured)";
+      nodeEl.classList.add("muted");
+    }
+    if (ctx.tokenName) {
+      tokenEl.textContent = ctx.tokenName;
+      tokenEl.classList.remove("muted");
+    } else {
+      tokenEl.textContent = "\u2014";
+      tokenEl.classList.add("muted");
+    }
+    fileEl.textContent = ctx.fileName ? `${ctx.fileName} \u203A ${ctx.page}` : "\u2014";
+    fileEl.classList.toggle("muted", !ctx.fileName);
+    userEl.textContent = ctx.user || "(unknown)";
+    userEl.classList.toggle("muted", !ctx.user);
+  }
+  function figmaNodeUrl(ctx) {
+    if (!ctx.fileKey || !ctx.node) return "";
+    const slug = (ctx.fileName || "file").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+    return `https://www.figma.com/design/${ctx.fileKey}/${slug}?node-id=${ctx.node.id.replace(":", "-")}`;
+  }
+  function setReqStatus(msg, type = "") {
+    const el = document.getElementById("reqStatus");
+    el.innerHTML = msg;
+    el.className = "status" + (type ? " " + type : "");
+  }
+  function bindReqChips(containerId, dataKey, onPick) {
+    document.querySelectorAll(`#${containerId} .chip`).forEach((chip) => {
+      chip.addEventListener("click", () => {
+        document.querySelectorAll(`#${containerId} .chip`).forEach((c) => c.classList.remove("on"));
+        chip.classList.add("on");
+        onPick(chip.dataset[dataKey]);
+      });
+    });
+  }
+  bindReqChips("reqKind", "kind", (v) => {
+    reqKind = v;
+  });
+  bindReqChips("reqPriority", "priority", (v) => {
+    reqPriority = v;
+  });
+  var _a11;
+  (_a11 = document.getElementById("reqSubmitBtn")) == null ? void 0 : _a11.addEventListener("click", async () => {
+    var _a12;
+    const summaryEl = document.getElementById("reqSummary");
+    const useCaseEl = document.getElementById("reqUseCase");
+    const summary = summaryEl.value.trim();
+    const useCase = useCaseEl.value.trim();
+    if (!summary) {
+      setReqStatus("Add a one-line summary first.", "err");
+      summaryEl.focus();
+      return;
+    }
+    if (!useCase) {
+      setReqStatus("Add a use case \u2014 it helps triage.", "err");
+      useCaseEl.focus();
+      return;
+    }
+    sendTelemetry("action:request-submit");
+    const btn = document.getElementById("reqSubmitBtn");
+    btn.disabled = true;
+    btn.textContent = "Submitting\u2026";
+    setReqStatus("");
+    const ctx = requestCtx;
+    const figmaUrl = ctx ? figmaNodeUrl(ctx) : "";
+    const bodyLines = [
+      `**Requested by:** ${(ctx == null ? void 0 : ctx.user) || "(unknown)"}`,
+      `**Type:** ${reqKind} \xB7 **Priority:** ${reqPriority}`,
+      "",
+      "### What",
+      summary,
+      "",
+      "### Use case",
+      useCase,
+      ""
+    ];
+    if (figmaUrl) bodyLines.push(`**Figma:** ${figmaUrl}`);
+    if (ctx == null ? void 0 : ctx.tokenName) bodyLines.push(`**Token:** \`${ctx.tokenName}\``);
+    if (ctx == null ? void 0 : ctx.fileName) bodyLines.push(`**File / page:** ${ctx.fileName} \u203A ${ctx.page}` + (ctx.node ? ` \xB7 **Node:** ${ctx.node.name}` : ""));
+    bodyLines.push("", "<sub>Filed from the S2A Toolkit plugin \xB7 Request tab.</sub>");
+    const issueBody = bodyLines.join("\n");
+    const title = `[Request] ${summary.slice(0, 70)}`;
+    const labels = ["s2a-request", "needs-triage"];
+    try {
+      let issueUrl = "";
+      let issueNumber = 0;
+      if (REQUEST_ENDPOINT) {
+        const res = await fetch(REQUEST_ENDPOINT, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            kind: reqKind,
+            priority: reqPriority,
+            summary,
+            useCase,
+            figmaUrl,
+            fileName: ctx == null ? void 0 : ctx.fileName,
+            page: ctx == null ? void 0 : ctx.page,
+            nodeName: (_a12 = ctx == null ? void 0 : ctx.node) == null ? void 0 : _a12.name,
+            tokenName: ctx == null ? void 0 : ctx.tokenName,
+            requester: ctx == null ? void 0 : ctx.user
+          })
+        });
+        if (!res.ok) throw new Error(`Intake endpoint returned ${res.status}.`);
+        const data = await res.json();
+        issueUrl = data.url;
+        issueNumber = data.number;
+      } else if (ghToken) {
+        const res = await fetch(`${GH_API}/issues`, {
+          method: "POST",
+          headers: __spreadProps(__spreadValues({}, ghHeaders()), { "Content-Type": "application/json" }),
+          body: JSON.stringify({ title, body: issueBody, labels })
+        });
+        if (res.status === 401 || res.status === 403) {
+          throw new Error(`GitHub rejected the token (${res.status}). The Request tab needs Issues: read/write on ${GH_REPO} added to your fine-grained PAT (and SSO/org authorization).`);
+        }
+        if (res.status !== 201) throw new Error(`Create failed (${res.status}).`);
+        const data = await res.json();
+        issueUrl = data.html_url;
+        issueNumber = data.number;
+      } else {
+        throw new Error("No intake endpoint set and no GitHub token saved. Save a PAT in Tools \u2192 Token release (add Issues: read/write), or configure the intake Worker.");
+      }
+      setReqStatus(`\u2713 Filed as <a href="${issueUrl}" target="_blank">#${issueNumber} \u2192</a> \u2014 triage will pick it up.`, "ok");
+      summaryEl.value = "";
+      useCaseEl.value = "";
+    } catch (err) {
+      setReqStatus("\u274C " + (err instanceof Error ? err.message : String(err)), "err");
+    } finally {
+      btn.disabled = false;
+      btn.textContent = "Submit request";
     }
   });
   postToPlugin("ui-ready");

--- a/apps/s2a-toolkit/dist/ui.html
+++ b/apps/s2a-toolkit/dist/ui.html
@@ -666,6 +666,49 @@ body {
   margin: 16px -12px;
 }
 
+/* ══ NEW: Request panel ═════════════════════════════════════════════════════ */
+
+.req-intro {
+  font-size: 11px;
+  color: var(--text-2);
+  line-height: 1.55;
+  margin-bottom: 12px;
+}
+
+.req-ctx {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.req-ctx-row { display: flex; align-items: baseline; gap: 8px; }
+.req-ctx-k {
+  flex-shrink: 0;
+  width: 34px;
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-3);
+}
+.req-ctx-v {
+  flex: 1;
+  min-width: 0;
+  font-size: 11px;
+  color: var(--text-1);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.req-ctx-v.muted { color: var(--text-3); }
+.req-ctx-v a { color: var(--accent); text-decoration: none; }
+.req-ctx-v a:hover { text-decoration: underline; }
+.status a { color: var(--accent); text-decoration: none; font-weight: 600; }
+.status a:hover { text-decoration: underline; }
+
 </style>
 </head>
 <body>
@@ -749,6 +792,13 @@ body {
         <path d="M8 4L10 6" stroke="currentColor" stroke-width="1.2"/>
       </svg>
       <span class="tab-label">Tools</span>
+    </button>
+    <!-- Request -->
+    <button class="tab" data-panel="request" aria-label="Request">
+      <svg class="tab-icon" width="13" height="13" viewBox="0 0 14 14" fill="none">
+        <path d="M12.5 1.5L6.5 7.5M12.5 1.5L8.5 12.5L6.5 7.5L1.5 5.5L12.5 1.5Z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/>
+      </svg>
+      <span class="tab-label">Request</span>
     </button>
   </nav>
 
@@ -868,6 +918,57 @@ body {
       <div style="height:16px;"></div>
     </div>
 
+    <!-- Request — file a triage-ready request from inside Figma -->
+    <div class="panel" id="requestPanel">
+      <div class="section-label">Request a change</div>
+      <p class="req-intro">Ask for a token, component, or change. Files a triage-ready GitHub issue — the design-system team reviews weekly.</p>
+
+      <!-- Auto-captured Figma context -->
+      <div class="req-ctx" id="reqCtx">
+        <div class="req-ctx-row"><span class="req-ctx-k">Node</span><span class="req-ctx-v muted" id="reqCtxNode">— none selected</span></div>
+        <div class="req-ctx-row"><span class="req-ctx-k">Token</span><span class="req-ctx-v muted" id="reqCtxToken">—</span></div>
+        <div class="req-ctx-row"><span class="req-ctx-k">File</span><span class="req-ctx-v muted" id="reqCtxFile">—</span></div>
+        <div class="req-ctx-row"><span class="req-ctx-k">By</span><span class="req-ctx-v muted" id="reqCtxUser">—</span></div>
+      </div>
+
+      <div class="form-field" style="margin-top:12px;">
+        <label class="form-label">Type</label>
+        <div class="chip-grid" id="reqKind">
+          <button class="chip on" data-kind="New token">New token</button>
+          <button class="chip" data-kind="Token change">Token change</button>
+          <button class="chip" data-kind="New component">New component</button>
+          <button class="chip" data-kind="Component change">Component change</button>
+          <button class="chip" data-kind="Bug">Bug</button>
+        </div>
+      </div>
+
+      <div class="form-field">
+        <label class="form-label" for="reqSummary">What do you need?</label>
+        <input class="form-input" id="reqSummary" type="text" placeholder="One line — e.g. a subtle elevation shadow token for cards" />
+      </div>
+
+      <div class="form-field">
+        <label class="form-label" for="reqUseCase">Use case — why / where</label>
+        <textarea class="form-input form-textarea" id="reqUseCase" placeholder="Where is it used, and why? Name the page or surface if you can."></textarea>
+      </div>
+
+      <div class="form-field">
+        <label class="form-label">Priority</label>
+        <div class="chip-grid" id="reqPriority">
+          <button class="chip on" data-priority="Nice to have">Nice to have</button>
+          <button class="chip" data-priority="Needed soon">Needed soon</button>
+          <button class="chip" data-priority="Blocking">Blocking</button>
+        </div>
+      </div>
+
+      <div class="btn-row">
+        <button class="btn" id="reqSubmitBtn" style="flex:1;">Submit request</button>
+      </div>
+      <div class="status" id="reqStatus"></div>
+
+      <div style="height:16px;"></div>
+    </div>
+
   </div>
 
   <!-- ── Command palette overlay ──────────────────────────────────────── -->
@@ -919,7 +1020,7 @@ body {
   function postToPlugin(type, payload) {
     parent.postMessage({ pluginMessage: __spreadValues({ type }, payload) }, "https://www.figma.com");
   }
-  var PLUGIN_VERSION = "0.1.0";
+  var PLUGIN_VERSION = "0.2.0";
   var TELEMETRY_ENDPOINT = "https://s2a-telemetry-collector.mmhuntsberry.workers.dev";
   var telemetryAnonId = "";
   var telemetryOptOut = false;
@@ -1002,7 +1103,8 @@ body {
   var requestCounter = 0;
   var panelEls = {
     home: document.getElementById("homePanel"),
-    tools: document.getElementById("toolsPanel")
+    tools: document.getElementById("toolsPanel"),
+    request: document.getElementById("requestPanel")
   };
   function switchPanel(panel) {
     activePanel = panel;
@@ -1013,6 +1115,7 @@ body {
       tab.classList.toggle("active", tab.dataset.panel === panel);
     });
     if (panel === "home") renderHomeView();
+    if (panel === "request") postToPlugin("request:capture");
   }
   document.querySelectorAll(".tab[data-panel]").forEach((tab) => {
     tab.addEventListener("click", () => {
@@ -1028,8 +1131,8 @@ body {
       description: "Copy a shareable link for the selected node(s)",
       category: "Tools",
       uiAction: () => {
-        var _a11;
-        return (_a11 = document.getElementById("copyNodeBtn")) == null ? void 0 : _a11.click();
+        var _a12;
+        return (_a12 = document.getElementById("copyNodeBtn")) == null ? void 0 : _a12.click();
       }
     },
     {
@@ -1069,6 +1172,13 @@ body {
       category: "Tools",
       uiAction: () => switchPanel("tools")
     },
+    {
+      id: "tools:request",
+      name: "Request a change",
+      description: "File a token/component/change request as a triage-ready GitHub issue",
+      category: "Tools",
+      uiAction: () => switchPanel("request")
+    },
     // Bridge
     {
       id: "bridge:connect",
@@ -1089,16 +1199,17 @@ body {
     "tools:copy-link",
     "tools:annotate",
     "tools:select-filter",
-    "tools:doc"
+    "tools:doc",
+    "tools:request"
   ];
   function fireFeature(feat) {
-    var _a11;
+    var _a12;
     logEvent(feat.id);
     closePalette();
     if (feat.uiAction) {
       feat.uiAction();
     } else if (feat.pluginAction) {
-      postToPlugin(feat.pluginAction, (_a11 = feat.pluginPayload) != null ? _a11 : {});
+      postToPlugin(feat.pluginAction, (_a12 = feat.pluginPayload) != null ? _a12 : {});
     }
     if (activePanel === "home") renderHomeView();
   }
@@ -1190,12 +1301,12 @@ body {
   }
   paletteInput.addEventListener("input", () => filterPalette(paletteInput.value));
   paletteInput.addEventListener("keydown", (e) => {
-    var _a11, _b;
+    var _a12, _b;
     if (e.key === "ArrowDown") {
       e.preventDefault();
       paletteSelected = Math.min(paletteSelected + 1, paletteFiltered.length - 1);
       renderPalette();
-      (_a11 = paletteList.querySelector(`[data-selected="true"]`)) == null ? void 0 : _a11.scrollIntoView({ block: "nearest" });
+      (_a12 = paletteList.querySelector(`[data-selected="true"]`)) == null ? void 0 : _a12.scrollIntoView({ block: "nearest" });
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       paletteSelected = Math.max(paletteSelected - 1, 0);
@@ -1260,7 +1371,7 @@ body {
   var _copyFileName = null;
   var _copyAllNodes = [];
   function copyToClipboard(text) {
-    var _a11;
+    var _a12;
     const ta = document.createElement("textarea");
     ta.value = text;
     ta.style.cssText = "position:fixed;left:-9999px;top:-9999px;opacity:0";
@@ -1273,7 +1384,7 @@ body {
     }
     document.body.removeChild(ta);
     try {
-      (_a11 = navigator.clipboard) == null ? void 0 : _a11.writeText(text).catch(() => {
+      (_a12 = navigator.clipboard) == null ? void 0 : _a12.writeText(text).catch(() => {
       });
     } catch (e) {
     }
@@ -1630,8 +1741,8 @@ body {
     el.className = "status" + (type ? " " + type : "");
   }
   function updateAnnotateSelection(sel) {
-    var _a11;
-    annotateNodeId = (_a11 = sel == null ? void 0 : sel.id) != null ? _a11 : null;
+    var _a12;
+    annotateNodeId = (_a12 = sel == null ? void 0 : sel.id) != null ? _a12 : null;
     const emptyEl = document.getElementById("annotateSelectionEmpty");
     const infoEl = document.getElementById("annotateSelectionInfo");
     const nameEl = document.getElementById("annotateNodeName");
@@ -1684,9 +1795,9 @@ body {
     el.className = "status" + (type ? " " + type : "");
   }
   function updateDocSelection(sel) {
-    var _a11, _b;
+    var _a12, _b;
     const isSet = (sel == null ? void 0 : sel.nodeType) === "COMPONENT_SET";
-    docSetId = isSet ? (_a11 = sel == null ? void 0 : sel.id) != null ? _a11 : null : null;
+    docSetId = isSet ? (_a12 = sel == null ? void 0 : sel.id) != null ? _a12 : null : null;
     const emptyEl = document.getElementById("docSelectionEmpty");
     const infoEl = document.getElementById("docSelectionInfo");
     const nameEl = document.getElementById("docSetName");
@@ -1715,7 +1826,7 @@ body {
     postToPlugin("doc:generate", { setId: docSetId });
   });
   window.addEventListener("message", (event) => {
-    var _a11, _b;
+    var _a12, _b, _c, _d, _e, _f, _g, _h;
     const msg = event.data.pluginMessage;
     if (!msg) return;
     switch (msg.type) {
@@ -1766,7 +1877,7 @@ body {
           updateCopyBtn(sel, msg.fileKey, msg.fileName, msg.allNodes);
           updateSectionBar(
             !!msg.isSection,
-            (_a11 = msg.sectionCount) != null ? _a11 : 0,
+            (_a12 = msg.sectionCount) != null ? _a12 : 0,
             (_b = msg.sectionName) != null ? _b : sel.name
           );
         } else {
@@ -1775,6 +1886,7 @@ body {
           updateCopyBtn(null, null);
           updateSectionBar(false, 0, "");
         }
+        if (activePanel === "request") postToPlugin("request:capture");
         break;
       }
       case "format-section:done": {
@@ -1803,6 +1915,18 @@ body {
       case "gh-token:value": {
         ghToken = msg.token || null;
         syncTokenReleaseAuthUi();
+        break;
+      }
+      case "request:context": {
+        requestCtx = {
+          user: (_c = msg.user) != null ? _c : null,
+          node: (_d = msg.node) != null ? _d : null,
+          fileKey: (_e = msg.fileKey) != null ? _e : null,
+          fileName: (_f = msg.fileName) != null ? _f : "",
+          page: (_g = msg.page) != null ? _g : "",
+          tokenName: (_h = msg.tokenName) != null ? _h : ""
+        };
+        renderRequestCtx(requestCtx);
         break;
       }
       case "doc:result": {
@@ -1875,7 +1999,7 @@ body {
   }
   var _a10;
   (_a10 = document.getElementById("tokenReleaseBtn")) == null ? void 0 : _a10.addEventListener("click", async () => {
-    var _a11;
+    var _a12;
     if (!ghToken) return;
     sendTelemetry("action:token-release");
     const btn = document.getElementById("tokenReleaseBtn");
@@ -1898,9 +2022,9 @@ body {
       for (let i = 0; i < 15 && !run; i++) {
         await new Promise((r) => setTimeout(r, 2e3));
         const data = await ghJson(`/actions/workflows/${GH_WORKFLOW}/runs?per_page=5`);
-        run = (_a11 = (data.workflow_runs || []).find(
+        run = (_a12 = (data.workflow_runs || []).find(
           (r) => new Date(r.created_at).getTime() >= dispatchedAt - 5e3
-        )) != null ? _a11 : null;
+        )) != null ? _a12 : null;
       }
       if (!run) throw new Error("Dispatched, but no run appeared within 30s \u2014 check the Actions tab.");
       const runLink = `<a href="${run.html_url}" target="_blank">Actions run \u2192</a>`;
@@ -1931,6 +2055,152 @@ body {
     } finally {
       btn.disabled = false;
       btn.textContent = "Release Tokens";
+    }
+  });
+  var REQUEST_ENDPOINT = "";
+  var requestCtx = null;
+  var reqKind = "New token";
+  var reqPriority = "Nice to have";
+  function renderRequestCtx(ctx) {
+    const nodeEl = document.getElementById("reqCtxNode");
+    const tokenEl = document.getElementById("reqCtxToken");
+    const fileEl = document.getElementById("reqCtxFile");
+    const userEl = document.getElementById("reqCtxUser");
+    if (!ctx) return;
+    if (ctx.node) {
+      nodeEl.textContent = `${ctx.node.name} \xB7 ${ctx.node.type.toLowerCase().replace(/_/g, " ")}`;
+      nodeEl.classList.remove("muted");
+    } else {
+      nodeEl.textContent = "\u2014 none selected (file & page still captured)";
+      nodeEl.classList.add("muted");
+    }
+    if (ctx.tokenName) {
+      tokenEl.textContent = ctx.tokenName;
+      tokenEl.classList.remove("muted");
+    } else {
+      tokenEl.textContent = "\u2014";
+      tokenEl.classList.add("muted");
+    }
+    fileEl.textContent = ctx.fileName ? `${ctx.fileName} \u203A ${ctx.page}` : "\u2014";
+    fileEl.classList.toggle("muted", !ctx.fileName);
+    userEl.textContent = ctx.user || "(unknown)";
+    userEl.classList.toggle("muted", !ctx.user);
+  }
+  function figmaNodeUrl(ctx) {
+    if (!ctx.fileKey || !ctx.node) return "";
+    const slug = (ctx.fileName || "file").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+    return `https://www.figma.com/design/${ctx.fileKey}/${slug}?node-id=${ctx.node.id.replace(":", "-")}`;
+  }
+  function setReqStatus(msg, type = "") {
+    const el = document.getElementById("reqStatus");
+    el.innerHTML = msg;
+    el.className = "status" + (type ? " " + type : "");
+  }
+  function bindReqChips(containerId, dataKey, onPick) {
+    document.querySelectorAll(`#${containerId} .chip`).forEach((chip) => {
+      chip.addEventListener("click", () => {
+        document.querySelectorAll(`#${containerId} .chip`).forEach((c) => c.classList.remove("on"));
+        chip.classList.add("on");
+        onPick(chip.dataset[dataKey]);
+      });
+    });
+  }
+  bindReqChips("reqKind", "kind", (v) => {
+    reqKind = v;
+  });
+  bindReqChips("reqPriority", "priority", (v) => {
+    reqPriority = v;
+  });
+  var _a11;
+  (_a11 = document.getElementById("reqSubmitBtn")) == null ? void 0 : _a11.addEventListener("click", async () => {
+    var _a12;
+    const summaryEl = document.getElementById("reqSummary");
+    const useCaseEl = document.getElementById("reqUseCase");
+    const summary = summaryEl.value.trim();
+    const useCase = useCaseEl.value.trim();
+    if (!summary) {
+      setReqStatus("Add a one-line summary first.", "err");
+      summaryEl.focus();
+      return;
+    }
+    if (!useCase) {
+      setReqStatus("Add a use case \u2014 it helps triage.", "err");
+      useCaseEl.focus();
+      return;
+    }
+    sendTelemetry("action:request-submit");
+    const btn = document.getElementById("reqSubmitBtn");
+    btn.disabled = true;
+    btn.textContent = "Submitting\u2026";
+    setReqStatus("");
+    const ctx = requestCtx;
+    const figmaUrl = ctx ? figmaNodeUrl(ctx) : "";
+    const bodyLines = [
+      `**Requested by:** ${(ctx == null ? void 0 : ctx.user) || "(unknown)"}`,
+      `**Type:** ${reqKind} \xB7 **Priority:** ${reqPriority}`,
+      "",
+      "### What",
+      summary,
+      "",
+      "### Use case",
+      useCase,
+      ""
+    ];
+    if (figmaUrl) bodyLines.push(`**Figma:** ${figmaUrl}`);
+    if (ctx == null ? void 0 : ctx.tokenName) bodyLines.push(`**Token:** \`${ctx.tokenName}\``);
+    if (ctx == null ? void 0 : ctx.fileName) bodyLines.push(`**File / page:** ${ctx.fileName} \u203A ${ctx.page}` + (ctx.node ? ` \xB7 **Node:** ${ctx.node.name}` : ""));
+    bodyLines.push("", "<sub>Filed from the S2A Toolkit plugin \xB7 Request tab.</sub>");
+    const issueBody = bodyLines.join("\n");
+    const title = `[Request] ${summary.slice(0, 70)}`;
+    const labels = ["s2a-request", "needs-triage"];
+    try {
+      let issueUrl = "";
+      let issueNumber = 0;
+      if (REQUEST_ENDPOINT) {
+        const res = await fetch(REQUEST_ENDPOINT, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            kind: reqKind,
+            priority: reqPriority,
+            summary,
+            useCase,
+            figmaUrl,
+            fileName: ctx == null ? void 0 : ctx.fileName,
+            page: ctx == null ? void 0 : ctx.page,
+            nodeName: (_a12 = ctx == null ? void 0 : ctx.node) == null ? void 0 : _a12.name,
+            tokenName: ctx == null ? void 0 : ctx.tokenName,
+            requester: ctx == null ? void 0 : ctx.user
+          })
+        });
+        if (!res.ok) throw new Error(`Intake endpoint returned ${res.status}.`);
+        const data = await res.json();
+        issueUrl = data.url;
+        issueNumber = data.number;
+      } else if (ghToken) {
+        const res = await fetch(`${GH_API}/issues`, {
+          method: "POST",
+          headers: __spreadProps(__spreadValues({}, ghHeaders()), { "Content-Type": "application/json" }),
+          body: JSON.stringify({ title, body: issueBody, labels })
+        });
+        if (res.status === 401 || res.status === 403) {
+          throw new Error(`GitHub rejected the token (${res.status}). The Request tab needs Issues: read/write on ${GH_REPO} added to your fine-grained PAT (and SSO/org authorization).`);
+        }
+        if (res.status !== 201) throw new Error(`Create failed (${res.status}).`);
+        const data = await res.json();
+        issueUrl = data.html_url;
+        issueNumber = data.number;
+      } else {
+        throw new Error("No intake endpoint set and no GitHub token saved. Save a PAT in Tools \u2192 Token release (add Issues: read/write), or configure the intake Worker.");
+      }
+      setReqStatus(`\u2713 Filed as <a href="${issueUrl}" target="_blank">#${issueNumber} \u2192</a> \u2014 triage will pick it up.`, "ok");
+      summaryEl.value = "";
+      useCaseEl.value = "";
+    } catch (err) {
+      setReqStatus("\u274C " + (err instanceof Error ? err.message : String(err)), "err");
+    } finally {
+      btn.disabled = false;
+      btn.textContent = "Submit request";
     }
   });
   postToPlugin("ui-ready");

--- a/apps/s2a-toolkit/dist/ui.html
+++ b/apps/s2a-toolkit/dist/ui.html
@@ -709,6 +709,41 @@ body {
 .status a { color: var(--accent); text-decoration: none; font-weight: 600; }
 .status a:hover { text-decoration: underline; }
 
+.req-optional { color: var(--text-3); font-weight: 400; text-transform: none; letter-spacing: 0; }
+.req-images { display: flex; flex-wrap: wrap; gap: 6px; }
+.req-images:empty { display: none; }
+.req-thumb {
+  position: relative;
+  width: 48px;
+  height: 48px;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  margin-bottom: 8px;
+}
+.req-thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.req-thumb-rm {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(0,0,0,0.6);
+  color: #fff;
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  font-family: inherit;
+}
+.req-thumb-rm:hover { background: var(--red); }
+
 </style>
 </head>
 <body>
@@ -961,6 +996,13 @@ body {
         </div>
       </div>
 
+      <div class="form-field">
+        <label class="form-label">Images <span class="req-optional">(optional)</span></label>
+        <div class="req-images" id="reqImages"></div>
+        <button class="btn btn-ghost btn-sm" id="reqAddImageBtn" type="button">+ Add image</button>
+        <input type="file" id="reqImageInput" accept="image/png,image/jpeg,image/gif,image/webp" multiple hidden />
+      </div>
+
       <div class="btn-row">
         <button class="btn" id="reqSubmitBtn" style="flex:1;">Submit request</button>
       </div>
@@ -1131,8 +1173,8 @@ body {
       description: "Copy a shareable link for the selected node(s)",
       category: "Tools",
       uiAction: () => {
-        var _a12;
-        return (_a12 = document.getElementById("copyNodeBtn")) == null ? void 0 : _a12.click();
+        var _a14;
+        return (_a14 = document.getElementById("copyNodeBtn")) == null ? void 0 : _a14.click();
       }
     },
     {
@@ -1203,13 +1245,13 @@ body {
     "tools:request"
   ];
   function fireFeature(feat) {
-    var _a12;
+    var _a14;
     logEvent(feat.id);
     closePalette();
     if (feat.uiAction) {
       feat.uiAction();
     } else if (feat.pluginAction) {
-      postToPlugin(feat.pluginAction, (_a12 = feat.pluginPayload) != null ? _a12 : {});
+      postToPlugin(feat.pluginAction, (_a14 = feat.pluginPayload) != null ? _a14 : {});
     }
     if (activePanel === "home") renderHomeView();
   }
@@ -1301,12 +1343,12 @@ body {
   }
   paletteInput.addEventListener("input", () => filterPalette(paletteInput.value));
   paletteInput.addEventListener("keydown", (e) => {
-    var _a12, _b;
+    var _a14, _b;
     if (e.key === "ArrowDown") {
       e.preventDefault();
       paletteSelected = Math.min(paletteSelected + 1, paletteFiltered.length - 1);
       renderPalette();
-      (_a12 = paletteList.querySelector(`[data-selected="true"]`)) == null ? void 0 : _a12.scrollIntoView({ block: "nearest" });
+      (_a14 = paletteList.querySelector(`[data-selected="true"]`)) == null ? void 0 : _a14.scrollIntoView({ block: "nearest" });
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       paletteSelected = Math.max(paletteSelected - 1, 0);
@@ -1371,7 +1413,7 @@ body {
   var _copyFileName = null;
   var _copyAllNodes = [];
   function copyToClipboard(text) {
-    var _a12;
+    var _a14;
     const ta = document.createElement("textarea");
     ta.value = text;
     ta.style.cssText = "position:fixed;left:-9999px;top:-9999px;opacity:0";
@@ -1384,7 +1426,7 @@ body {
     }
     document.body.removeChild(ta);
     try {
-      (_a12 = navigator.clipboard) == null ? void 0 : _a12.writeText(text).catch(() => {
+      (_a14 = navigator.clipboard) == null ? void 0 : _a14.writeText(text).catch(() => {
       });
     } catch (e) {
     }
@@ -1741,8 +1783,8 @@ body {
     el.className = "status" + (type ? " " + type : "");
   }
   function updateAnnotateSelection(sel) {
-    var _a12;
-    annotateNodeId = (_a12 = sel == null ? void 0 : sel.id) != null ? _a12 : null;
+    var _a14;
+    annotateNodeId = (_a14 = sel == null ? void 0 : sel.id) != null ? _a14 : null;
     const emptyEl = document.getElementById("annotateSelectionEmpty");
     const infoEl = document.getElementById("annotateSelectionInfo");
     const nameEl = document.getElementById("annotateNodeName");
@@ -1795,9 +1837,9 @@ body {
     el.className = "status" + (type ? " " + type : "");
   }
   function updateDocSelection(sel) {
-    var _a12, _b;
+    var _a14, _b;
     const isSet = (sel == null ? void 0 : sel.nodeType) === "COMPONENT_SET";
-    docSetId = isSet ? (_a12 = sel == null ? void 0 : sel.id) != null ? _a12 : null : null;
+    docSetId = isSet ? (_a14 = sel == null ? void 0 : sel.id) != null ? _a14 : null : null;
     const emptyEl = document.getElementById("docSelectionEmpty");
     const infoEl = document.getElementById("docSelectionInfo");
     const nameEl = document.getElementById("docSetName");
@@ -1826,7 +1868,7 @@ body {
     postToPlugin("doc:generate", { setId: docSetId });
   });
   window.addEventListener("message", (event) => {
-    var _a12, _b, _c, _d, _e, _f, _g, _h;
+    var _a14, _b, _c, _d, _e, _f, _g, _h;
     const msg = event.data.pluginMessage;
     if (!msg) return;
     switch (msg.type) {
@@ -1877,7 +1919,7 @@ body {
           updateCopyBtn(sel, msg.fileKey, msg.fileName, msg.allNodes);
           updateSectionBar(
             !!msg.isSection,
-            (_a12 = msg.sectionCount) != null ? _a12 : 0,
+            (_a14 = msg.sectionCount) != null ? _a14 : 0,
             (_b = msg.sectionName) != null ? _b : sel.name
           );
         } else {
@@ -2004,7 +2046,7 @@ body {
   }
   var _a10;
   (_a10 = document.getElementById("tokenReleaseBtn")) == null ? void 0 : _a10.addEventListener("click", async () => {
-    var _a12;
+    var _a14;
     if (!ghToken) return;
     sendTelemetry("action:token-release");
     const btn = document.getElementById("tokenReleaseBtn");
@@ -2027,9 +2069,9 @@ body {
       for (let i = 0; i < 15 && !run; i++) {
         await new Promise((r) => setTimeout(r, 2e3));
         const data = await ghJson(`/actions/workflows/${GH_WORKFLOW}/runs?per_page=5`);
-        run = (_a12 = (data.workflow_runs || []).find(
+        run = (_a14 = (data.workflow_runs || []).find(
           (r) => new Date(r.created_at).getTime() >= dispatchedAt - 5e3
-        )) != null ? _a12 : null;
+        )) != null ? _a14 : null;
       }
       if (!run) throw new Error("Dispatched, but no run appeared within 30s \u2014 check the Actions tab.");
       const runLink = `<a href="${run.html_url}" target="_blank">Actions run \u2192</a>`;
@@ -2129,9 +2171,52 @@ body {
   bindReqChips("reqPriority", "priority", (v) => {
     reqPriority = v;
   });
+  var reqImages = [];
+  var MAX_IMAGES = 4;
+  var MAX_IMAGE_BYTES = 4 * 1024 * 1024;
+  function renderReqImages() {
+    const wrap = document.getElementById("reqImages");
+    wrap.innerHTML = reqImages.map(
+      (img, i) => `<div class="req-thumb"><img src="${img.dataUrl}" alt="${esc(img.name)}"><button class="req-thumb-rm" data-i="${i}" title="Remove image" type="button">\xD7</button></div>`
+    ).join("");
+    wrap.querySelectorAll(".req-thumb-rm").forEach((b) => {
+      b.addEventListener("click", () => {
+        reqImages.splice(Number(b.dataset.i), 1);
+        renderReqImages();
+      });
+    });
+    const addBtn = document.getElementById("reqAddImageBtn");
+    if (addBtn) addBtn.style.display = reqImages.length >= MAX_IMAGES ? "none" : "";
+  }
   var _a11;
-  (_a11 = document.getElementById("reqSubmitBtn")) == null ? void 0 : _a11.addEventListener("click", async () => {
-    var _a12;
+  (_a11 = document.getElementById("reqAddImageBtn")) == null ? void 0 : _a11.addEventListener("click", () => {
+    document.getElementById("reqImageInput").click();
+  });
+  var _a12;
+  (_a12 = document.getElementById("reqImageInput")) == null ? void 0 : _a12.addEventListener("change", (e) => {
+    const input = e.target;
+    const files = Array.from(input.files || []);
+    input.value = "";
+    for (const file of files) {
+      if (reqImages.length >= MAX_IMAGES) {
+        setReqStatus(`Up to ${MAX_IMAGES} images.`, "err");
+        break;
+      }
+      if (file.size > MAX_IMAGE_BYTES) {
+        setReqStatus(`"${file.name}" is over 4MB \u2014 skipped.`, "err");
+        continue;
+      }
+      const reader = new FileReader();
+      reader.onload = () => {
+        reqImages.push({ name: file.name, type: file.type, dataUrl: String(reader.result), size: file.size });
+        renderReqImages();
+      };
+      reader.readAsDataURL(file);
+    }
+  });
+  var _a13;
+  (_a13 = document.getElementById("reqSubmitBtn")) == null ? void 0 : _a13.addEventListener("click", async () => {
+    var _a14;
     const summaryEl = document.getElementById("reqSummary");
     const useCaseEl = document.getElementById("reqUseCase");
     const summary = summaryEl.value.trim();
@@ -2186,9 +2271,10 @@ body {
             figmaUrl,
             fileName: ctx == null ? void 0 : ctx.fileName,
             page: ctx == null ? void 0 : ctx.page,
-            nodeName: (_a12 = ctx == null ? void 0 : ctx.node) == null ? void 0 : _a12.name,
+            nodeName: (_a14 = ctx == null ? void 0 : ctx.node) == null ? void 0 : _a14.name,
             tokenName: ctx == null ? void 0 : ctx.tokenName,
-            requester: ctx == null ? void 0 : ctx.user
+            requester: ctx == null ? void 0 : ctx.user,
+            images: reqImages.map((i) => ({ name: i.name, type: i.type, dataUrl: i.dataUrl }))
           })
         });
         if (!res.ok) throw new Error(`Intake endpoint returned ${res.status}.`);
@@ -2211,9 +2297,12 @@ body {
       } else {
         throw new Error("No intake endpoint set and no GitHub token saved. Save a PAT in Tools \u2192 Token release (add Issues: read/write), or configure the intake Worker.");
       }
-      setReqStatus(`\u2713 Filed as <a href="${issueUrl}" target="_blank">#${issueNumber} \u2192</a> \u2014 triage will pick it up.`, "ok");
+      const imgNote = !REQUEST_ENDPOINT && reqImages.length ? ` \xB7 \u26A0 ${reqImages.length} image${reqImages.length !== 1 ? "s" : ""} not attached (needs the intake Worker)` : "";
+      setReqStatus(`\u2713 Filed as <a href="${issueUrl}" target="_blank">#${issueNumber} \u2192</a> \u2014 triage will pick it up.${imgNote}`, "ok");
       summaryEl.value = "";
       useCaseEl.value = "";
+      reqImages = [];
+      renderReqImages();
     } catch (err) {
       setReqStatus("\u274C " + (err instanceof Error ? err.message : String(err)), "err");
     } finally {

--- a/apps/s2a-toolkit/dist/ui.html
+++ b/apps/s2a-toolkit/dist/ui.html
@@ -1927,6 +1927,11 @@ body {
           tokenName: (_h = msg.tokenName) != null ? _h : ""
         };
         renderRequestCtx(requestCtx);
+        if (_reqCtxResolve) {
+          const r = _reqCtxResolve;
+          _reqCtxResolve = null;
+          r(requestCtx);
+        }
         break;
       }
       case "doc:result": {
@@ -2061,6 +2066,19 @@ body {
   var requestCtx = null;
   var reqKind = "New token";
   var reqPriority = "Nice to have";
+  var _reqCtxResolve = null;
+  function captureContext(timeoutMs = 1500) {
+    return new Promise((resolve) => {
+      _reqCtxResolve = resolve;
+      postToPlugin("request:capture");
+      setTimeout(() => {
+        if (_reqCtxResolve === resolve) {
+          _reqCtxResolve = null;
+          resolve(requestCtx);
+        }
+      }, timeoutMs);
+    });
+  }
   function renderRequestCtx(ctx) {
     const nodeEl = document.getElementById("reqCtxNode");
     const tokenEl = document.getElementById("reqCtxToken");
@@ -2133,7 +2151,7 @@ body {
     btn.disabled = true;
     btn.textContent = "Submitting\u2026";
     setReqStatus("");
-    const ctx = requestCtx;
+    const ctx = await captureContext();
     const figmaUrl = ctx ? figmaNodeUrl(ctx) : "";
     const bodyLines = [
       `**Requested by:** ${(ctx == null ? void 0 : ctx.user) || "(unknown)"}`,

--- a/apps/s2a-toolkit/manifest.json
+++ b/apps/s2a-toolkit/manifest.json
@@ -6,7 +6,7 @@
   "main": "dist/code.js",
   "ui": "dist/ui.html",
   "enablePrivatePluginApi": true,
-  "permissions": ["teamlibrary"],
+  "permissions": ["teamlibrary", "currentuser"],
   "documentAccess": "dynamic-page",
   "networkAccess": {
     "allowedDomains": [

--- a/apps/s2a-toolkit/package.json
+++ b/apps/s2a-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s2a/s2a-toolkit",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "S2A design system Swiss Army knife \u2014 Bridge, Variables, Select",
   "private": true,
   "scripts": {

--- a/apps/s2a-toolkit/src/code.ts
+++ b/apps/s2a-toolkit/src/code.ts
@@ -424,6 +424,41 @@ figma.ui.onmessage = async (msg: { type: string; [key: string]: unknown }) => {
       break;
     }
 
+    // Gather the Figma context the Request tab attaches to an intake issue:
+    // the requester, the selected node, the file/page, and the first S2A token
+    // bound to that node (if any). Sent on demand — the UI asks when the Request
+    // tab opens and again on each selection change while it's active.
+    case 'request:capture': {
+      const sel = figma.currentPage.selection[0] ?? null;
+      let tokenName = '';
+      if (sel) {
+        const bv = (sel as any).boundVariables ?? {};
+        let firstId = '';
+        for (const k of Object.keys(bv)) {
+          const val = (bv as any)[k];
+          if (!val) continue;
+          const id = Array.isArray(val) ? (val.find((v: any) => v?.id) ?? {}).id : val?.id;
+          if (id) { firstId = id; break; }
+        }
+        if (firstId) {
+          try {
+            const v = await figma.variables.getVariableByIdAsync(firstId);
+            if (v) tokenName = v.name;
+          } catch { /* variable not resolvable — leave blank */ }
+        }
+      }
+      figma.ui.postMessage({
+        type: 'request:context',
+        user: figma.currentUser?.name ?? null,
+        node: sel ? { id: sel.id, name: sel.name, type: sel.type } : null,
+        fileKey: figma.fileKey ?? null,
+        fileName: figma.root.name,
+        page: figma.currentPage.name,
+        tokenName,
+      });
+      break;
+    }
+
     case 'select:apply-filter': {
       const setNode = await figma.getNodeByIdAsync(msg.setId as string);
       if (!setNode || setNode.type !== 'COMPONENT_SET') {

--- a/apps/s2a-toolkit/src/code.ts
+++ b/apps/s2a-toolkit/src/code.ts
@@ -429,32 +429,42 @@ figma.ui.onmessage = async (msg: { type: string; [key: string]: unknown }) => {
     // bound to that node (if any). Sent on demand — the UI asks when the Request
     // tab opens and again on each selection change while it's active.
     case 'request:capture': {
+      // Each field is guarded on its own — a throw on one (e.g. currentUser
+      // without the manifest permission) must never sink the whole context.
+      let user: string | null = null;
+      try { user = figma.currentUser?.name ?? null; } catch { /* no currentuser access */ }
+
       const sel = figma.currentPage.selection[0] ?? null;
       let tokenName = '';
       if (sel) {
-        const bv = (sel as any).boundVariables ?? {};
-        let firstId = '';
-        for (const k of Object.keys(bv)) {
-          const val = (bv as any)[k];
-          if (!val) continue;
-          const id = Array.isArray(val) ? (val.find((v: any) => v?.id) ?? {}).id : val?.id;
-          if (id) { firstId = id; break; }
-        }
-        if (firstId) {
-          try {
+        try {
+          const bv = (sel as any).boundVariables ?? {};
+          let firstId = '';
+          for (const k of Object.keys(bv)) {
+            const val = (bv as any)[k];
+            if (!val) continue;
+            const id = Array.isArray(val) ? (val.find((v: any) => v?.id) ?? {}).id : val?.id;
+            if (id) { firstId = id; break; }
+          }
+          if (firstId) {
             const v = await figma.variables.getVariableByIdAsync(firstId);
             if (v) tokenName = v.name;
-          } catch { /* variable not resolvable — leave blank */ }
-        }
+          }
+        } catch { /* variable not resolvable — leave blank */ }
       }
+
+      let fileName = '';
+      let fileKey: string | null = null;
+      let page = '';
+      try { fileName = figma.root.name; } catch { /* ignore */ }
+      try { fileKey  = figma.fileKey ?? null; } catch { /* ignore */ }
+      try { page     = figma.currentPage.name; } catch { /* ignore */ }
+
       figma.ui.postMessage({
         type: 'request:context',
-        user: figma.currentUser?.name ?? null,
+        user,
         node: sel ? { id: sel.id, name: sel.name, type: sel.type } : null,
-        fileKey: figma.fileKey ?? null,
-        fileName: figma.root.name,
-        page: figma.currentPage.name,
-        tokenName,
+        fileKey, fileName, page, tokenName,
       });
       break;
     }

--- a/apps/s2a-toolkit/src/ui.css
+++ b/apps/s2a-toolkit/src/ui.css
@@ -662,3 +662,46 @@ body {
   margin: 16px -12px;
 }
 
+/* ══ NEW: Request panel ═════════════════════════════════════════════════════ */
+
+.req-intro {
+  font-size: 11px;
+  color: var(--text-2);
+  line-height: 1.55;
+  margin-bottom: 12px;
+}
+
+.req-ctx {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.req-ctx-row { display: flex; align-items: baseline; gap: 8px; }
+.req-ctx-k {
+  flex-shrink: 0;
+  width: 34px;
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-3);
+}
+.req-ctx-v {
+  flex: 1;
+  min-width: 0;
+  font-size: 11px;
+  color: var(--text-1);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.req-ctx-v.muted { color: var(--text-3); }
+.req-ctx-v a { color: var(--accent); text-decoration: none; }
+.req-ctx-v a:hover { text-decoration: underline; }
+.status a { color: var(--accent); text-decoration: none; font-weight: 600; }
+.status a:hover { text-decoration: underline; }
+

--- a/apps/s2a-toolkit/src/ui.css
+++ b/apps/s2a-toolkit/src/ui.css
@@ -705,3 +705,38 @@ body {
 .status a { color: var(--accent); text-decoration: none; font-weight: 600; }
 .status a:hover { text-decoration: underline; }
 
+.req-optional { color: var(--text-3); font-weight: 400; text-transform: none; letter-spacing: 0; }
+.req-images { display: flex; flex-wrap: wrap; gap: 6px; }
+.req-images:empty { display: none; }
+.req-thumb {
+  position: relative;
+  width: 48px;
+  height: 48px;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  margin-bottom: 8px;
+}
+.req-thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.req-thumb-rm {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(0,0,0,0.6);
+  color: #fff;
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  font-family: inherit;
+}
+.req-thumb-rm:hover { background: var(--red); }
+

--- a/apps/s2a-toolkit/src/ui.html
+++ b/apps/s2a-toolkit/src/ui.html
@@ -86,6 +86,13 @@
       </svg>
       <span class="tab-label">Tools</span>
     </button>
+    <!-- Request -->
+    <button class="tab" data-panel="request" aria-label="Request">
+      <svg class="tab-icon" width="13" height="13" viewBox="0 0 14 14" fill="none">
+        <path d="M12.5 1.5L6.5 7.5M12.5 1.5L8.5 12.5L6.5 7.5L1.5 5.5L12.5 1.5Z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/>
+      </svg>
+      <span class="tab-label">Request</span>
+    </button>
   </nav>
 
   <!-- ── Panels ───────────────────────────────────────────────────────── -->
@@ -201,6 +208,57 @@
       <div class="status" id="tokenReleaseStatus"></div>
 
       <!-- bottom padding for scroll clearance -->
+      <div style="height:16px;"></div>
+    </div>
+
+    <!-- Request — file a triage-ready request from inside Figma -->
+    <div class="panel" id="requestPanel">
+      <div class="section-label">Request a change</div>
+      <p class="req-intro">Ask for a token, component, or change. Files a triage-ready GitHub issue — the design-system team reviews weekly.</p>
+
+      <!-- Auto-captured Figma context -->
+      <div class="req-ctx" id="reqCtx">
+        <div class="req-ctx-row"><span class="req-ctx-k">Node</span><span class="req-ctx-v muted" id="reqCtxNode">— none selected</span></div>
+        <div class="req-ctx-row"><span class="req-ctx-k">Token</span><span class="req-ctx-v muted" id="reqCtxToken">—</span></div>
+        <div class="req-ctx-row"><span class="req-ctx-k">File</span><span class="req-ctx-v muted" id="reqCtxFile">—</span></div>
+        <div class="req-ctx-row"><span class="req-ctx-k">By</span><span class="req-ctx-v muted" id="reqCtxUser">—</span></div>
+      </div>
+
+      <div class="form-field" style="margin-top:12px;">
+        <label class="form-label">Type</label>
+        <div class="chip-grid" id="reqKind">
+          <button class="chip on" data-kind="New token">New token</button>
+          <button class="chip" data-kind="Token change">Token change</button>
+          <button class="chip" data-kind="New component">New component</button>
+          <button class="chip" data-kind="Component change">Component change</button>
+          <button class="chip" data-kind="Bug">Bug</button>
+        </div>
+      </div>
+
+      <div class="form-field">
+        <label class="form-label" for="reqSummary">What do you need?</label>
+        <input class="form-input" id="reqSummary" type="text" placeholder="One line — e.g. a subtle elevation shadow token for cards" />
+      </div>
+
+      <div class="form-field">
+        <label class="form-label" for="reqUseCase">Use case — why / where</label>
+        <textarea class="form-input form-textarea" id="reqUseCase" placeholder="Where is it used, and why? Name the page or surface if you can."></textarea>
+      </div>
+
+      <div class="form-field">
+        <label class="form-label">Priority</label>
+        <div class="chip-grid" id="reqPriority">
+          <button class="chip on" data-priority="Nice to have">Nice to have</button>
+          <button class="chip" data-priority="Needed soon">Needed soon</button>
+          <button class="chip" data-priority="Blocking">Blocking</button>
+        </div>
+      </div>
+
+      <div class="btn-row">
+        <button class="btn" id="reqSubmitBtn" style="flex:1;">Submit request</button>
+      </div>
+      <div class="status" id="reqStatus"></div>
+
       <div style="height:16px;"></div>
     </div>
 

--- a/apps/s2a-toolkit/src/ui.html
+++ b/apps/s2a-toolkit/src/ui.html
@@ -254,6 +254,13 @@
         </div>
       </div>
 
+      <div class="form-field">
+        <label class="form-label">Images <span class="req-optional">(optional)</span></label>
+        <div class="req-images" id="reqImages"></div>
+        <button class="btn btn-ghost btn-sm" id="reqAddImageBtn" type="button">+ Add image</button>
+        <input type="file" id="reqImageInput" accept="image/png,image/jpeg,image/gif,image/webp" multiple hidden />
+      </div>
+
       <div class="btn-row">
         <button class="btn" id="reqSubmitBtn" style="flex:1;">Submit request</button>
       </div>

--- a/apps/s2a-toolkit/src/ui.ts
+++ b/apps/s2a-toolkit/src/ui.ts
@@ -1214,6 +1214,47 @@ function bindReqChips(containerId: string, dataKey: 'kind' | 'priority', onPick:
 bindReqChips('reqKind', 'kind', v => { reqKind = v; });
 bindReqChips('reqPriority', 'priority', v => { reqPriority = v; });
 
+// ── Image attachments ────────────────────────────────────────────────────────
+// Read to data URLs in the UI thread and carried in the submit payload. Hosting
+// is the Worker's job (uploads to object storage, embeds the URLs) — a PAT can't
+// attach binaries to an issue, so direct mode files the issue without them.
+interface ReqImage { name: string; type: string; dataUrl: string; size: number; }
+let reqImages: ReqImage[] = [];
+const MAX_IMAGES = 4;
+const MAX_IMAGE_BYTES = 4 * 1024 * 1024; // 4MB each
+
+function renderReqImages() {
+  const wrap = document.getElementById('reqImages') as HTMLElement;
+  wrap.innerHTML = reqImages.map((img, i) =>
+    `<div class="req-thumb"><img src="${img.dataUrl}" alt="${esc(img.name)}"><button class="req-thumb-rm" data-i="${i}" title="Remove image" type="button">×</button></div>`
+  ).join('');
+  wrap.querySelectorAll<HTMLButtonElement>('.req-thumb-rm').forEach(b => {
+    b.addEventListener('click', () => { reqImages.splice(Number(b.dataset.i), 1); renderReqImages(); });
+  });
+  const addBtn = document.getElementById('reqAddImageBtn') as HTMLButtonElement | null;
+  if (addBtn) addBtn.style.display = reqImages.length >= MAX_IMAGES ? 'none' : '';
+}
+
+document.getElementById('reqAddImageBtn')?.addEventListener('click', () => {
+  (document.getElementById('reqImageInput') as HTMLInputElement).click();
+});
+
+document.getElementById('reqImageInput')?.addEventListener('change', (e) => {
+  const input = e.target as HTMLInputElement;
+  const files = Array.from(input.files || []);
+  input.value = ''; // let the same file be re-picked later
+  for (const file of files) {
+    if (reqImages.length >= MAX_IMAGES) { setReqStatus(`Up to ${MAX_IMAGES} images.`, 'err'); break; }
+    if (file.size > MAX_IMAGE_BYTES) { setReqStatus(`"${file.name}" is over 4MB — skipped.`, 'err'); continue; }
+    const reader = new FileReader();
+    reader.onload = () => {
+      reqImages.push({ name: file.name, type: file.type, dataUrl: String(reader.result), size: file.size });
+      renderReqImages();
+    };
+    reader.readAsDataURL(file);
+  }
+});
+
 document.getElementById('reqSubmitBtn')?.addEventListener('click', async () => {
   const summaryEl = document.getElementById('reqSummary') as HTMLInputElement;
   const useCaseEl = document.getElementById('reqUseCase') as HTMLTextAreaElement;
@@ -1259,6 +1300,7 @@ document.getElementById('reqSubmitBtn')?.addEventListener('click', async () => {
           kind: reqKind, priority: reqPriority, summary, useCase, figmaUrl,
           fileName: ctx?.fileName, page: ctx?.page, nodeName: ctx?.node?.name,
           tokenName: ctx?.tokenName, requester: ctx?.user,
+          images: reqImages.map(i => ({ name: i.name, type: i.type, dataUrl: i.dataUrl })),
         }),
       });
       if (!res.ok) throw new Error(`Intake endpoint returned ${res.status}.`);
@@ -1281,9 +1323,15 @@ document.getElementById('reqSubmitBtn')?.addEventListener('click', async () => {
       throw new Error('No intake endpoint set and no GitHub token saved. Save a PAT in Tools → Token release (add Issues: read/write), or configure the intake Worker.');
     }
 
-    setReqStatus(`✓ Filed as <a href="${issueUrl}" target="_blank">#${issueNumber} →</a> — triage will pick it up.`, 'ok');
+    // Direct mode (no Worker) can't host images — say so instead of dropping them silently.
+    const imgNote = (!REQUEST_ENDPOINT && reqImages.length)
+      ? ` · ⚠ ${reqImages.length} image${reqImages.length !== 1 ? 's' : ''} not attached (needs the intake Worker)`
+      : '';
+    setReqStatus(`✓ Filed as <a href="${issueUrl}" target="_blank">#${issueNumber} →</a> — triage will pick it up.${imgNote}`, 'ok');
     summaryEl.value = '';
     useCaseEl.value = '';
+    reqImages = [];
+    renderReqImages();
   } catch (err) {
     setReqStatus('❌ ' + (err instanceof Error ? err.message : String(err)), 'err');
   } finally {

--- a/apps/s2a-toolkit/src/ui.ts
+++ b/apps/s2a-toolkit/src/ui.ts
@@ -972,6 +972,7 @@ window.addEventListener('message', (event) => {
         tokenName: (msg.tokenName as string) ?? '',
       };
       renderRequestCtx(requestCtx);
+      if (_reqCtxResolve) { const r = _reqCtxResolve; _reqCtxResolve = null; r(requestCtx); }
       break;
     }
 
@@ -1143,6 +1144,21 @@ let requestCtx: RequestCtx | null = null;
 let reqKind = 'New token';
 let reqPriority = 'Nice to have';
 
+// Ask code.ts for a fresh context snapshot and resolve when it answers (or on a
+// short timeout, falling back to the last known context). Used both to refresh
+// the card and — critically — at submit, so the issue never carries stale/empty
+// context because of a missed round-trip.
+let _reqCtxResolve: ((c: RequestCtx | null) => void) | null = null;
+function captureContext(timeoutMs = 1500): Promise<RequestCtx | null> {
+  return new Promise(resolve => {
+    _reqCtxResolve = resolve;
+    postToPlugin('request:capture');
+    setTimeout(() => {
+      if (_reqCtxResolve === resolve) { _reqCtxResolve = null; resolve(requestCtx); }
+    }, timeoutMs);
+  });
+}
+
 function renderRequestCtx(ctx: RequestCtx | null) {
   const nodeEl  = document.getElementById('reqCtxNode')  as HTMLElement;
   const tokenEl = document.getElementById('reqCtxToken') as HTMLElement;
@@ -1211,7 +1227,7 @@ document.getElementById('reqSubmitBtn')?.addEventListener('click', async () => {
   btn.disabled = true; btn.textContent = 'Submitting…';
   setReqStatus('');
 
-  const ctx = requestCtx;
+  const ctx = await captureContext(); // fresh snapshot — never a stale cache
   const figmaUrl = ctx ? figmaNodeUrl(ctx) : '';
   const bodyLines = [
     `**Requested by:** ${ctx?.user || '(unknown)'}`,

--- a/apps/s2a-toolkit/src/ui.ts
+++ b/apps/s2a-toolkit/src/ui.ts
@@ -13,7 +13,7 @@ function postToPlugin(type: string, payload?: Record<string, unknown>) {
 // set below. Nothing sensitive is sent — just the action id, timestamp, ok/error,
 // an anonymous per-install id (from clientStorage, provisioned by code.ts), and
 // the plugin version. Every path is fail-silent and never blocks the UI.
-const PLUGIN_VERSION = '0.1.0';
+const PLUGIN_VERSION = '0.2.0';
 // Set to your collector to enable, e.g. 'http://localhost:8787' (dev) or the
 // deployed Worker URL. Empty string = telemetry disabled. The chosen host must
 // also be listed in manifest.json → networkAccess.allowedDomains.
@@ -122,11 +122,12 @@ let requestCounter = 0;
 
 // ── Panel switching ───────────────────────────────────────────────────────────
 
-type Panel = 'home' | 'tools';
+type Panel = 'home' | 'tools' | 'request';
 
 const panelEls: Record<Panel, HTMLElement> = {
   home:     document.getElementById('homePanel')     as HTMLElement,
   tools:    document.getElementById('toolsPanel')    as HTMLElement,
+  request:  document.getElementById('requestPanel')  as HTMLElement,
 };
 
 function switchPanel(panel: Panel) {
@@ -138,6 +139,7 @@ function switchPanel(panel: Panel) {
     tab.classList.toggle('active', tab.dataset.panel === panel);
   });
   if (panel === 'home') renderHomeView();
+  if (panel === 'request') postToPlugin('request:capture'); // refresh the context card
 }
 
 document.querySelectorAll<HTMLButtonElement>('.tab[data-panel]').forEach(tab => {
@@ -205,6 +207,13 @@ const FEATURES: Feature[] = [
     category: 'Tools',
     uiAction: () => switchPanel('tools'),
   },
+  {
+    id: 'tools:request',
+    name: 'Request a change',
+    description: 'File a token/component/change request as a triage-ready GitHub issue',
+    category: 'Tools',
+    uiAction: () => switchPanel('request'),
+  },
 
   // Bridge
   {
@@ -228,6 +237,7 @@ const QUICK_ACTION_IDS = [
   'tools:annotate',
   'tools:select-filter',
   'tools:doc',
+  'tools:request',
 ];
 
 // ── Fire a feature ────────────────────────────────────────────────────────────
@@ -921,6 +931,7 @@ window.addEventListener('message', (event) => {
         updateCopyBtn(null, null);
         updateSectionBar(false, 0, '');
       }
+      if (activePanel === 'request') postToPlugin('request:capture');
       break;
     }
     case 'format-section:done': {
@@ -948,6 +959,19 @@ window.addEventListener('message', (event) => {
     case 'gh-token:value': {
       ghToken = (msg.token as string) || null;
       syncTokenReleaseAuthUi();
+      break;
+    }
+
+    case 'request:context': {
+      requestCtx = {
+        user:      (msg.user as string) ?? null,
+        node:      (msg.node as { id: string; name: string; type: string } | null) ?? null,
+        fileKey:   (msg.fileKey as string) ?? null,
+        fileName:  (msg.fileName as string) ?? '',
+        page:      (msg.page as string) ?? '',
+        tokenName: (msg.tokenName as string) ?? '',
+      };
+      renderRequestCtx(requestCtx);
       break;
     }
 
@@ -1090,6 +1114,164 @@ document.getElementById('tokenReleaseBtn')?.addEventListener('click', async () =
   } finally {
     btn.disabled = false;
     btn.textContent = 'Release Tokens';
+  }
+});
+
+// ── Request tab ────────────────────────────────────────────────────────────
+// Files a triage-ready request as a GitHub issue, matching the merged issue
+// form (.github/ISSUE_TEMPLATE/s2a-request.yml): labels s2a-request + needs-triage,
+// the Type/Priority/summary/use-case body, plus the auto-captured Figma context.
+//
+// Two submit paths:
+//   • Worker mode  — POST to the intake Worker (no GitHub account needed). Set
+//     REQUEST_ENDPOINT once the Worker is deployed + add its host to manifest
+//     networkAccess.allowedDomains. This is the self-serve path.
+//   • Direct mode  — reuse the saved GitHub PAT (Tools → Token release) to POST
+//     the issue straight to the API. Works today; the token needs Issues:write.
+// REQUEST_ENDPOINT empty ⇒ direct mode.
+const REQUEST_ENDPOINT = '';
+
+interface RequestCtx {
+  user: string | null;
+  node: { id: string; name: string; type: string } | null;
+  fileKey: string | null;
+  fileName: string;
+  page: string;
+  tokenName: string;
+}
+let requestCtx: RequestCtx | null = null;
+let reqKind = 'New token';
+let reqPriority = 'Nice to have';
+
+function renderRequestCtx(ctx: RequestCtx | null) {
+  const nodeEl  = document.getElementById('reqCtxNode')  as HTMLElement;
+  const tokenEl = document.getElementById('reqCtxToken') as HTMLElement;
+  const fileEl  = document.getElementById('reqCtxFile')  as HTMLElement;
+  const userEl  = document.getElementById('reqCtxUser')  as HTMLElement;
+  if (!ctx) return;
+
+  if (ctx.node) {
+    nodeEl.textContent = `${ctx.node.name} · ${ctx.node.type.toLowerCase().replace(/_/g, ' ')}`;
+    nodeEl.classList.remove('muted');
+  } else {
+    nodeEl.textContent = '— none selected (file & page still captured)';
+    nodeEl.classList.add('muted');
+  }
+
+  if (ctx.tokenName) {
+    tokenEl.textContent = ctx.tokenName;
+    tokenEl.classList.remove('muted');
+  } else {
+    tokenEl.textContent = '—';
+    tokenEl.classList.add('muted');
+  }
+
+  fileEl.textContent = ctx.fileName ? `${ctx.fileName} › ${ctx.page}` : '—';
+  fileEl.classList.toggle('muted', !ctx.fileName);
+  userEl.textContent = ctx.user || '(unknown)';
+  userEl.classList.toggle('muted', !ctx.user);
+}
+
+// Build the deep-link to the selected node — same shape as the copy-link button.
+function figmaNodeUrl(ctx: RequestCtx): string {
+  if (!ctx.fileKey || !ctx.node) return '';
+  const slug = (ctx.fileName || 'file').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  return `https://www.figma.com/design/${ctx.fileKey}/${slug}?node-id=${ctx.node.id.replace(':', '-')}`;
+}
+
+function setReqStatus(msg: string, type: '' | 'ok' | 'err' = '') {
+  const el = document.getElementById('reqStatus') as HTMLElement;
+  el.innerHTML = msg;
+  el.className = 'status' + (type ? ' ' + type : '');
+}
+
+// Single-select chip group (radio-style), like the token-release bump chips.
+function bindReqChips(containerId: string, dataKey: 'kind' | 'priority', onPick: (v: string) => void) {
+  document.querySelectorAll<HTMLButtonElement>(`#${containerId} .chip`).forEach(chip => {
+    chip.addEventListener('click', () => {
+      document.querySelectorAll<HTMLButtonElement>(`#${containerId} .chip`).forEach(c => c.classList.remove('on'));
+      chip.classList.add('on');
+      onPick(chip.dataset[dataKey]!);
+    });
+  });
+}
+bindReqChips('reqKind', 'kind', v => { reqKind = v; });
+bindReqChips('reqPriority', 'priority', v => { reqPriority = v; });
+
+document.getElementById('reqSubmitBtn')?.addEventListener('click', async () => {
+  const summaryEl = document.getElementById('reqSummary') as HTMLInputElement;
+  const useCaseEl = document.getElementById('reqUseCase') as HTMLTextAreaElement;
+  const summary = summaryEl.value.trim();
+  const useCase = useCaseEl.value.trim();
+  if (!summary) { setReqStatus('Add a one-line summary first.', 'err'); summaryEl.focus(); return; }
+  if (!useCase) { setReqStatus('Add a use case — it helps triage.', 'err'); useCaseEl.focus(); return; }
+
+  sendTelemetry('action:request-submit');
+  const btn = document.getElementById('reqSubmitBtn') as HTMLButtonElement;
+  btn.disabled = true; btn.textContent = 'Submitting…';
+  setReqStatus('');
+
+  const ctx = requestCtx;
+  const figmaUrl = ctx ? figmaNodeUrl(ctx) : '';
+  const bodyLines = [
+    `**Requested by:** ${ctx?.user || '(unknown)'}`,
+    `**Type:** ${reqKind} · **Priority:** ${reqPriority}`,
+    '',
+    '### What', summary,
+    '',
+    '### Use case', useCase,
+    '',
+  ];
+  if (figmaUrl)        bodyLines.push(`**Figma:** ${figmaUrl}`);
+  if (ctx?.tokenName)  bodyLines.push(`**Token:** \`${ctx.tokenName}\``);
+  if (ctx?.fileName)   bodyLines.push(`**File / page:** ${ctx.fileName} › ${ctx.page}` + (ctx.node ? ` · **Node:** ${ctx.node.name}` : ''));
+  bodyLines.push('', '<sub>Filed from the S2A Toolkit plugin · Request tab.</sub>');
+  const issueBody = bodyLines.join('\n');
+  const title  = `[Request] ${summary.slice(0, 70)}`;
+  const labels = ['s2a-request', 'needs-triage'];
+
+  try {
+    let issueUrl = '';
+    let issueNumber = 0;
+
+    if (REQUEST_ENDPOINT) {
+      // Worker mode — the endpoint holds the GitHub credential.
+      const res = await fetch(REQUEST_ENDPOINT, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          kind: reqKind, priority: reqPriority, summary, useCase, figmaUrl,
+          fileName: ctx?.fileName, page: ctx?.page, nodeName: ctx?.node?.name,
+          tokenName: ctx?.tokenName, requester: ctx?.user,
+        }),
+      });
+      if (!res.ok) throw new Error(`Intake endpoint returned ${res.status}.`);
+      const data = await res.json();
+      issueUrl = data.url; issueNumber = data.number;
+    } else if (ghToken) {
+      // Direct mode — reuse the saved PAT (needs Issues: read/write).
+      const res = await fetch(`${GH_API}/issues`, {
+        method: 'POST',
+        headers: { ...ghHeaders(), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, body: issueBody, labels }),
+      });
+      if (res.status === 401 || res.status === 403) {
+        throw new Error(`GitHub rejected the token (${res.status}). The Request tab needs Issues: read/write on ${GH_REPO} added to your fine-grained PAT (and SSO/org authorization).`);
+      }
+      if (res.status !== 201) throw new Error(`Create failed (${res.status}).`);
+      const data = await res.json();
+      issueUrl = data.html_url; issueNumber = data.number;
+    } else {
+      throw new Error('No intake endpoint set and no GitHub token saved. Save a PAT in Tools → Token release (add Issues: read/write), or configure the intake Worker.');
+    }
+
+    setReqStatus(`✓ Filed as <a href="${issueUrl}" target="_blank">#${issueNumber} →</a> — triage will pick it up.`, 'ok');
+    summaryEl.value = '';
+    useCaseEl.value = '';
+  } catch (err) {
+    setReqStatus('❌ ' + (err instanceof Error ? err.message : String(err)), 'err');
+  } finally {
+    btn.disabled = false; btn.textContent = 'Submit request';
   }
 });
 


### PR DESCRIPTION
## What

Phase 2 of the request intake ([spec](../blob/main/docs/request-intake-spec.md), [v1 form #142](https://github.com/adobecom/consonant/pull/142)): a **Request tab** in the S2A Toolkit plugin so designers file requests **without leaving Figma** — and the request arrives already triage-ready.

## The plugin's value: auto-captured context

The form itself mirrors the merged issue template (Type, Priority, summary, use case). What the plugin adds — that a web form can't — is **automatic Figma context**:

| Captured | Source |
|---|---|
| Requester | `figma.currentUser` |
| Selected node + deep link | `figma.currentPage.selection` → node-id URL |
| File › page | `figma.root.name` / `figma.currentPage.name` |
| Bound S2A token | the node's `boundVariables` → variable name |

It files an issue labeled `s2a-request` + `needs-triage` with all of that in the body — **identical shape to the web form**, so both feed the same triage flow. The context card refreshes live as you change selection.

## Two submit paths (spec-aligned)

- **Direct mode (works today):** reuses the saved GitHub PAT (Tools → Token release) to POST the issue. Needs `Issues: read/write` on the PAT. This is what runs now — `api.github.com` is already allow-listed, **no manifest change**.
- **Worker mode (dormant):** set `REQUEST_ENDPOINT` to the deployed intake Worker and it POSTs there instead — the **no-GitHub-account self-serve path** from the spec. Empty endpoint ⇒ direct mode. Mirrors the existing `TELEMETRY_ENDPOINT` pattern.

## Implementation notes

- New `request:capture` → `request:context` message pair in `code.ts`; everything else reuses existing panel/tab/message/CSS + the `ghToken` plumbing.
- Plugin version → `0.2.0`.
- `dist/` is tracked (Figma loads it) — rebuilt and committed alongside src.

## Test
- `npm run build` (esbuild) clean; Request tab present in built `ui.html`, handlers in both bundles.
- No new type errors beyond the repo's pre-existing ambient-`figma`-globals tsc noise (main baseline 174 → 181; the +7 are all `Cannot find name 'figma'` on my new `figma.*` calls, same benign config quirk as the other 154).
- Manual: open plugin → Request tab → context auto-fills → submit files a labeled issue and returns its link.

## Follow-up (not here)
Deploy the intake Worker → set `REQUEST_ENDPOINT` + add its host to `networkAccess.allowedDomains` to flip on no-token self-serve. Then the `approved`→Jira mirror (needs a corp-network runner — Jira is internal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)