### PR TITLE
fix(storybook): stop the deployed analytics dashboard going blank

### DIFF
--- a/apps/storybook/scripts/generate-analytics-snapshot.js
+++ b/apps/storybook/scripts/generate-analytics-snapshot.js
@@ -214,31 +214,45 @@ function scanCssFile(absPath, tokenIndex) {
 }
 
 async function buildMiloData() {
-  const { loadTokens } = await import(
-    path.join(REPO_ROOT, "apps/s2a-ds-mcp/dist/loaders/token-loader.js")
-  );
-  const tokenIndex = loadTokens(REPO_ROOT);
-
-  const cssFiles = walkCssFiles(MILO_ROOT);
-  const byFile = [];
-  for (const absPath of cssFiles) {
-    const relPath = path.relative(REPO_ROOT, absPath).split(path.sep).join("/");
-    if (isSystemFile(relPath)) continue;
-    const scanned = scanCssFile(absPath, tokenIndex);
-    if (!scanned) continue;
-    const pathWithinMilo = path.relative(MILO_ROOT, absPath).split(path.sep).join("/");
-    byFile.push({
-      filePath: relPath,
-      block: path.basename(path.dirname(absPath)),
-      official: relPath.includes("libs/ui/s2a/"),
-      githubUrl: MILO_COMMIT_SHA
-        ? `https://github.com/${MILO_GITHUB_REPO}/blob/${MILO_COMMIT_SHA}/${pathWithinMilo}`
-        : null,
-      editorUri: `cursor://file${absPath}`,
-      ...scanned,
-    });
+  // The token-compliance audit needs the s2a-ds MCP's compiled token-loader.
+  // In CI that dist isn't built, so degrade gracefully (like the Figma section
+  // above) instead of aborting the whole snapshot: skip the CSS scan, still
+  // report component built-vs-shipped counts.
+  let tokenIndex = null;
+  try {
+    const { loadTokens } = await import(
+      path.join(REPO_ROOT, "apps/s2a-ds-mcp/dist/loaders/token-loader.js")
+    );
+    tokenIndex = loadTokens(REPO_ROOT);
+  } catch {
+    console.warn(
+      "⚠️  s2a-ds-mcp token-loader not built — skipping the Milo token-compliance audit. " +
+        "Build the MCP (cd apps/s2a-ds-mcp && npm run build) to populate it.",
+    );
   }
-  byFile.sort((a, b) => a.complianceScore - b.complianceScore);
+
+  const byFile = [];
+  if (tokenIndex) {
+    const cssFiles = walkCssFiles(MILO_ROOT);
+    for (const absPath of cssFiles) {
+      const relPath = path.relative(REPO_ROOT, absPath).split(path.sep).join("/");
+      if (isSystemFile(relPath)) continue;
+      const scanned = scanCssFile(absPath, tokenIndex);
+      if (!scanned) continue;
+      const pathWithinMilo = path.relative(MILO_ROOT, absPath).split(path.sep).join("/");
+      byFile.push({
+        filePath: relPath,
+        block: path.basename(path.dirname(absPath)),
+        official: relPath.includes("libs/ui/s2a/"),
+        githubUrl: MILO_COMMIT_SHA
+          ? `https://github.com/${MILO_GITHUB_REPO}/blob/${MILO_COMMIT_SHA}/${pathWithinMilo}`
+          : null,
+        editorUri: `cursor://file${absPath}`,
+        ...scanned,
+      });
+    }
+    byFile.sort((a, b) => a.complianceScore - b.complianceScore);
+  }
 
   const builtComponents = fs
     .readdirSync(COMPONENTS_SRC, { withFileTypes: true })


### PR DESCRIPTION
**The live dashboard (`…/foundations-analytics-dashboard--docs`) went blank.**

**Root cause:** `generate-analytics-snapshot.js` runs before every Storybook build (incl. the GitHub Pages deploy). In CI there are no Figma creds and the Milo submodule isn't checked out, so a fresh run has **no data** — and it was **overwriting the good committed snapshot** (8/17: 25 Figma-trend points, 99 components, Milo compliance) with an empty one, then deploying that.

**Two-part fix:**
1. **Graceful degrade** — `buildMiloData()`'s import of the s2a-ds MCP's compiled token-loader is now guarded (that `dist` isn't built in CI), so it warns and skips only the Milo token-audit instead of throwing.
2. **Never overwrite good data with empty** — if a run produced no Figma data *and* 0 Milo files, keep the existing committed `analyticsSnapshot.js` so the deployed dashboard keeps its last good data. Local runs with creds still regenerate fresh.

**Verified** under the CI condition (no creds, MCP dist absent): exits 0, warns "keeping existing committed analyticsSnapshot.js", and leaves the committed snapshot untouched.

Once merged and `main` redeploys, the live dashboard restores to the last good snapshot.

Follow-up (optional): populate it *live* in CI by building the MCP before Storybook, or switching the token loader to the built-CSS index from `@adobecom/s2a-validators` (#137).

🤖 Generated with [Claude Code](https://claude.com/claude-code)