### PR TITLE
refactor(storybook): analytics token audit uses @adobecom/s2a-validators

### DIFF
--- a/apps/storybook/scripts/generate-analytics-snapshot.js
+++ b/apps/storybook/scripts/generate-analytics-snapshot.js
@@ -180,10 +180,12 @@ function scanCssFile(absPath, tokenIndex) {
     for (const m of line.matchAll(TOKEN_VAR_RE)) {
       const cssProp = m[1].trim();
       if (!usedTokens.has(cssProp)) {
-        const entries = tokenIndex.byProp.get(cssProp);
+        // Validators TokenIndex: `known` = every shipped --s2a-* var, `primitive`
+        // = the design-only ones. (More accurate than the old MCP loader, which
+        // over-flagged semantic tokens via hiddenFromPublishing.)
         usedTokens.set(cssProp, {
-          found: !!entries,
-          designOnly: entries?.[0]?.designOnly ?? false,
+          found: tokenIndex.known.has(cssProp),
+          designOnly: tokenIndex.primitive.has(cssProp),
         });
       }
     }
@@ -214,20 +216,21 @@ function scanCssFile(absPath, tokenIndex) {
 }
 
 async function buildMiloData() {
-  // The token-compliance audit needs the s2a-ds MCP's compiled token-loader.
-  // In CI that dist isn't built, so degrade gracefully (like the Figma section
-  // above) instead of aborting the whole snapshot: skip the CSS scan, still
-  // report component built-vs-shipped counts.
+  // The token-compliance audit uses @adobecom/s2a-validators — the one
+  // authoritative token index (built from the shipped token CSS), shared with the
+  // eval scorers. It reads dist/packages/tokens/css/dev, which `tokens:build`
+  // produces, so it works in CI. If it's unavailable, degrade gracefully (like the
+  // Figma section) and skip only the CSS scan.
   let tokenIndex = null;
   try {
-    const { loadTokens } = await import(
-      path.join(REPO_ROOT, "apps/s2a-ds-mcp/dist/loaders/token-loader.js")
+    const { loadTokenIndex } = await import(
+      path.join(REPO_ROOT, "packages/validators/dist/index.js")
     );
-    tokenIndex = loadTokens(REPO_ROOT);
+    tokenIndex = loadTokenIndex(REPO_ROOT);
   } catch {
     console.warn(
-      "⚠️  s2a-ds-mcp token-loader not built — skipping the Milo token-compliance audit. " +
-        "Build the MCP (cd apps/s2a-ds-mcp && npm run build) to populate it.",
+      "⚠️  @adobecom/s2a-validators token index unavailable — skipping the Milo token-compliance audit. " +
+        "Run `npm run tokens:build` (and build packages/validators) to populate it.",
     );
   }
 

--- a/packages/validators/dist/cli.d.ts
+++ b/packages/validators/dist/cli.d.ts
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+export {};

--- a/packages/validators/dist/cli.js
+++ b/packages/validators/dist/cli.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// cli.ts — CI consumer. Validate CSS files against the authoritative token index.
+//
+//   s2a-validate-css [--strict] <file.css> [more.css ...]
+//
+// Exits non-zero if any file has violations, printing them as stable codes so a
+// CI log (or a diff of two runs) reads clearly. Reuses the SAME validateCss the
+// MCP and evals use — one definition of "violation."
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadTokenIndex } from "./token-index.js";
+import { validateCss } from "./validate-css.js";
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// packages/validators/src -> repo root
+const REPO_ROOT = resolve(__dirname, "..", "..", "..");
+const args = process.argv.slice(2);
+const strict = args.includes("--strict");
+const files = args.filter((a) => a !== "--strict");
+if (files.length === 0) {
+    console.error("usage: s2a-validate-css [--strict] <file.css> [...]");
+    process.exit(2);
+}
+const index = loadTokenIndex(process.env.DS_ROOT ? resolve(process.env.DS_ROOT) : REPO_ROOT);
+console.error(`[s2a-validate-css] token index: ${index.known.size} known, ${index.primitive.size} primitive\n`);
+let totalHard = 0;
+for (const file of files) {
+    let css;
+    try {
+        css = readFileSync(resolve(file), "utf-8");
+    }
+    catch {
+        console.error(`✗ ${file}: cannot read`);
+        totalHard++;
+        continue;
+    }
+    const { ok, score, violations } = validateCss(css, index, { strict });
+    totalHard += violations.length;
+    if (ok) {
+        console.log(`✓ ${file} — clean (score ${score}/5)`);
+    }
+    else {
+        console.log(`✗ ${file} — ${violations.length} violation(s), score ${score}/5`);
+        for (const v of violations) {
+            console.log(`    ${v.code}${v.line ? ` (line ${v.line})` : ""}: ${v.value ?? ""}`);
+        }
+    }
+}
+process.exit(totalHard > 0 ? 1 : 0);

--- a/packages/validators/dist/index.d.ts
+++ b/packages/validators/dist/index.d.ts
@@ -1,0 +1,4 @@
+export { loadTokenIndex, type TokenIndex } from "./token-index.js";
+export { validateCss, type ValidateCssOptions } from "./validate-css.js";
+export { validateSpec, type ComponentSpec, type GeneratedSummary } from "./validate-spec.js";
+export type { Violation, ValidationResult } from "./types.js";

--- a/packages/validators/dist/index.js
+++ b/packages/validators/dist/index.js
@@ -1,0 +1,4 @@
+// @adobecom/s2a-validators — one authoritative home for token/spec validation.
+export { loadTokenIndex } from "./token-index.js";
+export { validateCss } from "./validate-css.js";
+export { validateSpec } from "./validate-spec.js";

--- a/packages/validators/dist/token-index.d.ts
+++ b/packages/validators/dist/token-index.d.ts
@@ -1,0 +1,8 @@
+export interface TokenIndex {
+    /** cssProp names defined in the primitives CSS (design-only). */
+    primitive: Set<string>;
+    /** every cssProp name defined in the shipped token CSS. */
+    known: Set<string>;
+}
+/** Load the token index from the built token CSS under a repo root. */
+export declare function loadTokenIndex(dsRoot: string): TokenIndex;

--- a/packages/validators/dist/token-index.js
+++ b/packages/validators/dist/token-index.js
@@ -1,0 +1,40 @@
+// token-index.ts — build the AUTHORITATIVE token index from the BUILT CSS.
+//
+// Why the built CSS and not the source JSON:
+//   - The primitive/semantic split is clean by file: anything DEFINED in
+//     tokens.primitives*.css is a design-only primitive; anything in
+//     tokens.semantic*/responsive*.css is a shippable semantic token. (The source
+//     JSON's `hiddenFromPublishing` flag over-flags semantic tokens, so it's the
+//     wrong signal.)
+//   - The built CSS is what actually ships, so it's the true registry of valid
+//     --s2a-* custom properties.
+//
+// Note: component tokens are often defined *locally* inside a component's own CSS
+// (context aliases), so validateCss also learns definitions from the file under
+// test — see validate-css.ts.
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+/** Matches a custom-property DEFINITION: `--s2a-foo: value`. */
+const DEF_RE = /(--s2a-[a-z0-9-]+)\s*:/g;
+/** Load the token index from the built token CSS under a repo root. */
+export function loadTokenIndex(dsRoot) {
+    const dir = resolve(dsRoot, "dist/packages/tokens/css/dev");
+    const primitive = new Set();
+    const known = new Set();
+    if (!existsSync(dir)) {
+        throw new Error(`[s2a-validators] built token CSS not found at ${dir}. Run the token build first.`);
+    }
+    for (const fileName of readdirSync(dir)) {
+        if (!fileName.endsWith(".css"))
+            continue;
+        const isPrimitiveFile = fileName.startsWith("tokens.primitives");
+        const css = readFileSync(join(dir, fileName), "utf-8");
+        for (const m of css.matchAll(DEF_RE)) {
+            const name = m[1];
+            known.add(name);
+            if (isPrimitiveFile)
+                primitive.add(name);
+        }
+    }
+    return { primitive, known };
+}

--- a/packages/validators/dist/types.d.ts
+++ b/packages/validators/dist/types.d.ts
@@ -1,0 +1,12 @@
+export interface Violation {
+    /** Stable, diffable code — e.g. PRIMITIVE_TOKEN, HARDCODED_HEX, UNKNOWN_TOKEN. */
+    code: string;
+    message: string;
+    value?: string;
+    line?: number;
+}
+export interface ValidationResult {
+    ok: boolean;
+    score: 1 | 2 | 3 | 4 | 5;
+    violations: Violation[];
+}

--- a/packages/validators/dist/types.js
+++ b/packages/validators/dist/types.js
@@ -1,0 +1,2 @@
+// types.ts — shared validation types.
+export {};

--- a/packages/validators/dist/validate-css.d.ts
+++ b/packages/validators/dist/validate-css.d.ts
@@ -1,0 +1,7 @@
+import type { TokenIndex } from "./token-index.js";
+import type { ValidationResult } from "./types.js";
+export interface ValidateCssOptions {
+    /** Also flag raw px values (off by default — noisy around media queries). */
+    strict?: boolean;
+}
+export declare function validateCss(css: string, index: TokenIndex, opts?: ValidateCssOptions): ValidationResult;

--- a/packages/validators/dist/validate-css.js
+++ b/packages/validators/dist/validate-css.js
@@ -1,0 +1,60 @@
+// validate-css.ts — the ONE authoritative CSS token validator.
+//
+// Consumed by: the s2a-ds MCP (validate_css tool), CI (the cli), and the eval
+// scorers. Because it resolves every --s2a-* usage against the token index's
+// `designOnly` flag, PRIMITIVE_TOKEN is a fact, not a naming guess.
+const HEX_RE = /#[0-9a-fA-F]{3,8}\b/g;
+const RGB_RE = /\brgba?\([^)]*\)/g;
+const VAR_RE = /var\(\s*(--s2a-[a-z0-9-]+)\s*[,)]/g;
+// A local custom-property DEFINITION in the file under test (component alias).
+const LOCAL_DEF_RE = /(--s2a-[a-z0-9-]+)\s*:/g;
+// Raw px in a value, excluding 0/1px (borders) and anything inside var().
+const RAW_PX_RE = /(?<!var\([^)]*)\b([2-9]\d*|1\d+)px\b/g;
+function scoreFrom(hard) {
+    if (hard === 0)
+        return 5;
+    if (hard <= 1)
+        return 3;
+    if (hard <= 3)
+        return 2;
+    return 1;
+}
+export function validateCss(css, index, opts = {}) {
+    const violations = [];
+    // Custom properties this file defines itself (component context aliases) are
+    // legitimate targets for var() — treat them as known.
+    const localDefs = new Set();
+    for (const m of css.matchAll(LOCAL_DEF_RE))
+        localDefs.add(m[1]);
+    css.split("\n").forEach((line, i) => {
+        const ln = i + 1;
+        for (const m of line.matchAll(HEX_RE)) {
+            violations.push({ code: "HARDCODED_HEX", message: "Hardcoded hex color — use a semantic color token.", value: m[0], line: ln });
+        }
+        for (const m of line.matchAll(RGB_RE)) {
+            violations.push({ code: "HARDCODED_RGB", message: "Hardcoded rgb()/rgba() — use a semantic color token.", value: m[0], line: ln });
+        }
+        // Authoritative token resolution.
+        for (const m of line.matchAll(VAR_RE)) {
+            const name = m[1];
+            if (index.primitive.has(name)) {
+                violations.push({ code: "PRIMITIVE_TOKEN", message: `${name} is a design-only primitive — use its semantic alias.`, value: name, line: ln });
+            }
+            else if (!index.known.has(name) && !localDefs.has(name)) {
+                violations.push({ code: "UNKNOWN_TOKEN", message: `${name} is not a known S2A token and is not defined locally.`, value: name, line: ln });
+            }
+        }
+        if (opts.strict) {
+            for (const m of line.matchAll(RAW_PX_RE)) {
+                violations.push({ code: "HARDCODED_PX", message: "Raw px — likely maps to a spacing/radius token.", value: m[0], line: ln });
+            }
+        }
+    });
+    // HARDCODED_* and PRIMITIVE_TOKEN are hard failures (unambiguous, actionable).
+    // UNKNOWN_TOKEN is a WARNING: component tokens are currently filtered out of the
+    // shipped token CSS, so a var() the global registry doesn't know may still be a
+    // legitimate component token provided at runtime. It informs; it doesn't fail.
+    const HARD = new Set(["HARDCODED_HEX", "HARDCODED_RGB", "HARDCODED_PX", "PRIMITIVE_TOKEN"]);
+    const hard = violations.filter((v) => HARD.has(v.code)).length;
+    return { ok: hard === 0, score: scoreFrom(hard), violations };
+}

--- a/packages/validators/dist/validate-spec.d.ts
+++ b/packages/validators/dist/validate-spec.d.ts
@@ -1,0 +1,17 @@
+import type { ValidationResult } from "./types.js";
+export interface ComponentSpec {
+    name: string;
+    variants?: Record<string, string[]>;
+    props?: Array<{
+        name: string;
+    }>;
+    a11y?: {
+        wcag?: string[];
+    };
+}
+export interface GeneratedSummary {
+    variants?: Record<string, string[]>;
+    props?: string[];
+    wcag?: string[];
+}
+export declare function validateSpec(generated: GeneratedSummary, spec: ComponentSpec): ValidationResult;

--- a/packages/validators/dist/validate-spec.js
+++ b/packages/validators/dist/validate-spec.js
@@ -1,0 +1,45 @@
+// validate-spec.ts — does a generated artifact cover the spec.json contract?
+export function validateSpec(generated, spec) {
+    const violations = [];
+    const specVariants = spec.variants ?? {};
+    const genVariants = generated.variants ?? {};
+    let required = 0;
+    let covered = 0;
+    for (const [axis, values] of Object.entries(specVariants)) {
+        if (!(axis in genVariants)) {
+            violations.push({ code: "MISSING_VARIANT_AXIS", message: `Missing variant axis "${axis}".`, value: axis });
+            required += values.length;
+            continue;
+        }
+        for (const v of values) {
+            required++;
+            if (genVariants[axis].includes(v))
+                covered++;
+            else
+                violations.push({ code: "MISSING_VARIANT_VALUE", message: `Missing "${axis}" value "${v}".`, value: `${axis}=${v}` });
+        }
+    }
+    const specProps = (spec.props ?? []).map((p) => p.name);
+    const genProps = new Set(generated.props ?? []);
+    let coveredProps = 0;
+    for (const p of specProps) {
+        if (genProps.has(p))
+            coveredProps++;
+        else
+            violations.push({ code: "MISSING_PROP", message: `Missing prop "${p}".`, value: p });
+    }
+    const specScs = spec.a11y?.wcag ?? [];
+    const genScs = new Set(generated.wcag ?? []);
+    let coveredScs = 0;
+    for (const sc of specScs) {
+        if (genScs.has(sc))
+            coveredScs++;
+        else
+            violations.push({ code: "MISSING_A11Y_SC", message: `Spec requires WCAG ${sc} — not addressed.`, value: sc });
+    }
+    const total = required + specProps.length + specScs.length || 1;
+    const hit = covered + coveredProps + coveredScs;
+    const ratio = hit / total;
+    const score = ratio >= 1 ? 5 : ratio >= 0.9 ? 4 : ratio >= 0.7 ? 3 : ratio >= 0.4 ? 2 : 1;
+    return { ok: violations.length === 0, score, violations };
+}


### PR DESCRIPTION
Consolidates the analytics dashboard's Milo token-compliance audit onto **`@adobecom/s2a-validators`** — the same authoritative token index the eval scorers use — replacing the s2a-ds MCP's compiled token-loader.

## Why
The MCP token-loader keyed `designOnly` off Figma's `hiddenFromPublishing`, which **over-flags semantic tokens** (e.g. `--s2a-spacing-md` was counted as a design-only "leak"). The validators index keys off the **built primitives CSS** — the real signal. So this is a *correctness* upgrade, not just a swap.

## Changes
- **Loader:** `loadTokens` (MCP dist) → `loadTokenIndex` (validators). Reads `dist/packages/tokens/css/dev`, which `tokens:build` produces, so it resolves in CI.
- **`scanCssFile`:** `found = index.known.has(cssProp)`, `designOnly = index.primitive.has(cssProp)` — a direct 1:1 mapping.
- **Committed `packages/validators/dist`** so the script imports it without a separate build step (dist is plain JS, no runtime deps).
- Graceful-degrade + the don't-overwrite-committed guard preserved.

## Verified
Validators index imports and classifies correctly: `spacing-md` → semantic, `spacing-16`/`gray-25` → primitive, unknowns caught. Generator preserves the committed snapshot when no fresh data is available.

## Note on live-refresh
This makes the *token index* CI-resolvable and unifies the source of truth. Fully refreshing the Milo audit **on deploy** additionally needs the `context/milo` submodule checked out in the workflows (it currently isn't → 0 files → the guard keeps the last good snapshot). That's a heavier CI change (big submodule) — separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)