### PR TITLE
fix(storybook): keep committed analytics snapshot when CI has no data (restores live dashboard)

### DIFF
--- a/apps/storybook/scripts/generate-analytics-snapshot.js
+++ b/apps/storybook/scripts/generate-analytics-snapshot.js
@@ -362,6 +362,18 @@ async function main() {
   const miloFidelity = await buildMiloData();
   meta.miloFilesScanned = miloFidelity.byFile.length;
 
+  // Never overwrite a good committed snapshot with an empty one. In CI there are
+  // no Figma creds and the Milo submodule isn't checked out, so a fresh run has
+  // no data — keep the last committed snapshot so the deployed dashboard doesn't
+  // go blank. Only write when we actually produced data (or nothing is committed).
+  const hasData = meta.figmaAvailable || miloFidelity.byFile.length > 0;
+  if (!hasData && fs.existsSync(OUTPUT_MODULE)) {
+    console.warn(
+      "⚠️  No fresh Figma or Milo data (CI without creds/submodule) — keeping the existing committed analyticsSnapshot.js so the dashboard keeps its last good data.",
+    );
+    process.exit(0);
+  }
+
   writeSnapshot({ meta, figmaTrend, componentAdoption, topConsumers, miloFidelity });
   console.log(
     `✅ Generated stories/generated/analyticsSnapshot.js (figma: ${meta.figmaAvailable ? "live" : "unavailable"}, milo files scanned: ${meta.miloFilesScanned})`,


### PR DESCRIPTION
**Restores the blank live dashboard** (`…/foundations-analytics-dashboard--docs`).

Follow-up to #145, which merged with **only** the graceful-degrade change — my "don't overwrite" commit lost a merge race. On its own, graceful-degrade makes the generator **succeed and write an empty snapshot** in CI (no Figma creds, no Milo submodule), which is exactly what blanked the deployed dashboard.

**Fix:** if a run produced no Figma data *and* scanned 0 Milo files, **keep the existing committed `analyticsSnapshot.js`** instead of overwriting it. Local runs with creds still regenerate fresh.

**Verified** in the CI condition: exits 0, warns "keeping existing committed analyticsSnapshot.js", leaves the good 8/17 committed snapshot untouched → next deploy shows real data again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)