### PR TITLE
chore(validators): publish @adobecom/s2a-validators to GitHub Packages

### DIFF
--- a/.github/workflows/publish-validators.yml
+++ b/.github/workflows/publish-validators.yml
@@ -1,0 +1,89 @@
+name: Publish Validators
+
+# Publishes @adobecom/s2a-validators to GitHub Packages when its version bumps on
+# main. Mirrors publish-mcp.yml: the merge is gated by CODEOWNERS review, and the
+# actual registry push additionally requires an environment reviewer.
+#
+# This is the ONE authoritative token/spec validator — consumed by the s2a-ds MCP
+# (validate_css), CI, and the eval scorers. Publishing it makes those consumers
+# share one definition of "what's a violation" instead of each re-implementing it.
+#
+# Publishing runs on GitHub's own GITHUB_TOKEN (packages: write) — no personal
+# token, nothing on anyone's machine. It is idempotent: a version already on the
+# registry is skipped (registries are immutable per version).
+#
+# The published tarball is built by the package's `prepack` (tsc), so it always
+# ships a fresh dist/.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/validators/package.json" # version bump = a release
+  workflow_dispatch: # manual re-publish of the current version
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-validators
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: token-release
+    defaults:
+      run:
+        working-directory: packages/validators
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Node (GitHub Packages)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@adobecom"
+
+      # Dev deps (typescript) are needed because `prepack` compiles dist/.
+      # No lockfile here (this is a source package, not a built artifact dir),
+      # so use `npm install` rather than `npm ci`.
+      - name: Install
+        run: npm install --no-audit --no-fund
+
+      - name: Read package version
+        id: v
+        run: echo "version=$(npm pkg get version | tr -d '\"')" >> "$GITHUB_OUTPUT"
+
+      - name: Publish (skip if the version already exists)
+        id: publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          OUT=$(npm publish 2>&1); CODE=$?
+          echo "$OUT"
+          if [ $CODE -eq 0 ]; then
+            echo "result=published" >> "$GITHUB_OUTPUT"
+          elif echo "$OUT" | grep -qiE "cannot publish over|already exists|E409|EPUBLISHCONFLICT|conflict"; then
+            echo "::notice::@adobecom/s2a-validators@${{ steps.v.outputs.version }} is already on the registry — skipping."
+            echo "result=skipped" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Publish failed for a reason other than a version conflict."
+            exit $CODE
+          fi
+
+      - name: Summary
+        if: always()
+        run: |
+          V="${{ steps.v.outputs.version }}"
+          case "${{ steps.publish.outputs.result }}" in
+            published) echo "### 📦 Published @adobecom/s2a-validators@$V to GitHub Packages" >> "$GITHUB_STEP_SUMMARY" ;;
+            skipped)   echo "### ⏭️ @adobecom/s2a-validators@$V was already published — nothing to do" >> "$GITHUB_STEP_SUMMARY" ;;
+            *)         echo "### ⚠️ Publish did not complete for @adobecom/s2a-validators@$V" >> "$GITHUB_STEP_SUMMARY" ;;
+          esac

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -1,15 +1,23 @@
 {
   "name": "@adobecom/s2a-validators",
   "version": "0.1.0",
-  "private": true,
   "description": "Authoritative S2A token/spec validators — one source of truth for the MCP, CI, and evals.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": { "s2a-validate-css": "./dist/cli.js" },
   "files": ["dist"],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adobecom/consonant.git",
+    "directory": "packages/validators"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "prepack": "tsc -p tsconfig.json",
     "demo": "tsx demo.ts",
     "validate:css": "tsx src/cli.ts"
   },


### PR DESCRIPTION
## What

Makes `@adobecom/s2a-validators` a **real published package** on GitHub Packages — the prerequisite for pointing the MCP's `validate_css` at it (the follow-up PR).

Today the validator lib is `private: true` and consumed only in-repo by relative path (the analytics dashboard, #148). To let the **published** MCP share the same code with its own npm consumers, it has to be installable from the registry.

## Changes

- **`packages/validators/package.json`** — drop `private: true`; add `publishConfig` (GitHub Packages registry), `repository`, and a `prepack` that runs `tsc` so every publish ships fresh `dist/`.
- **`.github/workflows/publish-validators.yml`** — new workflow mirroring `publish-mcp.yml`:
  - fires on a version bump to `packages/validators/package.json` (or manual dispatch)
  - gated by the `token-release` environment reviewer + CODEOWNERS on merge
  - publishes on GitHub's `GITHUB_TOKEN` (no personal token), idempotent (skips a version already on the registry)

`dist/` is already committed and verified byte-identical to a clean `tsc` build. `npm publish --dry-run` packs 14 files (dist + package.json), 5.6 kB.

## Sequence

1. **This PR** → merge → `@adobecom/s2a-validators@0.1.0` lands on the registry.
2. **Follow-up PR** → add it to the MCP's deps + lockfile and rewrite `validate_css`/`check_token_in_css` to delegate to `loadTokenIndex` + `validateCss` (fixes the `hiddenFromPublishing` designOnly bug and makes `validate_css` actually catch primitive-token leaks, which it currently misses).

Two PRs, in this order, avoids a CI race — the MCP's `npm ci` can only resolve the dependency once it's live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)